### PR TITLE
fix(e2e): make runtime startup and builds reliable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ fmt: ## Run go fmt against code.
 	go fmt ./...
 
 .PHONY: vet
-vet: ## Run go vet against code.
+vet: generate proto ## Run go vet against code.
 	go vet ./...
 
 .PHONY: lint
@@ -56,7 +56,7 @@ lint: fmt vet golangci-lint ## Run go fmt, go vet, and golangci-lint.
 	$(GOLANGCI_LINT) run ./...
 
 .PHONY: test
-test: generate manifests fmt vet ## Run unit tests.
+test: generate manifests proto fmt vet ## Run unit tests.
 	go test $$(go list ./... | grep -v /test/integration | grep -v /test/e2e) -coverprofile cover.out
 
 .PHONY: test-integration
@@ -76,13 +76,12 @@ E2E_IMG_BASH_RUNTIME ?= kruntimes-bash-runtime:$(E2E_IMAGE_TAG)
 E2E_IMG_PYTHON_RUNTIME ?= kruntimes-python-runtime:$(E2E_IMAGE_TAG)
 
 .PHONY: e2e-setup
-e2e-setup: manifests ## Create kind cluster, load images, and deploy chart.
-	$(MAKE) docker-build \
-		IMG_SCHEDULER=$(E2E_IMG_SCHEDULER) \
-		IMG_CONTROLLER=$(E2E_IMG_CONTROLLER) \
-		IMG_RUNTIMED=$(E2E_IMG_RUNTIMED) \
-		IMG_BASH_RUNTIME=$(E2E_IMG_BASH_RUNTIME) \
-		IMG_PYTHON_RUNTIME=$(E2E_IMG_PYTHON_RUNTIME)
+e2e-setup: IMG_SCHEDULER = $(E2E_IMG_SCHEDULER)
+e2e-setup: IMG_CONTROLLER = $(E2E_IMG_CONTROLLER)
+e2e-setup: IMG_RUNTIMED = $(E2E_IMG_RUNTIMED)
+e2e-setup: IMG_BASH_RUNTIME = $(E2E_IMG_BASH_RUNTIME)
+e2e-setup: IMG_PYTHON_RUNTIME = $(E2E_IMG_PYTHON_RUNTIME)
+e2e-setup: manifests docker-build ## Create kind cluster, load images, and deploy chart.
 	kind get clusters | grep $(KIND_CLUSTER_NAME) || kind create cluster --name $(KIND_CLUSTER_NAME) --wait 120s
 	kind load docker-image $(E2E_IMG_SCHEDULER) --name $(KIND_CLUSTER_NAME)
 	kind load docker-image $(E2E_IMG_CONTROLLER) --name $(KIND_CLUSTER_NAME)
@@ -97,16 +96,18 @@ e2e-setup: manifests ## Create kind cluster, load images, and deploy chart.
 		--namespace $(NAMESPACE) --create-namespace --wait --timeout 120s
 
 .PHONY: e2e-test
-e2e-test: ## Run E2E tests against the kind cluster.
+e2e-test: generate ## Run E2E tests against the kind cluster.
 	KRUNTIMES_BASH_RUNTIME_IMAGE=$(E2E_IMG_BASH_RUNTIME) \
 	KRUNTIMES_PYTHON_RUNTIME_IMAGE=$(E2E_IMG_PYTHON_RUNTIME) \
 	KRUNTIMES_RUNTIMED_IMAGE=$(E2E_IMG_RUNTIMED) \
 	go test ./test/e2e/... -v -count=1 -failfast
 
 .PHONY: e2e
-e2e: ## Full E2E: setup cluster, deploy, run tests.
-	$(MAKE) e2e-setup E2E_IMAGE_TAG=$(E2E_RUN_IMAGE_TAG)
-	$(MAKE) e2e-test E2E_IMAGE_TAG=$(E2E_RUN_IMAGE_TAG)
+e2e: E2E_IMAGE_TAG := $(E2E_RUN_IMAGE_TAG)
+e2e: e2e-setup e2e-test ## Full E2E: setup cluster, deploy, run tests.
+
+# Preserve setup-before-test ordering even when make is invoked with -j.
+.NOTPARALLEL: e2e-setup e2e
 
 .PHONY: e2e-cleanup
 e2e-cleanup: ## Delete the kind cluster.
@@ -115,7 +116,7 @@ e2e-cleanup: ## Delete the kind cluster.
 ##@ Build
 
 .PHONY: build
-build: generate ## Build all binaries.
+build: generate proto ## Build all binaries.
 	go build -o bin/scheduler ./cmd/scheduler
 	go build -o bin/runtimed ./cmd/runtimed
 	go build -o bin/controller ./cmd/controller
@@ -127,7 +128,7 @@ build-scheduler: generate ## Build scheduler binary.
 	go build -o bin/scheduler ./cmd/scheduler
 
 .PHONY: build-runtimed
