### PR TITLE
feat(runtimed): bound outputs and emit structured logs

### DIFF
--- a/internal/runtimed/controller.go
+++ b/internal/runtimed/controller.go
@@ -1,14 +1,13 @@
 package runtimed
 
 import (
-	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 
@@ -32,6 +31,7 @@ import (
 
 	pb "github.com/kruntimes/kruntimes/api/runtime/v1"
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	"github.com/kruntimes/kruntimes/internal/artifact"
 	runretry "github.com/kruntimes/kruntimes/internal/retry"
 	rlegpkg "github.com/kruntimes/kruntimes/internal/runtimed/rleg"
 	"github.com/kruntimes/kruntimes/internal/runtimepod"
@@ -76,10 +76,12 @@ type Controller struct {
 	RuntimeEndpoint string
 	Workers         int
 
-	HeartbeatInterval time.Duration
+	HeartbeatInterval  time.Duration
+	ExecutionLogWriter io.Writer
 
 	activeRuns sync.Map // uid → *activeRun
 	rlegCh     chan event.GenericEvent
+	logMu      sync.Mutex
 
 	runtimeCli pb.RuntimeClient
 	rleg       rlegpkg.RunLifecycleEventGenerator
@@ -314,14 +316,11 @@ func (c *Controller) reconcileRunningRecovered(ctx context.Context, run *v1alpha
 	ar := c.addRecoveredRun(run)
 	switch resp.State {
 	case pb.ExecutionState_EXECUTION_STATE_SUCCEEDED:
-		return c.applySuccess(ctx, ar, resp.Stdout)
+		return c.applySuccess(ctx, ar, resp)
 	case pb.ExecutionState_EXECUTION_STATE_FAILED:
 		reason := classifyFailureReason(resp, nil)
-		msg := resp.ErrorMessage
-		if msg == "" {
-			msg = resp.Stderr
-		}
-		return c.applyFailure(ctx, ar, reason, msg)
+		msg := summarizeRuntimeFailure(resp)
+		return c.applyFailureWithOutput(ctx, ar, reason, msg, outputFromStatus(resp))
 	default:
 		return ctrl.Result{}, nil
 	}
@@ -365,14 +364,11 @@ func (c *Controller) reconcileRunningActive(ctx context.Context, ar *activeRun) 
 
 	switch resp.State {
 	case pb.ExecutionState_EXECUTION_STATE_SUCCEEDED:
-		return c.applySuccess(ctx, ar, resp.Stdout)
+		return c.applySuccess(ctx, ar, resp)
 	case pb.ExecutionState_EXECUTION_STATE_FAILED:
 		reason := classifyFailureReason(resp, nil)
-		msg := resp.ErrorMessage
-		if msg == "" {
-			msg = resp.Stderr
-		}
-		return c.applyFailure(ctx, ar, reason, msg)
+		msg := summarizeRuntimeFailure(resp)
+		return c.applyFailureWithOutput(ctx, ar, reason, msg, outputFromStatus(resp))
 	}
 	return ctrl.Result{}, nil
 }
@@ -415,16 +411,25 @@ func (c *Controller) reconcileRetryBackoff(ctx context.Context, ar *activeRun) (
 // applySuccess — terminal success, no retry
 // ===========================================================================
 
-func (c *Controller) applySuccess(ctx context.Context, ar *activeRun, stdout string) (ctrl.Result, error) {
+func (c *Controller) applySuccess(ctx context.Context, ar *activeRun, resp *pb.StatusResponse) (ctrl.Result, error) {
 	run := ar.run
+	outputs, err := readOutputs(outputsPath(ar.workDir))
+	if err != nil {
+		reason := reasonOutputsInvalid
+		if isOutputsTooLarge(err) {
+			reason = reasonOutputsTooLarge
+		}
+		return c.applyTerminalWithOutput(ctx, ar, v1alpha1.RunFailed, reason, err.Error(), outputFromStatus(resp))
+	}
+
 	now := metav1.Now()
 	if run.Status.Attempt == 0 {
 		run.Status.Attempt = 1
 	}
 	run.Status.Phase = v1alpha1.RunSucceeded
-	run.Status.Message = stdout
+	run.Status.Message = "execution completed"
 	run.Status.CompletionTime = &now
-	run.Status.Outputs = readOutputs(ar.workDir)
+	run.Status.Outputs = outputs
 	meta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{
 		Type: "Running", Status: metav1.ConditionFalse, Reason: "Completed", Message: "",
 	})
@@ -436,6 +441,7 @@ func (c *Controller) applySuccess(ctx context.Context, ar *activeRun, stdout str
 		return ctrl.Result{}, err
 	}
 
+	c.emitExecutionOutput(run, outputFromStatus(resp))
 	c.cleanup(ctx, ar, v1alpha1.RunSucceeded)
 	if run.Status.Attempt > 1 {
 		c.recordEvent(run, corev1.EventTypeNormal, "RunSucceeded",
@@ -449,13 +455,23 @@ func (c *Controller) applySuccess(ctx context.Context, ar *activeRun, stdout str
 // ===========================================================================
 
 func (c *Controller) applyFailure(ctx context.Context, ar *activeRun, reason, msg string) (ctrl.Result, error) {
+	return c.applyFailureWithOutput(ctx, ar, reason, msg, executionOutput{})
+}
+
+func (c *Controller) applyFailureWithOutput(
+	ctx context.Context,
+	ar *activeRun,
+	reason, msg string,
+	output executionOutput,
+) (ctrl.Result, error) {
 	run := ar.run
 	policy := runretry.WithDefaults(run.Spec.RetryPolicy)
+	msg = boundedStatusMessage(msg)
 
 	curAttempt := runretry.CurrentAttempt(run.Status.Attempt)
 
 	if !runretry.ShouldRetry(policy, curAttempt, reason) {
-		return c.applyTerminal(ctx, ar, terminalPhaseForFailure(reason), reason, msg)
+		return c.applyTerminalWithOutput(ctx, ar, terminalPhaseForFailure(reason), reason, msg, output)
 	}
 
 	// Schedule retry.
@@ -496,7 +512,18 @@ func (c *Controller) scheduleRetry(ctx context.Context, ar *activeRun, curAttemp
 // ===========================================================================
 
 func (c *Controller) applyTerminal(ctx context.Context, ar *activeRun, phase v1alpha1.RunPhase, reason, msg string) (ctrl.Result, error) {
+	return c.applyTerminalWithOutput(ctx, ar, phase, reason, msg, executionOutput{})
+}
+
+func (c *Controller) applyTerminalWithOutput(
+	ctx context.Context,
+	ar *activeRun,
+	phase v1alpha1.RunPhase,
+	reason, msg string,
+	output executionOutput,
+) (ctrl.Result, error) {
 	run := ar.run
+	msg = boundedStatusMessage(msg)
 	if run.Status.Attempt == 0 {
 		run.Status.Attempt = 1
 	}
@@ -516,6 +543,7 @@ func (c *Controller) applyTerminal(ctx context.Context, ar *activeRun, phase v1a
 		return ctrl.Result{}, err
 	}
 
+	c.emitExecutionOutput(run, output)
 	c.cleanup(ctx, ar, phase)
 	c.recordEvent(run, corev1.EventTypeWarning, "RunRetriesExhausted",
 		"Run failed after %d attempts: %s: %s", run.Status.Attempt, reason, msg)
@@ -545,6 +573,11 @@ func (c *Controller) startExecution(ctx context.Context, ar *activeRun) error {
 	for _, e := range run.Spec.Env {
 		env[e.Name] = e.Value
 	}
+	outputPath := outputsPath(ar.workDir)
+	if err := os.Remove(outputPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("reset outputs file: %w", err)
+	}
+	env[artifact.OutputsEnv] = outputPath
 	var timeoutSec int64
 	if run.Spec.Timeout != nil {
 		timeoutSec = int64(run.Spec.Timeout.Duration.Seconds())
@@ -777,34 +810,6 @@ func podNamespace() string {
 		return ns
 	}
 	return "default"
-}
-
-func readOutputs(workingDir string) map[string]string {
-	if workingDir == "" {
-		return nil
-	}
-	f, err := os.Open(filepath.Join(workingDir, "outputs"))
-	if err != nil {
-		return nil
-	}
-	defer f.Close()
-
-	outputs := make(map[string]string)
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) == 2 {
-			outputs[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		klog.Warningf("error reading outputs file %s: %v", workingDir, err)
-	}
-	return outputs
 }
 
 // statusAdapter adapts the gRPC client to rlegpkg.StatusProvider.

--- a/internal/runtimed/controller_test.go
+++ b/internal/runtimed/controller_test.go
@@ -1,9 +1,12 @@
 package runtimed
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,12 +14,14 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	"github.com/kruntimes/kruntimes/internal/artifact"
 	runretry "github.com/kruntimes/kruntimes/internal/retry"
 )
 
@@ -91,14 +96,20 @@ func TestPrepareSource_InlineDefaultEntrypoint(t *testing.T) {
 }
 
 func TestReadOutputs_Empty(t *testing.T) {
-	outputs := readOutputs("")
+	outputs, err := readOutputs("")
+	if err != nil {
+		t.Fatalf("readOutputs: %v", err)
+	}
 	if outputs != nil {
 		t.Error("expected nil for empty workingDir")
 	}
 }
 
 func TestReadOutputs_Nonexistent(t *testing.T) {
-	outputs := readOutputs("/nonexistent/path")
+	outputs, err := readOutputs(filepath.Join(t.TempDir(), "missing"))
+	if err != nil {
+		t.Fatalf("readOutputs: %v", err)
+	}
 	if outputs != nil {
 		t.Error("expected nil for nonexistent file")
 	}
@@ -107,9 +118,13 @@ func TestReadOutputs_Nonexistent(t *testing.T) {
 func TestReadOutputs_Valid(t *testing.T) {
 	dir := t.TempDir()
 	content := "key1=val1\nkey2=val2\n# comment\nkey3 = val3\n"
-	_ = os.WriteFile(filepath.Join(dir, "outputs"), []byte(content), 0o644)
+	path := filepath.Join(dir, "outputs")
+	_ = os.WriteFile(path, []byte(content), 0o644)
 
-	outputs := readOutputs(dir)
+	outputs, err := readOutputs(path)
+	if err != nil {
+		t.Fatalf("readOutputs: %v", err)
+	}
 	if len(outputs) != 3 {
 		t.Fatalf("expected 3 outputs, got %d: %v", len(outputs), outputs)
 	}
@@ -124,16 +139,92 @@ func TestReadOutputs_Valid(t *testing.T) {
 	}
 }
 
-func TestReadOutputs_SkipsMalformed(t *testing.T) {
+func TestReadOutputs_RejectsMalformed(t *testing.T) {
 	dir := t.TempDir()
-	content := "no_equal_sign\n=empty_key\nb=\n  \n"
-	_ = os.WriteFile(filepath.Join(dir, "outputs"), []byte(content), 0o644)
+	path := filepath.Join(dir, "outputs")
+	_ = os.WriteFile(path, []byte("no_equal_sign\n"), 0o644)
 
-	outputs := readOutputs(dir)
-	// "no_equal_sign" has no "=", skipped. "=empty_key" yields key="" value="empty_key".
-	// "b=" yields key="b" value="". Whitespace-only lines are skipped.
-	if _, ok := outputs["b"]; !ok {
-		t.Errorf("expected key 'b', got %v", outputs)
+	if _, err := readOutputs(path); err == nil || isOutputsTooLarge(err) {
+		t.Fatalf("readOutputs error = %v, want invalid outputs error", err)
+	}
+}
+
+func TestReadOutputs_DuplicateKeyLastWins(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "outputs")
+	_ = os.WriteFile(path, []byte("version=v1\nversion=v2\n"), 0o644)
+
+	outputs, err := readOutputs(path)
+	if err != nil {
+		t.Fatalf("readOutputs: %v", err)
+	}
+	if got := outputs["version"]; got != "v2" {
+		t.Fatalf("version = %q, want v2", got)
+	}
+}
+
+func TestReadOutputs_Limits(t *testing.T) {
+	tests := []struct {
+		name    string
+		content []byte
+	}{
+		{
+			name:    "invalid utf8",
+			content: []byte{'k', '=', 0xff, '\n'},
+		},
+		{
+			name:    "key too large",
+			content: []byte(strings.Repeat("k", artifact.MaxOutputKeyBytes+1) + "=v\n"),
+		},
+		{
+			name:    "value too large",
+			content: []byte("k=" + strings.Repeat("v", artifact.MaxOutputValueBytes+1) + "\n"),
+		},
+		{
+			name: "too many keys",
+			content: []byte(func() string {
+				var b strings.Builder
+				for i := 0; i <= artifact.MaxOutputKeys; i++ {
+					b.WriteString("key")
+					b.WriteString(strings.Repeat("x", i))
+					b.WriteString("=v\n")
+				}
+				return b.String()
+			}()),
+		},
+		{
+			name: "total too large",
+			content: []byte(func() string {
+				var b strings.Builder
+				for i := 0; i < 9; i++ {
+					b.WriteString("key")
+					b.WriteByte(byte('a' + i))
+					b.WriteByte('=')
+					b.WriteString(strings.Repeat("v", artifact.MaxOutputValueBytes))
+					b.WriteByte('\n')
+				}
+				return b.String()
+			}()),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "outputs")
+			if err := os.WriteFile(path, tt.content, 0o644); err != nil {
+				t.Fatalf("write outputs: %v", err)
+			}
+			_, err := readOutputs(path)
+			if err == nil {
+				t.Fatal("readOutputs succeeded, want error")
+			}
+			if tt.name == "invalid utf8" {
+				if isOutputsTooLarge(err) {
+					t.Fatalf("error = %v, want invalid outputs", err)
+				}
+			} else if !isOutputsTooLarge(err) {
+				t.Fatalf("error = %v, want outputs too large", err)
+			}
+		})
 	}
 }
 
@@ -319,8 +410,176 @@ func TestReconcileRunningRecoversMissingActiveRun(t *testing.T) {
 	if updated.Status.Phase != v1alpha1.RunSucceeded {
 		t.Fatalf("phase = %s, want Succeeded", updated.Status.Phase)
 	}
-	if updated.Status.Message != "done" {
-		t.Fatalf("message = %q, want done", updated.Status.Message)
+	if updated.Status.Message != "execution completed" {
+		t.Fatalf("message = %q, want execution completed", updated.Status.Message)
+	}
+}
+
+func TestApplySuccessRejectsInvalidOutputsWithoutRetry(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	workDir := t.TempDir()
+	if err := os.WriteFile(outputsPath(workDir), []byte("invalid\n"), 0o644); err != nil {
+		t.Fatalf("write outputs: %v", err)
+	}
+	run := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "invalid-outputs", Namespace: "default", UID: "invalid-outputs-uid"},
+		Spec: v1alpha1.RunSpec{
+			Runtime:     "bash",
+			RetryPolicy: &v1alpha1.RetryPolicy{MaxAttempts: 3},
+		},
+		Status: v1alpha1.RunStatus{Phase: v1alpha1.RunRunning, AssignedPod: "pod-a"},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.Run{}).
+		WithObjects(run).
+		Build()
+	c := &Controller{Client: k8sClient, Hostname: "pod-a"}
+	ar := &activeRun{run: run, workDir: workDir, start: time.Now()}
+	c.activeRuns.Store(string(run.UID), ar)
+
+	if _, err := c.applySuccess(t.Context(), ar, &pb.StatusResponse{Stdout: "done"}); err != nil {
+		t.Fatalf("applySuccess: %v", err)
+	}
+
+	var updated v1alpha1.Run
+	if err := k8sClient.Get(t.Context(), types.NamespacedName{Name: run.Name, Namespace: run.Namespace}, &updated); err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if updated.Status.Phase != v1alpha1.RunFailed {
+		t.Fatalf("phase = %s, want Failed", updated.Status.Phase)
+	}
+	if updated.Status.Attempt != 1 {
+		t.Fatalf("attempt = %d, want 1", updated.Status.Attempt)
+	}
+	completed := meta.FindStatusCondition(updated.Status.Conditions, "Completed")
+	if completed == nil || completed.Reason != reasonOutputsInvalid {
+		t.Fatalf("Completed condition = %#v, want reason %s", completed, reasonOutputsInvalid)
+	}
+	if c.activeRunCount() != 0 {
+		t.Fatalf("active runs = %d, want 0", c.activeRunCount())
+	}
+}
+
+func TestApplySuccessEmitsStructuredOutputAfterStatusUpdate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	run := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "logged", Namespace: "team-a", UID: "logged-uid"},
+		Spec:       v1alpha1.RunSpec{Runtime: "bash"},
+		Status:     v1alpha1.RunStatus{Phase: v1alpha1.RunRunning, AssignedPod: "pod-a"},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.Run{}).
+		WithObjects(run).
+		Build()
+	var output bytes.Buffer
+	c := &Controller{Client: k8sClient, Hostname: "pod-a", ExecutionLogWriter: &output}
+	ar := &activeRun{run: run, workDir: t.TempDir(), start: time.Now()}
+	largeStdout := "stdout-secret-" + strings.Repeat("x", maxStatusMessageBytes*2)
+
+	if _, err := c.applySuccess(t.Context(), ar, &pb.StatusResponse{
+		Stdout: largeStdout + "\nworld\n",
+		Stderr: "warning\n",
+	}); err != nil {
+		t.Fatalf("applySuccess: %v", err)
+	}
+
+	var updated v1alpha1.Run
+	if err := k8sClient.Get(t.Context(), types.NamespacedName{Name: run.Name, Namespace: run.Namespace}, &updated); err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if updated.Status.Message != "execution completed" || strings.Contains(updated.Status.Message, "stdout-secret") {
+		t.Fatalf("status message contains stdout: %q", updated.Status.Message)
+	}
+
+	lines := strings.Split(strings.TrimSpace(output.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("log lines = %d, want 3: %q", len(lines), output.String())
+	}
+	for i, line := range lines {
+		var entry executionLogLine
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("unmarshal line %d: %v", i, err)
+		}
+		if entry.RunUID != "logged-uid" || entry.RunName != "logged" || entry.Namespace != "team-a" ||
+			entry.Runtime != "bash" || entry.Pod != "pod-a" {
+			t.Fatalf("unexpected metadata on line %d: %#v", i, entry)
+		}
+	}
+}
+
+func TestApplyFailureBoundsStatusMessageAndLogsFullStderr(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+	run := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "failed", Namespace: "team-a", UID: "failed-uid"},
+		Spec:       v1alpha1.RunSpec{Runtime: "bash"},
+		Status:     v1alpha1.RunStatus{Phase: v1alpha1.RunRunning, AssignedPod: "pod-a"},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.Run{}).
+		WithObjects(run).
+		Build()
+	var output bytes.Buffer
+	c := &Controller{Client: k8sClient, Hostname: "pod-a", ExecutionLogWriter: &output}
+	ar := &activeRun{run: run, workDir: t.TempDir(), start: time.Now()}
+	stderr := strings.Repeat("early-", 400) + "useful-tail"
+	resp := &pb.StatusResponse{Stderr: stderr}
+
+	if _, err := c.applyFailureWithOutput(
+		t.Context(),
+		ar,
+		runretry.ReasonRuntimeError,
+		summarizeRuntimeFailure(resp),
+		outputFromStatus(resp),
+	); err != nil {
+		t.Fatalf("applyFailureWithOutput: %v", err)
+	}
+
+	var updated v1alpha1.Run
+	if err := k8sClient.Get(t.Context(), types.NamespacedName{Name: run.Name, Namespace: run.Namespace}, &updated); err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if len(updated.Status.Message) > maxStatusMessageBytes {
+		t.Fatalf("status message is %d bytes, want <= %d", len(updated.Status.Message), maxStatusMessageBytes)
+	}
+	if !strings.HasPrefix(updated.Status.Message, "runtime stderr: ... ") ||
+		!strings.HasSuffix(updated.Status.Message, "useful-tail") {
+		t.Fatalf("status message does not contain bounded stderr tail: %q", updated.Status.Message)
+	}
+	if strings.Contains(updated.Status.Message, strings.Repeat("early-", 200)) {
+		t.Fatal("status message contains unbounded stderr")
+	}
+	if !strings.Contains(output.String(), stderr) {
+		t.Fatal("structured log does not contain full stderr")
+	}
+}
+
+func TestSummarizeRuntimeFailureCapsErrorMessage(t *testing.T) {
+	message := "runtime-error-" + strings.Repeat("x", maxStatusMessageBytes*2)
+	got := summarizeRuntimeFailure(&pb.StatusResponse{
+		ErrorMessage: message,
+		Stderr:       strings.Repeat("stderr", maxStatusMessageBytes),
+	})
+	if len(got) > maxStatusMessageBytes {
+		t.Fatalf("message is %d bytes, want <= %d", len(got), maxStatusMessageBytes)
+	}
+	if !strings.HasPrefix(got, "runtime-error-") || !strings.HasSuffix(got, "...") {
+		t.Fatalf("unexpected bounded error message: %q", got)
+	}
+	if strings.Contains(got, "stderr") {
+		t.Fatalf("error message unexpectedly contains stderr: %q", got)
 	}
 }
 
@@ -440,6 +699,9 @@ func TestStartExecutionWaitsForRuntimeReady(t *testing.T) {
 	if runtimeClient.executeOptions == 0 {
 		t.Fatal("expected Execute to wait for the runtime connection to become ready")
 	}
+	if got := runtimeClient.executeRequest.Env[artifact.OutputsEnv]; got != outputsPath(ar.workDir) {
+		t.Fatalf("%s = %q, want %q", artifact.OutputsEnv, got, outputsPath(ar.workDir))
+	}
 }
 
 type fakeRuntimeClient struct {
@@ -449,10 +711,12 @@ type fakeRuntimeClient struct {
 	list           *pb.ListResponse
 	listErr        error
 	executeOptions int
+	executeRequest *pb.ExecuteRequest
 }
 
-func (f *fakeRuntimeClient) Execute(_ context.Context, _ *pb.ExecuteRequest, opts ...grpc.CallOption) (*pb.ExecuteResponse, error) {
+func (f *fakeRuntimeClient) Execute(_ context.Context, req *pb.ExecuteRequest, opts ...grpc.CallOption) (*pb.ExecuteResponse, error) {
 	f.executeOptions = len(opts)
+	f.executeRequest = req
 	return &pb.ExecuteResponse{}, nil
 }
 

--- a/internal/runtimed/execution_logs.go
+++ b/internal/runtimed/execution_logs.go
@@ -1,0 +1,70 @@
+package runtimed
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+
+	pb "github.com/kruntimes/kruntimes/api/runtime/v1"
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+type executionOutput struct {
+	stdout string
+	stderr string
+}
+
+type executionLogLine struct {
+	RunUID    string `json:"run_uid"`
+	RunName   string `json:"run_name"`
+	Namespace string `json:"namespace"`
+	Runtime   string `json:"runtime"`
+	Pod       string `json:"pod"`
+	Stream    string `json:"stream"`
+	Message   string `json:"message"`
+}
+
+func outputFromStatus(resp *pb.StatusResponse) executionOutput {
+	if resp == nil {
+		return executionOutput{}
+	}
+	return executionOutput{stdout: resp.Stdout, stderr: resp.Stderr}
+}
+
+func (c *Controller) emitExecutionOutput(run *v1alpha1.Run, output executionOutput) {
+	if run == nil {
+		return
+	}
+	writer := c.ExecutionLogWriter
+	if writer == nil {
+		writer = os.Stdout
+	}
+
+	c.logMu.Lock()
+	defer c.logMu.Unlock()
+	c.emitStream(writer, run, "stdout", output.stdout)
+	c.emitStream(writer, run, "stderr", output.stderr)
+}
+
+func (c *Controller) emitStream(writer io.Writer, run *v1alpha1.Run, stream, content string) {
+	for _, message := range strings.Split(strings.TrimSuffix(content, "\n"), "\n") {
+		if message == "" {
+			continue
+		}
+		line := executionLogLine{
+			RunUID:    string(run.UID),
+			RunName:   run.Name,
+			Namespace: run.Namespace,
+			Runtime:   run.Spec.Runtime,
+			Pod:       c.Hostname,
+			Stream:    stream,
+			Message:   strings.TrimSuffix(message, "\r"),
+		}
+		encoded, err := json.Marshal(line)
+		if err != nil {
+			continue
+		}
+		_, _ = writer.Write(append(encoded, '\n'))
+	}
+}

--- a/internal/runtimed/outputs.go
+++ b/internal/runtimed/outputs.go
@@ -1,0 +1,115 @@
+package runtimed
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/kruntimes/kruntimes/internal/artifact"
+)
+
+const (
+	reasonOutputsInvalid  = "OutputsInvalid"
+	reasonOutputsTooLarge = "OutputsTooLarge"
+)
+
+type outputsTooLargeError struct {
+	message string
+}
+
+func (e *outputsTooLargeError) Error() string {
+	return e.message
+}
+
+func isOutputsTooLarge(err error) bool {
+	var target *outputsTooLargeError
+	return errors.As(err, &target)
+}
+
+func outputsPath(workingDir string) string {
+	return filepath.Join(workingDir, "outputs")
+}
+
+// readOutputs parses KEY=VALUE lines. Duplicate keys are deterministic: the
+// last declaration replaces the previous value.
+func readOutputs(path string) (map[string]string, error) {
+	if path == "" {
+		return nil, nil
+	}
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read outputs: %w", err)
+	}
+	defer f.Close()
+
+	outputs := make(map[string]string)
+	totalBytes := 0
+	reader := bufio.NewReader(f)
+	lineNumber := 0
+	for {
+		line, readErr := reader.ReadString('\n')
+		if readErr != nil && !errors.Is(readErr, io.EOF) {
+			return nil, fmt.Errorf("read outputs: %w", readErr)
+		}
+		if line != "" {
+			lineNumber++
+			line = strings.TrimSuffix(line, "\n")
+			line = strings.TrimSuffix(line, "\r")
+			if !utf8.ValidString(line) {
+				return nil, fmt.Errorf("outputs line %d is not valid UTF-8", lineNumber)
+			}
+			trimmed := strings.TrimSpace(line)
+			if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+				key, value, ok := strings.Cut(trimmed, "=")
+				if !ok {
+					return nil, fmt.Errorf("outputs line %d must use KEY=VALUE format", lineNumber)
+				}
+				key = strings.TrimSpace(key)
+				value = strings.TrimSpace(value)
+				if key == "" {
+					return nil, fmt.Errorf("outputs line %d has an empty key", lineNumber)
+				}
+				if len(key) > artifact.MaxOutputKeyBytes {
+					return nil, &outputsTooLargeError{message: fmt.Sprintf(
+						"output key on line %d exceeds %d bytes", lineNumber, artifact.MaxOutputKeyBytes,
+					)}
+				}
+				if len(value) > artifact.MaxOutputValueBytes {
+					return nil, &outputsTooLargeError{message: fmt.Sprintf(
+						"output value for %q exceeds %d bytes", key, artifact.MaxOutputValueBytes,
+					)}
+				}
+
+				if previous, exists := outputs[key]; exists {
+					totalBytes -= len(key) + len(previous)
+				} else if len(outputs) >= artifact.MaxOutputKeys {
+					return nil, &outputsTooLargeError{message: fmt.Sprintf(
+						"outputs exceed %d keys", artifact.MaxOutputKeys,
+					)}
+				}
+				totalBytes += len(key) + len(value)
+				if totalBytes > artifact.MaxOutputsBytes {
+					return nil, &outputsTooLargeError{message: fmt.Sprintf(
+						"outputs exceed %d bytes", artifact.MaxOutputsBytes,
+					)}
+				}
+				outputs[key] = value
+			}
+		}
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+	}
+	if len(outputs) == 0 {
+		return nil, nil
+	}
+	return outputs, nil
+}

--- a/internal/runtimed/status_message.go
+++ b/internal/runtimed/status_message.go
@@ -1,0 +1,64 @@
+package runtimed
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	pb "github.com/kruntimes/kruntimes/api/runtime/v1"
+)
+
+const maxStatusMessageBytes = 1024
+
+func summarizeRuntimeFailure(resp *pb.StatusResponse) string {
+	if resp == nil {
+		return "runtime execution failed"
+	}
+	if resp.ErrorMessage != "" {
+		return boundedStatusMessage(resp.ErrorMessage)
+	}
+	if resp.Stderr != "" {
+		return boundedStatusMessageTail("runtime stderr: ", resp.Stderr)
+	}
+	return "runtime execution failed"
+}
+
+func boundedStatusMessage(message string) string {
+	message = strings.ToValidUTF8(message, "\uFFFD")
+	if len(message) <= maxStatusMessageBytes {
+		return message
+	}
+	const suffix = "..."
+	return truncateUTF8Prefix(message, maxStatusMessageBytes-len(suffix)) + suffix
+}
+
+func boundedStatusMessageTail(prefix, message string) string {
+	message = strings.ToValidUTF8(strings.TrimSpace(message), "\uFFFD")
+	if len(prefix)+len(message) <= maxStatusMessageBytes {
+		return prefix + message
+	}
+	const marker = "... "
+	available := maxStatusMessageBytes - len(prefix) - len(marker)
+	return prefix + marker + truncateUTF8Tail(message, available)
+}
+
+func truncateUTF8Prefix(value string, maxBytes int) string {
+	if len(value) <= maxBytes {
+		return value
+	}
+	end := maxBytes
+	for end > 0 && !utf8.RuneStart(value[end]) {
+		end--
+	}
+	return value[:end]
+}
+
+func truncateUTF8Tail(value string, maxBytes int) string {
+	if len(value) <= maxBytes {
+		return value
+	}
+	start := len(value) - maxBytes
+	for start < len(value) && !utf8.RuneStart(value[start]) {
+		start++
+	}
+	return value[start:]
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -332,6 +332,7 @@ func waitForWorkflow(t *testing.T, wf *v1alpha1.Workflow, timeout time.Duration)
 func TestFullRunLifecycle(t *testing.T) {
 	ensureRuntime(t, "bash", bashRuntimeImage(), 9091)
 
+	const stdout = "hello-not-in-run-status"
 	run := &v1alpha1.Run{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "e2e-",
@@ -339,7 +340,7 @@ func TestFullRunLifecycle(t *testing.T) {
 		},
 		Spec: v1alpha1.RunSpec{
 			Runtime: "bash",
-			Args:    []string{"echo hello"},
+			Args:    []string{"echo " + stdout},
 		},
 	}
 	if err := k8sClient.Create(context.Background(), run); err != nil {
@@ -347,6 +348,12 @@ func TestFullRunLifecycle(t *testing.T) {
 	}
 	t.Logf("Created Run %s (runtime=bash)", run.Name)
 	waitForRun(t, run, 30*time.Second)
+	if run.Status.Message != "execution completed" {
+		t.Fatalf("success message = %q, want stable summary", run.Status.Message)
+	}
+	if strings.Contains(run.Status.Message, stdout) {
+		t.Fatalf("success message contains stdout: %q", run.Status.Message)
+	}
 	t.Logf("Run completed successfully: %s", run.Status.Message)
 }
 
@@ -471,8 +478,8 @@ func TestRuntimedRecoversRunningRunAfterRestart(t *testing.T) {
 	waitForRuntimedRestart(t, run.Status.AssignedPod, beforeRestart)
 
 	waitForRun(t, run, 60*time.Second)
-	if !strings.Contains(run.Status.Message, "recovered") {
-		t.Fatalf("expected recovered stdout, got %q", run.Status.Message)
+	if run.Status.Message != "execution completed" {
+		t.Fatalf("success message = %q, want stable summary", run.Status.Message)
 	}
 }
 
@@ -894,11 +901,11 @@ func TestWorkflowStepOutputs(t *testing.T) {
 					Steps: []v1alpha1.StepSpec{
 						{
 							Name: "gen-version",
-							Run:  "echo version=v1.0 >> outputs",
+							Run:  `echo version=v1.0 >> "$KRUNTIME_OUTPUTS"`,
 						},
 						{
 							Name: "build-image",
-							Run:  "echo image=app:${{ steps.gen-version.outputs.version }} >> outputs",
+							Run:  `echo image=app:${{ steps.gen-version.outputs.version }} >> "$KRUNTIME_OUTPUTS"`,
 						},
 					},
 					Outputs: map[string]string{
@@ -927,6 +934,76 @@ func TestWorkflowStepOutputs(t *testing.T) {
 		t.Fatalf("build-image outputs mismatch: got %v", buildStep.Outputs)
 	}
 	t.Logf("All outputs verified")
+}
+
+func TestRunInvalidOutputsDoesNotRetry(t *testing.T) {
+	ensureRuntime(t, "bash", bashRuntimeImage(), 9091)
+
+	run := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "e2e-invalid-outputs-",
+			Namespace:    testNamespace,
+		},
+		Spec: v1alpha1.RunSpec{
+			Runtime: "bash",
+			Args:    []string{`printf 'invalid\n' > "$KRUNTIME_OUTPUTS"`},
+			RetryPolicy: &v1alpha1.RetryPolicy{
+				MaxAttempts: 3,
+				Backoff:     metav1.Duration{Duration: time.Second},
+			},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), run); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	waitForRunPhase(t, run, 30*time.Second, v1alpha1.RunFailed)
+	assertOutputsFailure(t, run, "OutputsInvalid")
+}
+
+func TestRunOversizedOutputsDoesNotRetry(t *testing.T) {
+	ensureRuntime(t, "bash", bashRuntimeImage(), 9091)
+
+	run := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "e2e-oversized-outputs-",
+			Namespace:    testNamespace,
+		},
+		Spec: v1alpha1.RunSpec{
+			Runtime: "bash",
+			Args: []string{
+				`printf 'value=' > "$KRUNTIME_OUTPUTS"; head -c 8193 /dev/zero | tr '\0' x >> "$KRUNTIME_OUTPUTS"`,
+			},
+			RetryPolicy: &v1alpha1.RetryPolicy{
+				MaxAttempts: 3,
+				Backoff:     metav1.Duration{Duration: time.Second},
+			},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), run); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	waitForRunPhase(t, run, 30*time.Second, v1alpha1.RunFailed)
+	assertOutputsFailure(t, run, "OutputsTooLarge")
+}
+
+func assertOutputsFailure(t *testing.T, run *v1alpha1.Run, reason string) {
+	t.Helper()
+	if run.Status.Attempt != 1 {
+		t.Fatalf("attempt = %d, want 1 for non-retryable outputs failure", run.Status.Attempt)
+	}
+	if run.Status.CompletionTime == nil {
+		t.Fatal("expected completion time")
+	}
+	running := findRunCondition(run, "Running")
+	if running == nil || running.Status != metav1.ConditionFalse || running.Reason != reason {
+		t.Fatalf("Running condition = %#v, want False/%s", running, reason)
+	}
+	completed := findRunCondition(run, "Completed")
+	if completed == nil || completed.Status != metav1.ConditionFalse || completed.Reason != reason {
+		t.Fatalf("Completed condition = %#v, want False/%s", completed, reason)
+	}
 }
 
 func TestRunRetry(t *testing.T) {
@@ -990,7 +1067,7 @@ func TestWorkflowTopoOrder(t *testing.T) {
 					RunsOn: "bash",
 					Steps: []v1alpha1.StepSpec{{
 						Name: "generate",
-						Run:  "echo version=v2.0 >> outputs",
+						Run:  `echo version=v2.0 >> "$KRUNTIME_OUTPUTS"`,
 					}},
 				},
 				// lint also has no needs, runs in parallel with prep.
@@ -998,7 +1075,7 @@ func TestWorkflowTopoOrder(t *testing.T) {
 					RunsOn: "bash",
 					Steps: []v1alpha1.StepSpec{{
 						Name: "check",
-						Run:  "echo lint=ok >> outputs",
+						Run:  `echo lint=ok >> "$KRUNTIME_OUTPUTS"`,
 					}},
 				},
 				// build needs prep explicitly, and references lint's output implicitly.


### PR DESCRIPTION
## Summary
- inject and validate bounded `KRUNTIME_OUTPUTS` results
- keep stdout/stderr out of Run status and emit structured logs with Run identity
- add unit and e2e coverage for invalid and oversized outputs

## Tests
- `GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false make test`
- `GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false make test-integration`