### PR TITLE
fix(api): change CRD group to kruntimes.io

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Run CRD (Pending) → Scheduler → Run (Scheduled, assignedPod)
 
 ### Key types
 
-- **Run CRD** (`api/v1alpha1/run_types.go`): the central state machine. Phase: Pending → Scheduled → Running → Succeeded/Failed. Spec holds runtime name, args, env, timeout. Status holds phase, assignedPod, message, timestamps. CRD group: `runtimes.kruntimes.io/v1alpha1`. Short name: `rn`. Scheduler treats empty phase as equivalent to Pending (the kubebuilder default on status subresource doesn't apply on Create).
+- **Run CRD** (`api/v1alpha1/run_types.go`): the central state machine. Phase: Pending → Scheduled → Running → Succeeded/Failed. Spec holds runtime name, args, env, timeout. Status holds phase, assignedPod, message, timestamps. CRD group: `kruntimes.io/v1alpha1`. Short name: `rn`. Scheduler treats empty phase as equivalent to Pending (the kubebuilder default on status subresource doesn't apply on Create).
 
 - **Runtime CRD** (`api/v1alpha1/runtime_types.go`): defines a runtime type (image, port, replicas). The Runtime controller creates a Deployment with **two containers** — the runtime server + runtimed daemon — sharing an emptyDir `/workspace`. Pod label `runtime: <cr-name>` is used by the scheduler for pod selection.
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Cancellation is user initiated by setting `spec.cancelRequested: true`, usually 
 
 When an assigned Runtime Pod is deleted, terminating, or unhealthy, the stale Run reaper classifies the Run with a pod-related reason. If retry policy allows retry, it clears `status.assignedPod`, resets scheduling state to `Pending`, and the Scheduler assigns a new Runtime Pod. If retry is exhausted or not allowed, the Run terminates as `Failed`.
 
-Runtime Pods report runtimed liveness through the Pod condition `runtimes.kruntimes.io/RuntimedReady`. Static per-pod capacity is declared on `Runtime.spec.capacity.resources`; the built-in `runs` resource controls concurrent Run executions per Runtime Pod and is copied to the Pod annotation `runtimes.kruntimes.io/capacity.runs`. The Scheduler derives fast-changing usage from its Run cache and only assigns to Runtime Pods that are Kubernetes Ready, runtimed-ready, and below capacity. Runtimed also enforces the same local capacity before claiming a Scheduled Run.
+Runtime Pods report runtimed liveness through the Pod condition `kruntimes.io/RuntimedReady`. Static per-pod capacity is declared on `Runtime.spec.capacity.resources`; the built-in `runs` resource controls concurrent Run executions per Runtime Pod and is copied to the Pod annotation `kruntimes.io/capacity.runs`. The Scheduler derives fast-changing usage from its Run cache and only assigns to Runtime Pods that are Kubernetes Ready, runtimed-ready, and below capacity. Runtimed also enforces the same local capacity before claiming a Scheduled Run.
 
 Terminal phases are:
 
@@ -510,7 +510,7 @@ service Runtime {
 Deploy with a Runtime CR:
 
 ```yaml
-apiVersion: runtimes.kruntimes.io/v1alpha1
+apiVersion: kruntimes.io/v1alpha1
 kind: Runtime
 metadata:
   name: my-python

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -1,5 +1,5 @@
 // Package v1alpha1 contains API Schema definitions for the kruntimes v1alpha1 API group.
-// +groupName=runtimes.kruntimes.io
+// +groupName=kruntimes.io
 // +versionName=v1alpha1
 package v1alpha1
 
@@ -10,7 +10,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects.
-	GroupVersion = schema.GroupVersion{Group: "runtimes.kruntimes.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "kruntimes.io", Version: "v1alpha1"}
 
 	//nolint:staticcheck // scheme.Builder is deliberately used for kubebuilder integration
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/api/v1alpha1/runtime_types.go
+++ b/api/v1alpha1/runtime_types.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	// RuntimePodAnnotationPrefix is the annotation prefix used for Runtime Pod metadata.
-	RuntimePodAnnotationPrefix = "runtimes.kruntimes.io/"
+	RuntimePodAnnotationPrefix = "kruntimes.io/"
 
 	// RuntimePodCapacityAnnotationPrefix prefixes per-pod runtime capacity annotations.
 	RuntimePodCapacityAnnotationPrefix = RuntimePodAnnotationPrefix + "capacity."
@@ -19,7 +19,7 @@ const (
 	RuntimeDefaultRunsCapacity int32 = 2
 
 	// RuntimePodRuntimedReadyCondition reports whether the runtimed daemon is heartbeating.
-	RuntimePodRuntimedReadyCondition corev1.PodConditionType = "runtimes.kruntimes.io/RuntimedReady"
+	RuntimePodRuntimedReadyCondition corev1.PodConditionType = "kruntimes.io/RuntimedReady"
 )
 
 // +kubebuilder:object:generate=true

--- a/charts/kruntimes-runtimes/templates/bash-runtime.yaml
+++ b/charts/kruntimes-runtimes/templates/bash-runtime.yaml
@@ -1,4 +1,4 @@
-apiVersion: runtimes.kruntimes.io/v1alpha1
+apiVersion: kruntimes.io/v1alpha1
 kind: Runtime
 metadata:
   name: bash

--- a/charts/kruntimes-runtimes/templates/python-runtime.yaml
+++ b/charts/kruntimes-runtimes/templates/python-runtime.yaml
@@ -1,4 +1,4 @@
-apiVersion: runtimes.kruntimes.io/v1alpha1
+apiVersion: kruntimes.io/v1alpha1
 kind: Runtime
 metadata:
   name: python

--- a/charts/kruntimes/crds/kruntimes.io_runs.yaml
+++ b/charts/kruntimes/crds/kruntimes.io_runs.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
-  name: runs.runtimes.kruntimes.io
+  name: runs.kruntimes.io
 spec:
-  group: runtimes.kruntimes.io
+  group: kruntimes.io
   names:
     kind: Run
     listKind: RunList

--- a/charts/kruntimes/crds/kruntimes.io_runtimes.yaml
+++ b/charts/kruntimes/crds/kruntimes.io_runtimes.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
-  name: runtimes.runtimes.kruntimes.io
+  name: runtimes.kruntimes.io
 spec:
-  group: runtimes.kruntimes.io
+  group: kruntimes.io
   names:
     kind: Runtime
     listKind: RuntimeList

--- a/charts/kruntimes/crds/kruntimes.io_workflows.yaml
+++ b/charts/kruntimes/crds/kruntimes.io_workflows.yaml
@@ -4,9 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
-  name: workflows.runtimes.kruntimes.io
+  name: workflows.kruntimes.io
 spec:
-  group: runtimes.kruntimes.io
+  group: kruntimes.io
   names:
     kind: Workflow
     listKind: WorkflowList

--- a/charts/kruntimes/templates/controller-rbac.yaml
+++ b/charts/kruntimes/templates/controller-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "kruntimes.labels" . | nindent 4 }}
 rules:
   - apiGroups:
-      - runtimes.kruntimes.io
+      - kruntimes.io
     resources:
       - runtimes
     verbs:
@@ -14,7 +14,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - runtimes.kruntimes.io
+      - kruntimes.io
     resources:
       - runtimes/status
     verbs:
@@ -22,7 +22,7 @@ rules:
       - update
       - patch
   - apiGroups:
-      - runtimes.kruntimes.io
+      - kruntimes.io
     resources:
       - workflows
     verbs:
@@ -30,7 +30,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - runtimes.kruntimes.io
+      - kruntimes.io
     resources:
       - workflows/status
     verbs:
@@ -38,7 +38,7 @@ rules:
       - update
       - patch
   - apiGroups:
-      - runtimes.kruntimes.io
+      - kruntimes.io
     resources:
       - runs
     verbs:
@@ -47,7 +47,7 @@ rules:
       - watch
       - create
   - apiGroups:
-      - runtimes.kruntimes.io
+      - kruntimes.io
     resources:
       - runs/status
     verbs:

--- a/charts/kruntimes/templates/runtimed-rbac.yaml
+++ b/charts/kruntimes/templates/runtimed-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "kruntimes.labels" . | nindent 4 }}
 rules:
   - apiGroups:
-      - runtimes.kruntimes.io
+      - kruntimes.io
     resources:
       - runs
     verbs:
@@ -14,7 +14,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - runtimes.kruntimes.io
+      - kruntimes.io
     resources:
       - runs/status
     verbs:

--- a/charts/kruntimes/templates/scheduler-rbac.yaml
+++ b/charts/kruntimes/templates/scheduler-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "kruntimes.labels" . | nindent 4 }}
 rules:
   - apiGroups:
-      - runtimes.kruntimes.io
+      - kruntimes.io
     resources:
       - runs
     verbs:
@@ -14,7 +14,7 @@ rules:
       - list
       - watch
   - apiGroups:
-      - runtimes.kruntimes.io
+      - kruntimes.io
     resources:
       - runs/status
     verbs:

--- a/internal/controller/runtime_controller.go
+++ b/internal/controller/runtime_controller.go
@@ -38,8 +38,8 @@ type RuntimeReconciler struct {
 	DefaultDaemonImage string
 }
 
-// +kubebuilder:rbac:groups=runtimes.kruntimes.io,resources=runtimes,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups=runtimes.kruntimes.io,resources=runtimes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=kruntimes.io,resources=runtimes,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=kruntimes.io,resources=runtimes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 

--- a/internal/controller/workflow_controller.go
+++ b/internal/controller/workflow_controller.go
@@ -24,9 +24,9 @@ type WorkflowReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=runtimes.kruntimes.io,resources=workflows,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups=runtimes.kruntimes.io,resources=workflows/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=runtimes.kruntimes.io,resources=runs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=kruntimes.io,resources=workflows,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=kruntimes.io,resources=workflows/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=kruntimes.io,resources=runs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 func (r *WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/internal/scheduler/reconciler.go
+++ b/internal/scheduler/reconciler.go
@@ -63,8 +63,8 @@ type RunReconciler struct {
 	RuntimedHeartbeatStaleAfter time.Duration
 }
 
-// +kubebuilder:rbac:groups=runtimes.kruntimes.io,resources=runs,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups=runtimes.kruntimes.io,resources=runs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=kruntimes.io,resources=runs,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=kruntimes.io,resources=runs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 
 func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
## Summary
- change the Kubernetes API group from runtimes.kruntimes.io to kruntimes.io
- keep all APIs in the existing api/v1alpha1 Go package and one Kubernetes API group
- update kubebuilder annotations, RBAC, Runtime manifests, docs, pod annotations/conditions, and regenerated CRD filenames/manifests

## Verification
- make generate
- make manifests
- go test ./api/... ./internal/scheduler/... ./internal/controller/... ./internal/runtimepod/...
- helm template kruntimes charts/kruntimes
- helm template kruntimes-runtimes charts/kruntimes-runtimes
- make test-integration
- git diff --check