-build-runtimed: generate ## Build runtimed binary.
+build-runtimed: generate proto ## Build runtimed binary.
 	go build -o bin/runtimed ./cmd/runtimed
 
 .PHONY: build-controller
@@ -139,7 +140,7 @@ build-cli: generate ## Build krt binary.
 	go build -o bin/krt ./cmd/krt
 
 .PHONY: build-bash-runtime
-build-bash-runtime: generate ## Build bash-runtime binary.
+build-bash-runtime: proto ## Build bash-runtime binary.
 	go build -o bin/bash-runtime ./runtimes/bash/cmd
 
 .PHONY: run-scheduler
@@ -147,7 +148,7 @@ run-scheduler: generate manifests ## Run scheduler locally (requires kubeconfig)
 	go run ./cmd/scheduler --kubeconfig=$(HOME)/.kube/config
 
 .PHONY: run-runtimed
-run-runtimed: generate manifests ## Run runtimed locally (requires kubeconfig).
+run-runtimed: generate manifests proto ## Run runtimed locally (requires kubeconfig).
 	go run ./cmd/runtimed --kubeconfig=$(HOME)/.kube/config
 
 ##@ Docker
@@ -156,23 +157,23 @@ run-runtimed: generate manifests ## Run runtimed locally (requires kubeconfig).
 docker-build: docker-build-scheduler docker-build-controller docker-build-runtimed docker-build-bash-runtime docker-build-python-runtime ## Build all Docker images.
 
 .PHONY: docker-build-scheduler
-docker-build-scheduler: ## Build scheduler Docker image.
+docker-build-scheduler: generate ## Build scheduler Docker image.
 	$(CONTAINER_TOOL) build -t $(IMG_SCHEDULER) -f Dockerfile.scheduler .
 
 .PHONY: docker-build-controller
-docker-build-controller: ## Build controller Docker image.
+docker-build-controller: generate ## Build controller Docker image.
 	$(CONTAINER_TOOL) build -t $(IMG_CONTROLLER) -f Dockerfile.controller .
 
 .PHONY: docker-build-runtimed
-docker-build-runtimed: ## Build runtimed Docker image.
+docker-build-runtimed: generate proto ## Build runtimed Docker image.
 	$(CONTAINER_TOOL) build -t $(IMG_RUNTIMED) -f Dockerfile.runtimed .
 
 .PHONY: docker-build-bash-runtime
-docker-build-bash-runtime: ## Build bash-runtime Docker image.
+docker-build-bash-runtime: proto ## Build bash-runtime Docker image.
 	$(CONTAINER_TOOL) build -t $(IMG_BASH_RUNTIME) -f Dockerfile.bash-runtime .
 
 .PHONY: docker-build-python-runtime
-docker-build-python-runtime: ## Build python-runtime Docker image from committed protobuf stubs.
+docker-build-python-runtime: proto-python ## Build python-runtime Docker image.
 	$(CONTAINER_TOOL) build -t $(IMG_PYTHON_RUNTIME) -f Dockerfile.python-runtime .
 
 .PHONY: docker-push

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ docker-build-bash-runtime: ## Build bash-runtime Docker image.
 	$(CONTAINER_TOOL) build -t $(IMG_BASH_RUNTIME) -f Dockerfile.bash-runtime .
 
 .PHONY: docker-build-python-runtime
-docker-build-python-runtime: proto-python ## Build python-runtime Docker image.
+docker-build-python-runtime: ## Build python-runtime Docker image from committed protobuf stubs.
 	$(CONTAINER_TOOL) build -t $(IMG_PYTHON_RUNTIME) -f Dockerfile.python-runtime .
 
 .PHONY: docker-push

--- a/Makefile
+++ b/Makefile
@@ -253,11 +253,22 @@ protoc-gen-go: ## Install protoc-gen-go if not present.
 protoc-gen-go-grpc: ## Install protoc-gen-go-grpc if not present.
 	@test -x $(PROTOC_GEN_GO_GRPC) || go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
+UV = $(GOBIN)/uv
+.PHONY: uv
+uv: ## Install uv locally if not present.
+	@test -x "$(UV)" || ( \
+		mkdir -p "$(GOBIN)"; \
+		installer=$$(mktemp); \
+		trap 'rm -f "$$installer"' 0; \
+		curl -LsSf https://astral.sh/uv/install.sh -o "$$installer"; \
+		env UV_INSTALL_DIR="$(GOBIN)" UV_NO_MODIFY_PATH=1 sh "$$installer" \
+	)
+
 .PHONY: proto-python
-proto-python: ## Generate Python gRPC stubs from proto.
+proto-python: uv ## Generate Python gRPC stubs from proto.
 	@mkdir -p runtimes/python/pb
 	@touch runtimes/python/pb/__init__.py
-	@cd runtimes/python && uv run python -m grpc_tools.protoc \
+	@cd runtimes/python && $(UV) run python -m grpc_tools.protoc \
 		--proto_path=../../api/runtime/v1 \
 		--python_out=pb \
 		--grpc_python_out=pb \

--- a/internal/controller/runtime_controller.go
+++ b/internal/controller/runtime_controller.go
@@ -173,7 +173,7 @@ func (r *RuntimeReconciler) buildDeployment(rt *v1alpha1.Runtime) *appsv1.Deploy
 		Image:           daemonImage,
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Args: []string{
-			fmt.Sprintf("--runtime-endpoint=localhost:%d", port),
+			fmt.Sprintf("--runtime-endpoint=127.0.0.1:%d", port),
 			"--status-addr=:9093",
 		},
 		Env: []corev1.EnvVar{

--- a/internal/controller/runtime_controller_test.go
+++ b/internal/controller/runtime_controller_test.go
@@ -39,4 +39,7 @@ func TestBuildDeploymentAddsCapacityAnnotationsAndWorkers(t *testing.T) {
 	if !slices.Contains(daemon.Args, "--workers=3") {
 		t.Fatalf("daemon args = %v, want --workers=3", daemon.Args)
 	}
+	if !slices.Contains(daemon.Args, "--runtime-endpoint=127.0.0.1:9091") {
+		t.Fatalf("daemon args = %v, want IPv4 loopback runtime endpoint", daemon.Args)
+	}
 }

--- a/internal/runtimed/controller.go
+++ b/internal/runtimed/controller.go
@@ -563,7 +563,7 @@ func (c *Controller) startExecution(ctx context.Context, ar *activeRun) error {
 		WorkingDir:     ar.workDir,
 		Entrypoint:     entrypoint,
 		Handler:        run.Spec.Handler,
-	})
+	}, grpc.WaitForReady(true))
 	return err
 }
 

--- a/internal/runtimed/controller_test.go
+++ b/internal/runtimed/controller_test.go
@@ -423,15 +423,36 @@ func TestRecoverActiveRunsOnceAddsRuntimeExecutions(t *testing.T) {
 	}
 }
 
-type fakeRuntimeClient struct {
-	pb.RuntimeClient
-	status    *pb.StatusResponse
-	statusErr error
-	list      *pb.ListResponse
-	listErr   error
+func TestStartExecutionWaitsForRuntimeReady(t *testing.T) {
+	runtimeClient := &fakeRuntimeClient{}
+	c := &Controller{runtimeCli: runtimeClient}
+	ar := &activeRun{
+		run: &v1alpha1.Run{
+			ObjectMeta: metav1.ObjectMeta{UID: "run-uid"},
+			Spec:       v1alpha1.RunSpec{Runtime: "python"},
+		},
+		workDir: t.TempDir(),
+	}
+
+	if err := c.startExecution(t.Context(), ar); err != nil {
+		t.Fatalf("startExecution: %v", err)
+	}
+	if runtimeClient.executeOptions == 0 {
+		t.Fatal("expected Execute to wait for the runtime connection to become ready")
+	}
 }
 
-func (f *fakeRuntimeClient) Execute(context.Context, *pb.ExecuteRequest, ...grpc.CallOption) (*pb.ExecuteResponse, error) {
+type fakeRuntimeClient struct {
+	pb.RuntimeClient
+	status         *pb.StatusResponse
+	statusErr      error
+	list           *pb.ListResponse
+	listErr        error
+	executeOptions int
+}
+
+func (f *fakeRuntimeClient) Execute(_ context.Context, _ *pb.ExecuteRequest, opts ...grpc.CallOption) (*pb.ExecuteResponse, error) {
+	f.executeOptions = len(opts)
 	return &pb.ExecuteResponse{}, nil
 }
 

--- a/runtimes/python/cmd/main.py
+++ b/runtimes/python/cmd/main.py
@@ -19,7 +19,8 @@ def main():
     runtime_pb2_grpc.add_RuntimeServicer_to_server(
         PythonRuntime(work_dir=args.work_dir), server
     )
-    server.add_insecure_port(f"[::]:{args.port}")
+    if server.add_insecure_port(f"0.0.0.0:{args.port}") == 0:
+        raise RuntimeError(f"failed to bind Python runtime to port {args.port}")
     server.start()
     print(f"Python runtime listening on port {args.port}", flush=True)
 


### PR DESCRIPTION
## Summary
- use explicit loopback addresses and wait-for-ready execution for runtime startup
- install uv automatically for Python protobuf generation
- wire generated sources into their build and Docker consumers
- replace recursive e2e make calls with native prerequisites and target-specific variables

## Validation
- `make e2e E2E_RUN_IMAGE_TAG=e2e-20260606181500`
- `make test`
- `make generate proto proto-python`
- Python runtime unit tests (5 passed)
- `make -n -j5 e2e E2E_RUN_IMAGE_TAG=e2e-order-test CONTAINER_TOOL=echo HELM=echo`