### PR TITLE
feat(runtime): release terminal execution state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Run CRD (Pending) → Scheduler → Run (Scheduled, assignedPod)
 
 - **Runtime CRD** (`api/v1alpha1/runtime_types.go`): defines a runtime type (image, port, replicas). The Runtime controller creates a Deployment with **two containers** — the runtime server + runtimed daemon — sharing an emptyDir `/workspace`. Pod label `runtime: <cr-name>` is used by the scheduler for pod selection.
 
-- **gRPC Runtime service** (`api/runtime/v1/runtime.proto`): `Execute / Status / List / Cancel`. The runtimed daemon calls this on `localhost:<port>` to delegate command execution. Import as `pb "github.com/kruntimes/kruntimes/api/runtime/v1"`.
+- **gRPC Runtime service** (`api/runtime/v1/runtime.proto`): `Execute / Status / List / Cancel / Forget`. The runtimed daemon calls this on `localhost:<port>` to delegate command execution. `Forget` releases terminal execution state after the Run status is persisted. Import as `pb "github.com/kruntimes/kruntimes/api/runtime/v1"`.
 
 ### Controllers
 

--- a/README.md
+++ b/README.md
@@ -289,10 +289,17 @@ Execute(RunSpec) -> ExecutionID
 Status(ExecutionID) -> ExecutionStatus
 List() -> repeated Execution
 Cancel(ExecutionID) -> CancelResult
+Forget(ExecutionID) -> ForgetResult
 Health() -> HealthStatus
 ```
 
 `List` is used by Runtimed to recover local execution state after restart. On startup, runtimed compares Runtime Server executions with Runs assigned to its Pod, rebuilds its in-memory active Run set, and resumes status polling. If a Running Run is no longer present in the Runtime Server, runtimed routes it through the normal retry or terminal failure path. `Cancel` is best-effort and should eventually result in `Cancelled`, `Failed`, or `Timeout`. `Health` is used for Kubernetes pod liveness probes and runtime health checks.
+
+After a terminal Run status is persisted, runtimed calls `Forget` to release the
+Runtime Server's retained execution state and output, then removes the Run's
+workspace. `Forget` is idempotent from runtimed's perspective: `NotFound` is
+treated as already released. Runtime Servers should reject forgetting an active
+execution.
 
 ### Data Plane vs Control Plane
 
@@ -562,6 +569,7 @@ service Runtime {
     rpc Status(StatusRequest) returns (StatusResponse);
     rpc List(ListRequest) returns (ListResponse);
     rpc Cancel(CancelRequest) returns (CancelResponse);
+    rpc Forget(ForgetRequest) returns (ForgetResponse);
     rpc Health(HealthRequest) returns (HealthResponse);
 }
 ```

--- a/api/runtime/v1/runtime.pb.go
+++ b/api/runtime/v1/runtime.pb.go
@@ -502,6 +502,86 @@ func (*CancelResponse) Descriptor() ([]byte, []int) {
 	return file_api_runtime_v1_runtime_proto_rawDescGZIP(), []int{7}
 }
 
+type ForgetRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ForgetRequest) Reset() {
+	*x = ForgetRequest{}
+	mi := &file_api_runtime_v1_runtime_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ForgetRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ForgetRequest) ProtoMessage() {}
+
+func (x *ForgetRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_runtime_v1_runtime_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ForgetRequest.ProtoReflect.Descriptor instead.
+func (*ForgetRequest) Descriptor() ([]byte, []int) {
+	return file_api_runtime_v1_runtime_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *ForgetRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+type ForgetResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ForgetResponse) Reset() {
+	*x = ForgetResponse{}
+	mi := &file_api_runtime_v1_runtime_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ForgetResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ForgetResponse) ProtoMessage() {}
+
+func (x *ForgetResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_runtime_v1_runtime_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ForgetResponse.ProtoReflect.Descriptor instead.
+func (*ForgetResponse) Descriptor() ([]byte, []int) {
+	return file_api_runtime_v1_runtime_proto_rawDescGZIP(), []int{9}
+}
+
 type HealthRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -510,7 +590,7 @@ type HealthRequest struct {
 
 func (x *HealthRequest) Reset() {
 	*x = HealthRequest{}
-	mi := &file_api_runtime_v1_runtime_proto_msgTypes[8]
+	mi := &file_api_runtime_v1_runtime_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -522,7 +602,7 @@ func (x *HealthRequest) String() string {
 func (*HealthRequest) ProtoMessage() {}
 
 func (x *HealthRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_runtime_v1_runtime_proto_msgTypes[8]
+	mi := &file_api_runtime_v1_runtime_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -535,7 +615,7 @@ func (x *HealthRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthRequest.ProtoReflect.Descriptor instead.
 func (*HealthRequest) Descriptor() ([]byte, []int) {
-	return file_api_runtime_v1_runtime_proto_rawDescGZIP(), []int{8}
+	return file_api_runtime_v1_runtime_proto_rawDescGZIP(), []int{10}
 }
 
 type HealthResponse struct {
@@ -548,7 +628,7 @@ type HealthResponse struct {
 
 func (x *HealthResponse) Reset() {
 	*x = HealthResponse{}
-	mi := &file_api_runtime_v1_runtime_proto_msgTypes[9]
+	mi := &file_api_runtime_v1_runtime_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -560,7 +640,7 @@ func (x *HealthResponse) String() string {
 func (*HealthResponse) ProtoMessage() {}
 
 func (x *HealthResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_runtime_v1_runtime_proto_msgTypes[9]
+	mi := &file_api_runtime_v1_runtime_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -573,7 +653,7 @@ func (x *HealthResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthResponse.ProtoReflect.Descriptor instead.
 func (*HealthResponse) Descriptor() ([]byte, []int) {
-	return file_api_runtime_v1_runtime_proto_rawDescGZIP(), []int{9}
+	return file_api_runtime_v1_runtime_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *HealthResponse) GetHealthy() bool {
@@ -625,7 +705,10 @@ const file_api_runtime_v1_runtime_proto_rawDesc = "" +
 	"\aentries\x18\x01 \x03(\v2\x1b.executor.v1.StatusResponseR\aentries\"\x1f\n" +
 	"\rCancelRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"\x10\n" +
-	"\x0eCancelResponse\"\x0f\n" +
+	"\x0eCancelResponse\"\x1f\n" +
+	"\rForgetRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"\x10\n" +
+	"\x0eForgetResponse\"\x0f\n" +
 	"\rHealthRequest\"D\n" +
 	"\x0eHealthResponse\x12\x18\n" +
 	"\ahealthy\x18\x01 \x01(\bR\ahealthy\x12\x18\n" +
@@ -635,12 +718,13 @@ const file_api_runtime_v1_runtime_proto_rawDesc = "" +
 	"\x17EXECUTION_STATE_PENDING\x10\x01\x12\x1b\n" +
 	"\x17EXECUTION_STATE_RUNNING\x10\x02\x12\x1d\n" +
 	"\x19EXECUTION_STATE_SUCCEEDED\x10\x03\x12\x1a\n" +
-	"\x16EXECUTION_STATE_FAILED\x10\x042\xd5\x02\n" +
+	"\x16EXECUTION_STATE_FAILED\x10\x042\x98\x03\n" +
 	"\aRuntime\x12D\n" +
 	"\aExecute\x12\x1b.executor.v1.ExecuteRequest\x1a\x1c.executor.v1.ExecuteResponse\x12A\n" +
 	"\x06Status\x12\x1a.executor.v1.StatusRequest\x1a\x1b.executor.v1.StatusResponse\x12;\n" +
 	"\x04List\x12\x18.executor.v1.ListRequest\x1a\x19.executor.v1.ListResponse\x12A\n" +
 	"\x06Cancel\x12\x1a.executor.v1.CancelRequest\x1a\x1b.executor.v1.CancelResponse\x12A\n" +
+	"\x06Forget\x12\x1a.executor.v1.ForgetRequest\x1a\x1b.executor.v1.ForgetResponse\x12A\n" +
 	"\x06Health\x12\x1a.executor.v1.HealthRequest\x1a\x1b.executor.v1.HealthResponseB9Z7github.com/kruntimes/kruntimes/api/runtime/v1;runtimev1b\x06proto3"
 
 var (
@@ -656,7 +740,7 @@ func file_api_runtime_v1_runtime_proto_rawDescGZIP() []byte {
 }
 
 var file_api_runtime_v1_runtime_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_api_runtime_v1_runtime_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_api_runtime_v1_runtime_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_api_runtime_v1_runtime_proto_goTypes = []any{
 	(ExecutionState)(0),     // 0: executor.v1.ExecutionState
 	(*ExecuteRequest)(nil),  // 1: executor.v1.ExecuteRequest
@@ -667,26 +751,30 @@ var file_api_runtime_v1_runtime_proto_goTypes = []any{
 	(*ListResponse)(nil),    // 6: executor.v1.ListResponse
 	(*CancelRequest)(nil),   // 7: executor.v1.CancelRequest
 	(*CancelResponse)(nil),  // 8: executor.v1.CancelResponse
-	(*HealthRequest)(nil),   // 9: executor.v1.HealthRequest
-	(*HealthResponse)(nil),  // 10: executor.v1.HealthResponse
-	nil,                     // 11: executor.v1.ExecuteRequest.EnvEntry
+	(*ForgetRequest)(nil),   // 9: executor.v1.ForgetRequest
+	(*ForgetResponse)(nil),  // 10: executor.v1.ForgetResponse
+	(*HealthRequest)(nil),   // 11: executor.v1.HealthRequest
+	(*HealthResponse)(nil),  // 12: executor.v1.HealthResponse
+	nil,                     // 13: executor.v1.ExecuteRequest.EnvEntry
 }
 var file_api_runtime_v1_runtime_proto_depIdxs = []int32{
-	11, // 0: executor.v1.ExecuteRequest.env:type_name -> executor.v1.ExecuteRequest.EnvEntry
+	13, // 0: executor.v1.ExecuteRequest.env:type_name -> executor.v1.ExecuteRequest.EnvEntry
 	0,  // 1: executor.v1.StatusResponse.state:type_name -> executor.v1.ExecutionState
 	4,  // 2: executor.v1.ListResponse.entries:type_name -> executor.v1.StatusResponse
 	1,  // 3: executor.v1.Runtime.Execute:input_type -> executor.v1.ExecuteRequest
 	3,  // 4: executor.v1.Runtime.Status:input_type -> executor.v1.StatusRequest
 	5,  // 5: executor.v1.Runtime.List:input_type -> executor.v1.ListRequest
 	7,  // 6: executor.v1.Runtime.Cancel:input_type -> executor.v1.CancelRequest
-	9,  // 7: executor.v1.Runtime.Health:input_type -> executor.v1.HealthRequest
-	2,  // 8: executor.v1.Runtime.Execute:output_type -> executor.v1.ExecuteResponse
-	4,  // 9: executor.v1.Runtime.Status:output_type -> executor.v1.StatusResponse
-	6,  // 10: executor.v1.Runtime.List:output_type -> executor.v1.ListResponse
-	8,  // 11: executor.v1.Runtime.Cancel:output_type -> executor.v1.CancelResponse
-	10, // 12: executor.v1.Runtime.Health:output_type -> executor.v1.HealthResponse
-	8,  // [8:13] is the sub-list for method output_type
-	3,  // [3:8] is the sub-list for method input_type
+	9,  // 7: executor.v1.Runtime.Forget:input_type -> executor.v1.ForgetRequest
+	11, // 8: executor.v1.Runtime.Health:input_type -> executor.v1.HealthRequest
+	2,  // 9: executor.v1.Runtime.Execute:output_type -> executor.v1.ExecuteResponse
+	4,  // 10: executor.v1.Runtime.Status:output_type -> executor.v1.StatusResponse
+	6,  // 11: executor.v1.Runtime.List:output_type -> executor.v1.ListResponse
+	8,  // 12: executor.v1.Runtime.Cancel:output_type -> executor.v1.CancelResponse
+	10, // 13: executor.v1.Runtime.Forget:output_type -> executor.v1.ForgetResponse
+	12, // 14: executor.v1.Runtime.Health:output_type -> executor.v1.HealthResponse
+	9,  // [9:15] is the sub-list for method output_type
+	3,  // [3:9] is the sub-list for method input_type
 	3,  // [3:3] is the sub-list for extension type_name
 	3,  // [3:3] is the sub-list for extension extendee
 	0,  // [0:3] is the sub-list for field type_name
@@ -703,7 +791,7 @@ func file_api_runtime_v1_runtime_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_runtime_v1_runtime_proto_rawDesc), len(file_api_runtime_v1_runtime_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   11,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/runtime/v1/runtime.proto
+++ b/api/runtime/v1/runtime.proto
@@ -11,6 +11,9 @@ service Runtime {
     rpc Status(StatusRequest) returns (StatusResponse);
     rpc List(ListRequest) returns (ListResponse);
     rpc Cancel(CancelRequest) returns (CancelResponse);
+    // Forget releases a terminal execution and its retained output.
+    // Running executions must be cancelled before they can be forgotten.
+    rpc Forget(ForgetRequest) returns (ForgetResponse);
     rpc Health(HealthRequest) returns (HealthResponse);
 }
 
@@ -63,6 +66,12 @@ message CancelRequest {
 }
 
 message CancelResponse {}
+
+message ForgetRequest {
+    string id = 1;
+}
+
+message ForgetResponse {}
 
 message HealthRequest {}
 

--- a/api/runtime/v1/runtime_grpc.pb.go
+++ b/api/runtime/v1/runtime_grpc.pb.go
@@ -23,6 +23,7 @@ const (
 	Runtime_Status_FullMethodName  = "/executor.v1.Runtime/Status"
 	Runtime_List_FullMethodName    = "/executor.v1.Runtime/List"
 	Runtime_Cancel_FullMethodName  = "/executor.v1.Runtime/Cancel"
+	Runtime_Forget_FullMethodName  = "/executor.v1.Runtime/Forget"
 	Runtime_Health_FullMethodName  = "/executor.v1.Runtime/Health"
 )
 
@@ -37,6 +38,9 @@ type RuntimeClient interface {
 	Status(ctx context.Context, in *StatusRequest, opts ...grpc.CallOption) (*StatusResponse, error)
 	List(ctx context.Context, in *ListRequest, opts ...grpc.CallOption) (*ListResponse, error)
 	Cancel(ctx context.Context, in *CancelRequest, opts ...grpc.CallOption) (*CancelResponse, error)
+	// Forget releases a terminal execution and its retained output.
+	// Running executions must be cancelled before they can be forgotten.
+	Forget(ctx context.Context, in *ForgetRequest, opts ...grpc.CallOption) (*ForgetResponse, error)
 	Health(ctx context.Context, in *HealthRequest, opts ...grpc.CallOption) (*HealthResponse, error)
 }
 
@@ -88,6 +92,16 @@ func (c *runtimeClient) Cancel(ctx context.Context, in *CancelRequest, opts ...g
 	return out, nil
 }
 
+func (c *runtimeClient) Forget(ctx context.Context, in *ForgetRequest, opts ...grpc.CallOption) (*ForgetResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ForgetResponse)
+	err := c.cc.Invoke(ctx, Runtime_Forget_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *runtimeClient) Health(ctx context.Context, in *HealthRequest, opts ...grpc.CallOption) (*HealthResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(HealthResponse)
@@ -109,6 +123,9 @@ type RuntimeServer interface {
 	Status(context.Context, *StatusRequest) (*StatusResponse, error)
 	List(context.Context, *ListRequest) (*ListResponse, error)
 	Cancel(context.Context, *CancelRequest) (*CancelResponse, error)
+	// Forget releases a terminal execution and its retained output.
+	// Running executions must be cancelled before they can be forgotten.
+	Forget(context.Context, *ForgetRequest) (*ForgetResponse, error)
 	Health(context.Context, *HealthRequest) (*HealthResponse, error)
 	mustEmbedUnimplementedRuntimeServer()
 }
@@ -131,6 +148,9 @@ func (UnimplementedRuntimeServer) List(context.Context, *ListRequest) (*ListResp
 }
 func (UnimplementedRuntimeServer) Cancel(context.Context, *CancelRequest) (*CancelResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Cancel not implemented")
+}
+func (UnimplementedRuntimeServer) Forget(context.Context, *ForgetRequest) (*ForgetResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method Forget not implemented")
 }
 func (UnimplementedRuntimeServer) Health(context.Context, *HealthRequest) (*HealthResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Health not implemented")
@@ -228,6 +248,24 @@ func _Runtime_Cancel_Handler(srv interface{}, ctx context.Context, dec func(inte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Runtime_Forget_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ForgetRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RuntimeServer).Forget(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Runtime_Forget_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RuntimeServer).Forget(ctx, req.(*ForgetRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _Runtime_Health_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(HealthRequest)
 	if err := dec(in); err != nil {
@@ -268,6 +306,10 @@ var Runtime_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Cancel",
 			Handler:    _Runtime_Cancel_Handler,
+		},
+		{
+			MethodName: "Forget",
+			Handler:    _Runtime_Forget_Handler,
 		},
 		{
 			MethodName: "Health",

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -50,8 +50,8 @@
 
 - [ ] 为每个 execution 建立完整的并发保护和不可变状态快照。
 - [ ] 为 stdout/stderr 设置有界缓冲，禁止无限内存增长。
-- [ ] 为 Runtime API 增加 execution `Forget`/`Delete` 生命周期，或实现等价清理机制。
-- [ ] Run 完成后清理 `/workspace/<runUID>`，同时保留制品上传所需顺序。
+- [x] 为 Runtime API 增加 execution `Forget` 生命周期。
+- [x] Run 完成后清理 `/workspace/<runUID>`，同时保留制品上传所需顺序。
 - [ ] 对 Bash/Python 的取消和超时终止整个进程组，并等待退出。
 - [ ] 修复 Python Runtime 中共享 task 状态的并发访问。
 - [ ] 明确 Python handler 模式的隔离方案；在未隔离前标记为 trusted-code only。

--- a/internal/runtimed/controller.go
+++ b/internal/runtimed/controller.go
@@ -15,7 +15,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,7 +42,11 @@ import (
 
 var workspacePath = "/workspace" //nolint:gochecknoglobals
 
-const defaultHeartbeatInterval = 5 * time.Second
+const (
+	defaultHeartbeatInterval = 5 * time.Second
+	executionCleanupTimeout  = 5 * time.Second
+	executionCleanupRetry    = 100 * time.Millisecond
+)
 
 var (
 	runsCompleted = promauto.NewCounterVec(
@@ -595,16 +601,41 @@ func (c *Controller) applyTerminalWithOutput(
 }
 
 // ===========================================================================
-// cleanup — in-memory bookkeeping after a successful status update
+// cleanup — release runtime and workspace state after a successful status update
 // ===========================================================================
 
-func (c *Controller) cleanup(_ context.Context, ar *activeRun, phase v1alpha1.RunPhase) {
+func (c *Controller) cleanup(ctx context.Context, ar *activeRun, phase v1alpha1.RunPhase) {
 	if c.rleg != nil {
 		c.rleg.RemoveRun(string(ar.run.UID))
 	}
 	c.activeRuns.Delete(string(ar.run.UID))
+	c.releaseExecution(ctx, string(ar.run.UID))
+	if err := os.RemoveAll(workspaceForRun(ar.run)); err != nil {
+		c.Log.Error(err, "failed to remove Run workspace", "run", client.ObjectKeyFromObject(ar.run))
+	}
 	runDuration.WithLabelValues(ar.run.Spec.Runtime).Observe(time.Since(ar.start).Seconds())
 	runsCompleted.WithLabelValues(ar.run.Spec.Runtime, string(phase)).Inc()
+}
+
+func (c *Controller) releaseExecution(ctx context.Context, uid string) {
+	if c.runtimeCli == nil || uid == "" {
+		return
+	}
+	cleanupCtx, cancel := context.WithTimeout(ctx, executionCleanupTimeout)
+	defer cancel()
+
+	for {
+		_, err := c.runtimeCli.Forget(cleanupCtx, &pb.ForgetRequest{Id: uid})
+		if err == nil || status.Code(err) == codes.NotFound || status.Code(err) == codes.Unimplemented {
+			return
+		}
+		select {
+		case <-cleanupCtx.Done():
+			c.Log.Error(err, "failed to forget terminal runtime execution", "runUID", uid)
+			return
+		case <-time.After(executionCleanupRetry):
+		}
+	}
 }
 
 // ===========================================================================
@@ -854,6 +885,10 @@ func workDirForRun(run *v1alpha1.Run) string {
 		return filepath.Join(runDir, "repo")
 	}
 	return runDir
+}
+
+func workspaceForRun(run *v1alpha1.Run) string {
+	return filepath.Join(workspacePath, string(run.UID))
 }
 
 func podNamespace() string {

--- a/internal/runtimed/controller_test.go
+++ b/internal/runtimed/controller_test.go
@@ -733,12 +733,46 @@ func TestStartExecutionInjectsReservedArtifactDirectory(t *testing.T) {
 	}
 }
 
+func TestCleanupForgetsExecutionAndRemovesWorkspace(t *testing.T) {
+	setTestWorkspace(t)
+	run := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "cleanup", Namespace: "default", UID: "cleanup-uid"},
+		Spec:       v1alpha1.RunSpec{Runtime: "bash"},
+	}
+	runWorkspace := workspaceForRun(run)
+	if err := os.MkdirAll(runWorkspace, 0o755); err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runWorkspace, "retained"), []byte("data"), 0o600); err != nil {
+		t.Fatalf("write workspace file: %v", err)
+	}
+
+	runtimeClient := &fakeRuntimeClient{}
+	c := &Controller{runtimeCli: runtimeClient}
+	ar := &activeRun{run: run, workDir: runWorkspace, start: time.Now()}
+	c.activeRuns.Store(string(run.UID), ar)
+
+	c.cleanup(t.Context(), ar, v1alpha1.RunSucceeded)
+
+	if len(runtimeClient.forgetRequests) != 1 || runtimeClient.forgetRequests[0].Id != string(run.UID) {
+		t.Fatalf("Forget requests = %#v, want cleanup-uid", runtimeClient.forgetRequests)
+	}
+	if _, err := os.Stat(runWorkspace); !os.IsNotExist(err) {
+		t.Fatalf("workspace still exists or stat failed unexpectedly: %v", err)
+	}
+	if c.activeRunCount() != 0 {
+		t.Fatalf("active runs = %d, want 0", c.activeRunCount())
+	}
+}
+
 type fakeRuntimeClient struct {
 	pb.RuntimeClient
 	status         *pb.StatusResponse
 	statusErr      error
 	list           *pb.ListResponse
 	listErr        error
+	forgetErr      error
+	forgetRequests []*pb.ForgetRequest
 	executeOptions int
 	executeRequest *pb.ExecuteRequest
 }
@@ -768,6 +802,14 @@ func (f *fakeRuntimeClient) List(context.Context, *pb.ListRequest, ...grpc.CallO
 
 func (f *fakeRuntimeClient) Cancel(context.Context, *pb.CancelRequest, ...grpc.CallOption) (*pb.CancelResponse, error) {
 	return &pb.CancelResponse{}, nil
+}
+
+func (f *fakeRuntimeClient) Forget(_ context.Context, req *pb.ForgetRequest, _ ...grpc.CallOption) (*pb.ForgetResponse, error) {
+	f.forgetRequests = append(f.forgetRequests, req)
+	if f.forgetErr != nil {
+		return nil, f.forgetErr
+	}
+	return &pb.ForgetResponse{}, nil
 }
 
 func (f *fakeRuntimeClient) Health(context.Context, *pb.HealthRequest, ...grpc.CallOption) (*pb.HealthResponse, error) {

--- a/runtimes/bash/server.go
+++ b/runtimes/bash/server.go
@@ -209,6 +209,28 @@ func (s *Server) Cancel(ctx context.Context, req *pb.CancelRequest) (*pb.CancelR
 	return &pb.CancelResponse{}, nil
 }
 
+func (s *Server) Forget(_ context.Context, req *pb.ForgetRequest) (*pb.ForgetResponse, error) {
+	s.operationMu.Lock()
+	defer s.operationMu.Unlock()
+
+	entry := s.execution(req.Id)
+	if entry == nil {
+		return nil, status.Errorf(codes.NotFound, "request %s not found", req.Id)
+	}
+	select {
+	case <-entry.done:
+	default:
+		return nil, status.Errorf(codes.FailedPrecondition, "request %s is still running", req.Id)
+	}
+
+	s.mu.Lock()
+	if s.executions[req.Id] == entry {
+		delete(s.executions, req.Id)
+	}
+	s.mu.Unlock()
+	return &pb.ForgetResponse{}, nil
+}
+
 func (s *Server) Health(context.Context, *pb.HealthRequest) (*pb.HealthResponse, error) {
 	return &pb.HealthResponse{Healthy: true}, nil
 }

--- a/runtimes/bash/server_test.go
+++ b/runtimes/bash/server_test.go
@@ -14,7 +14,9 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 
 	pb "github.com/kruntimes/kruntimes/api/runtime/v1"
 )
@@ -158,6 +160,46 @@ func TestGetTask_NotFound(t *testing.T) {
 	_, err := client.Status(ctx, &pb.StatusRequest{Id: "nonexistent"})
 	if err == nil {
 		t.Error("expected error for nonexistent request")
+	}
+}
+
+func TestForgetTerminalExecution(t *testing.T) {
+	client, cleanup := startTestServer(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	if _, err := client.Execute(ctx, &pb.ExecuteRequest{
+		Id:   "forget-terminal",
+		Args: []string{"echo done"},
+	}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	waitForTerminalStatus(t, client, "forget-terminal")
+
+	if _, err := client.Forget(ctx, &pb.ForgetRequest{Id: "forget-terminal"}); err != nil {
+		t.Fatalf("Forget: %v", err)
+	}
+	if _, err := client.Status(ctx, &pb.StatusRequest{Id: "forget-terminal"}); status.Code(err) != codes.NotFound {
+		t.Fatalf("Status error = %v, want NotFound", err)
+	}
+}
+
+func TestForgetRejectsRunningExecution(t *testing.T) {
+	client, cleanup := startTestServer(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	if _, err := client.Execute(ctx, &pb.ExecuteRequest{
+		Id:   "forget-running",
+		Args: []string{"sleep 30"},
+	}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if _, err := client.Forget(ctx, &pb.ForgetRequest{Id: "forget-running"}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("Forget error = %v, want FailedPrecondition", err)
+	}
+	if _, err := client.Cancel(ctx, &pb.CancelRequest{Id: "forget-running"}); err != nil {
+		t.Fatalf("Cancel: %v", err)
 	}
 }
 

--- a/runtimes/python/pb/runtime_pb2.py
+++ b/runtimes/python/pb/runtime_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rruntime.proto\x12\x0b\x65xecutor.v1\"\xdc\x01\n\x0e\x45xecuteRequest\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\x12\x31\n\x03\x65nv\x18\x03 \x03(\x0b\x32$.executor.v1.ExecuteRequest.EnvEntry\x12\x17\n\x0ftimeout_seconds\x18\x04 \x01(\x03\x12\x13\n\x0bworking_dir\x18\x05 \x01(\t\x12\x12\n\nentrypoint\x18\x06 \x01(\t\x12\x0f\n\x07handler\x18\x07 \x01(\t\x1a*\n\x08\x45nvEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x1d\n\x0f\x45xecuteResponse\x12\n\n\x02id\x18\x01 \x01(\t\"\x1b\n\rStatusRequest\x12\n\n\x02id\x18\x01 \x01(\t\"\x92\x01\n\x0eStatusResponse\x12\n\n\x02id\x18\x01 \x01(\t\x12*\n\x05state\x18\x02 \x01(\x0e\x32\x1b.executor.v1.ExecutionState\x12\x11\n\texit_code\x18\x03 \x01(\x05\x12\x0e\n\x06stdout\x18\x04 \x01(\t\x12\x0e\n\x06stderr\x18\x05 \x01(\t\x12\x15\n\rerror_message\x18\x06 \x01(\t\"\r\n\x0bListRequest\"<\n\x0cListResponse\x12,\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x1b.executor.v1.StatusResponse\"\x1b\n\rCancelRequest\x12\n\n\x02id\x18\x01 \x01(\t\"\x10\n\x0e\x43\x61ncelResponse\"\x0f\n\rHealthRequest\"2\n\x0eHealthResponse\x12\x0f\n\x07healthy\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t*\xa6\x01\n\x0e\x45xecutionState\x12\x1f\n\x1b\x45XECUTION_STATE_UNSPECIFIED\x10\x00\x12\x1b\n\x17\x45XECUTION_STATE_PENDING\x10\x01\x12\x1b\n\x17\x45XECUTION_STATE_RUNNING\x10\x02\x12\x1d\n\x19\x45XECUTION_STATE_SUCCEEDED\x10\x03\x12\x1a\n\x16\x45XECUTION_STATE_FAILED\x10\x04\x32\xd5\x02\n\x07Runtime\x12\x44\n\x07\x45xecute\x12\x1b.executor.v1.ExecuteRequest\x1a\x1c.executor.v1.ExecuteResponse\x12\x41\n\x06Status\x12\x1a.executor.v1.StatusRequest\x1a\x1b.executor.v1.StatusResponse\x12;\n\x04List\x12\x18.executor.v1.ListRequest\x1a\x19.executor.v1.ListResponse\x12\x41\n\x06\x43\x61ncel\x12\x1a.executor.v1.CancelRequest\x1a\x1b.executor.v1.CancelResponse\x12\x41\n\x06Health\x12\x1a.executor.v1.HealthRequest\x1a\x1b.executor.v1.HealthResponseB9Z7github.com/kruntimes/kruntimes/api/runtime/v1;runtimev1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rruntime.proto\x12\x0b\x65xecutor.v1\"\xdc\x01\n\x0e\x45xecuteRequest\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04\x61rgs\x18\x02 \x03(\t\x12\x31\n\x03\x65nv\x18\x03 \x03(\x0b\x32$.executor.v1.ExecuteRequest.EnvEntry\x12\x17\n\x0ftimeout_seconds\x18\x04 \x01(\x03\x12\x13\n\x0bworking_dir\x18\x05 \x01(\t\x12\x12\n\nentrypoint\x18\x06 \x01(\t\x12\x0f\n\x07handler\x18\x07 \x01(\t\x1a*\n\x08\x45nvEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x1d\n\x0f\x45xecuteResponse\x12\n\n\x02id\x18\x01 \x01(\t\"\x1b\n\rStatusRequest\x12\n\n\x02id\x18\x01 \x01(\t\"\x92\x01\n\x0eStatusResponse\x12\n\n\x02id\x18\x01 \x01(\t\x12*\n\x05state\x18\x02 \x01(\x0e\x32\x1b.executor.v1.ExecutionState\x12\x11\n\texit_code\x18\x03 \x01(\x05\x12\x0e\n\x06stdout\x18\x04 \x01(\t\x12\x0e\n\x06stderr\x18\x05 \x01(\t\x12\x15\n\rerror_message\x18\x06 \x01(\t\"\r\n\x0bListRequest\"<\n\x0cListResponse\x12,\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x1b.executor.v1.StatusResponse\"\x1b\n\rCancelRequest\x12\n\n\x02id\x18\x01 \x01(\t\"\x10\n\x0e\x43\x61ncelResponse\"\x1b\n\rForgetRequest\x12\n\n\x02id\x18\x01 \x01(\t\"\x10\n\x0e\x46orgetResponse\"\x0f\n\rHealthRequest\"2\n\x0eHealthResponse\x12\x0f\n\x07healthy\x18\x01 \x01(\x08\x12\x0f\n\x07message\x18\x02 \x01(\t*\xa6\x01\n\x0e\x45xecutionState\x12\x1f\n\x1b\x45XECUTION_STATE_UNSPECIFIED\x10\x00\x12\x1b\n\x17\x45XECUTION_STATE_PENDING\x10\x01\x12\x1b\n\x17\x45XECUTION_STATE_RUNNING\x10\x02\x12\x1d\n\x19\x45XECUTION_STATE_SUCCEEDED\x10\x03\x12\x1a\n\x16\x45XECUTION_STATE_FAILED\x10\x04\x32\x98\x03\n\x07Runtime\x12\x44\n\x07\x45xecute\x12\x1b.executor.v1.ExecuteRequest\x1a\x1c.executor.v1.ExecuteResponse\x12\x41\n\x06Status\x12\x1a.executor.v1.StatusRequest\x1a\x1b.executor.v1.StatusResponse\x12;\n\x04List\x12\x18.executor.v1.ListRequest\x1a\x19.executor.v1.ListResponse\x12\x41\n\x06\x43\x61ncel\x12\x1a.executor.v1.CancelRequest\x1a\x1b.executor.v1.CancelResponse\x12\x41\n\x06\x46orget\x12\x1a.executor.v1.ForgetRequest\x1a\x1b.executor.v1.ForgetResponse\x12\x41\n\x06Health\x12\x1a.executor.v1.HealthRequest\x1a\x1b.executor.v1.HealthResponseB9Z7github.com/kruntimes/kruntimes/api/runtime/v1;runtimev1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -34,8 +34,8 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._serialized_options = b'Z7github.com/kruntimes/kruntimes/api/runtime/v1;runtimev1'
   _globals['_EXECUTEREQUEST_ENVENTRY']._loaded_options = None
   _globals['_EXECUTEREQUEST_ENVENTRY']._serialized_options = b'8\001'
-  _globals['_EXECUTIONSTATE']._serialized_start=656
-  _globals['_EXECUTIONSTATE']._serialized_end=822
+  _globals['_EXECUTIONSTATE']._serialized_start=703
+  _globals['_EXECUTIONSTATE']._serialized_end=869
   _globals['_EXECUTEREQUEST']._serialized_start=31
   _globals['_EXECUTEREQUEST']._serialized_end=251
   _globals['_EXECUTEREQUEST_ENVENTRY']._serialized_start=209
@@ -54,10 +54,14 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_CANCELREQUEST']._serialized_end=566
   _globals['_CANCELRESPONSE']._serialized_start=568
   _globals['_CANCELRESPONSE']._serialized_end=584
-  _globals['_HEALTHREQUEST']._serialized_start=586
-  _globals['_HEALTHREQUEST']._serialized_end=601
-  _globals['_HEALTHRESPONSE']._serialized_start=603
-  _globals['_HEALTHRESPONSE']._serialized_end=653
-  _globals['_RUNTIME']._serialized_start=825
-  _globals['_RUNTIME']._serialized_end=1166
+  _globals['_FORGETREQUEST']._serialized_start=586
+  _globals['_FORGETREQUEST']._serialized_end=613
+  _globals['_FORGETRESPONSE']._serialized_start=615
+  _globals['_FORGETRESPONSE']._serialized_end=631
+  _globals['_HEALTHREQUEST']._serialized_start=633
+  _globals['_HEALTHREQUEST']._serialized_end=648
+  _globals['_HEALTHRESPONSE']._serialized_start=650
+  _globals['_HEALTHRESPONSE']._serialized_end=700
+  _globals['_RUNTIME']._serialized_start=872
+  _globals['_RUNTIME']._serialized_end=1280
 # @@protoc_insertion_point(module_scope)

--- a/runtimes/python/pb/runtime_pb2_grpc.py
+++ b/runtimes/python/pb/runtime_pb2_grpc.py
@@ -56,6 +56,11 @@ class RuntimeStub(object):
                 request_serializer=runtime__pb2.CancelRequest.SerializeToString,
                 response_deserializer=runtime__pb2.CancelResponse.FromString,
                 _registered_method=True)
+        self.Forget = channel.unary_unary(
+                '/executor.v1.Runtime/Forget',
+                request_serializer=runtime__pb2.ForgetRequest.SerializeToString,
+                response_deserializer=runtime__pb2.ForgetResponse.FromString,
+                _registered_method=True)
         self.Health = channel.unary_unary(
                 '/executor.v1.Runtime/Health',
                 request_serializer=runtime__pb2.HealthRequest.SerializeToString,
@@ -92,6 +97,14 @@ class RuntimeServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def Forget(self, request, context):
+        """Forget releases a terminal execution and its retained output.
+        Running executions must be cancelled before they can be forgotten.
+        """
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
     def Health(self, request, context):
         """Missing associated documentation comment in .proto file."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
@@ -120,6 +133,11 @@ def add_RuntimeServicer_to_server(servicer, server):
                     servicer.Cancel,
                     request_deserializer=runtime__pb2.CancelRequest.FromString,
                     response_serializer=runtime__pb2.CancelResponse.SerializeToString,
+            ),
+            'Forget': grpc.unary_unary_rpc_method_handler(
+                    servicer.Forget,
+                    request_deserializer=runtime__pb2.ForgetRequest.FromString,
+                    response_serializer=runtime__pb2.ForgetResponse.SerializeToString,
             ),
             'Health': grpc.unary_unary_rpc_method_handler(
                     servicer.Health,
@@ -237,6 +255,33 @@ class Runtime(object):
             '/executor.v1.Runtime/Cancel',
             runtime__pb2.CancelRequest.SerializeToString,
             runtime__pb2.CancelResponse.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def Forget(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/executor.v1.Runtime/Forget',
+            runtime__pb2.ForgetRequest.SerializeToString,
+            runtime__pb2.ForgetResponse.FromString,
             options,
             channel_credentials,
             insecure,

--- a/runtimes/python/server.py
+++ b/runtimes/python/server.py
@@ -1,5 +1,6 @@
 import json
 import os
+import signal
 import subprocess
 import sys
 import threading
@@ -30,14 +31,15 @@ class PythonRuntime(runtime_pb2_grpc.RuntimeServicer):
                 "stderr": "",
                 "exit_code": 0,
                 "error_message": "",
+                "_cancelled": False,
+                "_done": threading.Event(),
             }
 
         task_dir = Path(request.working_dir) if request.working_dir else (self.base_dir / task_id)
         task_dir.mkdir(parents=True, exist_ok=True)
 
-        state = self._tasks[task_id]
         threading.Thread(
-            target=self._execute, args=(task_id, task_dir, request, state),
+            target=self._execute, args=(task_id, task_dir, request),
             daemon=True,
         ).start()
 
@@ -46,12 +48,71 @@ class PythonRuntime(runtime_pb2_grpc.RuntimeServicer):
     def Status(self, request, context):
         with self._lock:
             task = self._tasks.get(request.id)
-        if task is None:
-            context.set_code(grpc.StatusCode.NOT_FOUND)
-            context.set_details(f"task {request.id} not found")
-            return runtime_pb2.StatusResponse()
+            if task is None:
+                context.abort(
+                    grpc.StatusCode.NOT_FOUND,
+                    f"execution {request.id} not found",
+                )
+            return self._status_response(request.id, task)
+
+    def List(self, request, context):
+        with self._lock:
+            entries = []
+            for task_id, task in self._tasks.items():
+                entries.append(self._status_response(task_id, task))
+        return runtime_pb2.ListResponse(entries=entries)
+
+    def Cancel(self, request, context):
+        with self._lock:
+            task = self._tasks.get(request.id)
+            if task is None:
+                context.abort(
+                    grpc.StatusCode.NOT_FOUND,
+                    f"execution {request.id} not found",
+                )
+            task["_cancelled"] = True
+            proc = task.get("_proc")
+            done = task["_done"]
+            if proc is not None and proc.poll() is None:
+                self._signal_process_group(proc, signal.SIGTERM)
+
+        if not done.wait(timeout=2):
+            with self._lock:
+                proc = task.get("_proc")
+                if proc is not None and proc.poll() is None:
+                    self._signal_process_group(proc, signal.SIGKILL)
+            done.wait()
+
+        with self._lock:
+            self._tasks.pop(request.id, None)
+        return runtime_pb2.CancelResponse()
+
+    def Forget(self, request, context):
+        with self._lock:
+            task = self._tasks.get(request.id)
+            if task is None:
+                context.abort(
+                    grpc.StatusCode.NOT_FOUND,
+                    f"execution {request.id} not found",
+                )
+            if task["state"] not in (
+                runtime_pb2.EXECUTION_STATE_SUCCEEDED,
+                runtime_pb2.EXECUTION_STATE_FAILED,
+            ):
+                context.abort(
+                    grpc.StatusCode.FAILED_PRECONDITION,
+                    f"execution {request.id} is still running",
+                )
+            self._tasks.pop(request.id)
+        return runtime_pb2.ForgetResponse()
+
+    def Health(self, request, context):
+        return runtime_pb2.HealthResponse(healthy=True)
+
+    @staticmethod
+    def _status_response(task_id, task):
         return runtime_pb2.StatusResponse(
-            id=request.id,
+            id=task_id,
             state=task["state"],
             exit_code=task["exit_code"],
             stdout=task["stdout"],
@@ -59,65 +120,59 @@ class PythonRuntime(runtime_pb2_grpc.RuntimeServicer):
             error_message=task["error_message"],
         )
 
-    def List(self, request, context):
+    def _update_task(self, task_id, **updates):
         with self._lock:
-            entries = []
-            for task_id, task in self._tasks.items():
-                entries.append(runtime_pb2.StatusResponse(
-                    id=task_id,
-                    state=task["state"],
-                    exit_code=task["exit_code"],
-                    stdout=task["stdout"],
-                    stderr=task["stderr"],
-                    error_message=task["error_message"],
-                ))
-        return runtime_pb2.ListResponse(entries=entries)
+            task = self._tasks.get(task_id)
+            if task is not None:
+                task.update(updates)
 
-    def Cancel(self, request, context):
-        with self._lock:
-            task = self._tasks.get(request.id)
-        if task is None:
-            context.set_code(grpc.StatusCode.NOT_FOUND)
-            context.set_details(f"task {request.id} not found")
-            return runtime_pb2.CancelResponse()
+    @staticmethod
+    def _signal_process_group(proc, sig):
+        try:
+            os.killpg(proc.pid, sig)
+        except ProcessLookupError:
+            pass
 
-        proc = task.get("_proc")
-        if proc:
-            proc.terminate()
-        with self._lock:
-            self._tasks.pop(request.id, None)
-        return runtime_pb2.CancelResponse()
-
-    def Health(self, request, context):
-        return runtime_pb2.HealthResponse(healthy=True)
-
-    def _execute(self, task_id, task_dir, request, state):
+    def _execute(self, task_id, task_dir, request):
         try:
             if request.handler:
-                self._run_handler(task_id, task_dir, request, state)
+                self._run_handler(task_id, task_dir, request)
             else:
-                self._run_entrypoint(task_id, task_dir, request, state)
+                self._run_entrypoint(task_id, task_dir, request)
         except Exception as e:
-            state["state"] = runtime_pb2.EXECUTION_STATE_FAILED
-            state["error_message"] = str(e)
-
-    def _run_handler(self, task_id, task_dir, request, state):
-        sys.path.insert(0, str(task_dir))
-        try:
-            module_name, func_name = request.handler.rsplit(".", 1)
-            import importlib
-            mod = importlib.import_module(module_name)
-            func = getattr(mod, func_name)
-
-            event = {"args": list(request.args)}
-            result = func(event)
-            if result is not None:
-                state["stdout"] = json.dumps(result)
-            state["state"] = runtime_pb2.EXECUTION_STATE_SUCCEEDED
+            self._update_task(
+                task_id,
+                state=runtime_pb2.EXECUTION_STATE_FAILED,
+                error_message=str(e),
+            )
         finally:
-            sys.path.pop(0)
+            with self._lock:
+                task = self._tasks.get(task_id)
+                if task is not None:
+                    task["_done"].set()
 
-    def _run_entrypoint(self, task_id, task_dir, request, state):
+    def _run_handler(self, task_id, task_dir, request):
+        handler_script = """
+import importlib
+import json
+import sys
+
+module_name, func_name = sys.argv[1].rsplit(".", 1)
+event = json.loads(sys.argv[2])
+result = getattr(importlib.import_module(module_name), func_name)(event)
+if result is not None:
+    print(json.dumps(result))
+"""
+        cmd = [
+            sys.executable,
+            "-c",
+            handler_script,
+            request.handler,
+            json.dumps({"args": list(request.args)}),
+        ]
+        self._run_process(task_id, task_dir, request, cmd)
+
+    def _run_entrypoint(self, task_id, task_dir, request):
         entrypoint = request.entrypoint or "script"
         script = task_dir / entrypoint
         if script.exists():
@@ -125,34 +180,50 @@ class PythonRuntime(runtime_pb2_grpc.RuntimeServicer):
         elif request.args:
             cmd = [sys.executable] + list(request.args)
         else:
-            state["state"] = runtime_pb2.EXECUTION_STATE_FAILED
-            state["error_message"] = "no script or args provided"
+            self._update_task(
+                task_id,
+                state=runtime_pb2.EXECUTION_STATE_FAILED,
+                error_message="no script or args provided",
+            )
             return
 
+        self._run_process(task_id, task_dir, request, cmd)
+
+    def _run_process(self, task_id, task_dir, request, cmd):
         env = os.environ.copy()
         env.update(request.env)
         timeout = request.timeout_seconds or None
-
         try:
-            proc = subprocess.Popen(
-                cmd, cwd=str(task_dir), env=env,
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                text=True,
-            )
-            state["_proc"] = proc
+            with self._lock:
+                task = self._tasks.get(task_id)
+                if task is None or task["_cancelled"]:
+                    return
+                proc = subprocess.Popen(
+                    cmd, cwd=str(task_dir), env=env,
+                    stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                    text=True,
+                    start_new_session=True,
+                )
+                task["_proc"] = proc
             stdout, stderr = proc.communicate(timeout=timeout)
-            state["stdout"] = stdout
-            state["stderr"] = stderr
-            state["exit_code"] = proc.returncode
-            state["state"] = (
-                runtime_pb2.EXECUTION_STATE_SUCCEEDED
-                if proc.returncode == 0
-                else runtime_pb2.EXECUTION_STATE_FAILED
+            self._update_task(
+                task_id,
+                stdout=stdout,
+                stderr=stderr,
+                exit_code=proc.returncode,
+                state=(
+                    runtime_pb2.EXECUTION_STATE_SUCCEEDED
+                    if proc.returncode == 0
+                    else runtime_pb2.EXECUTION_STATE_FAILED
+                ),
             )
         except subprocess.TimeoutExpired:
-            proc.kill()
+            self._signal_process_group(proc, signal.SIGKILL)
             stdout, stderr = proc.communicate()
-            state["stdout"] = stdout or ""
-            state["stderr"] = stderr or ""
-            state["state"] = runtime_pb2.EXECUTION_STATE_FAILED
-            state["error_message"] = "timeout"
+            self._update_task(
+                task_id,
+                stdout=stdout or "",
+                stderr=stderr or "",
+                state=runtime_pb2.EXECUTION_STATE_FAILED,
+                error_message="timeout",
+            )

--- a/runtimes/python/server_test.py
+++ b/runtimes/python/server_test.py
@@ -89,6 +89,27 @@ def handler(event):
         lst = self.stub.List(runtime_pb2.ListRequest())
         self.assertGreaterEqual(len(lst.entries), 1)
         self.stub.Cancel(runtime_pb2.CancelRequest(id="test4"))
+        with self.assertRaises(grpc.RpcError) as ctx:
+            self.stub.Status(runtime_pb2.StatusRequest(id="test4"))
+        self.assertEqual(ctx.exception.code(), grpc.StatusCode.NOT_FOUND)
+
+    def test_cancel_terminates_handler(self):
+        wd = self._prepare_inline("""
+import time
+
+def handler(event):
+    time.sleep(30)
+    return {"status": "late"}
+""", filename="app.py")
+        self.stub.Execute(runtime_pb2.ExecuteRequest(
+            id="cancel-handler",
+            working_dir=wd,
+            handler="app.handler",
+        ))
+        self.stub.Cancel(runtime_pb2.CancelRequest(id="cancel-handler"))
+        with self.assertRaises(grpc.RpcError) as ctx:
+            self.stub.Status(runtime_pb2.StatusRequest(id="cancel-handler"))
+        self.assertEqual(ctx.exception.code(), grpc.StatusCode.NOT_FOUND)
 
     def test_duplicate_id(self):
         wd = self._prepare_inline("print(1)")
@@ -102,6 +123,29 @@ def handler(event):
                 working_dir=wd,
             ))
         self.assertEqual(ctx.exception.code(), grpc.StatusCode.ALREADY_EXISTS)
+
+    def test_forget_terminal_execution(self):
+        wd = self._prepare_inline("print(1)")
+        self.stub.Execute(runtime_pb2.ExecuteRequest(
+            id="forget-terminal",
+            working_dir=wd,
+        ))
+        self._wait("forget-terminal")
+        self.stub.Forget(runtime_pb2.ForgetRequest(id="forget-terminal"))
+        with self.assertRaises(grpc.RpcError) as ctx:
+            self.stub.Status(runtime_pb2.StatusRequest(id="forget-terminal"))
+        self.assertEqual(ctx.exception.code(), grpc.StatusCode.NOT_FOUND)
+
+    def test_forget_rejects_running_execution(self):
+        wd = self._prepare_inline("import time; time.sleep(30)")
+        self.stub.Execute(runtime_pb2.ExecuteRequest(
+            id="forget-running",
+            working_dir=wd,
+        ))
+        with self.assertRaises(grpc.RpcError) as ctx:
+            self.stub.Forget(runtime_pb2.ForgetRequest(id="forget-running"))
+        self.assertEqual(ctx.exception.code(), grpc.StatusCode.FAILED_PRECONDITION)
+        self.stub.Cancel(runtime_pb2.CancelRequest(id="forget-running"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Add `Forget` to the Runtime gRPC API so runtimed can release terminal execution state after a Run status update is persisted.

This change also makes terminal cleanup explicit and complete:
- runtimed calls `Forget` after persisting a terminal Run status, then removes the per-Run workspace
- the bash runtime supports terminal execution release and rejects `Forget` for running executions
- the python runtime supports the same lifecycle and now waits for child processes and handler subprocesses to exit on `Cancel`, so workspace cleanup does not race with still-running execution
- README, CLAUDE guidance, and the open source readiness checklist are updated to document the new lifecycle

## Compatibility and Operations

- Runtime API adds `Forget(ForgetRequest) returns (ForgetResponse)`
- runtimed treats `Unimplemented` and `NotFound` as successful cleanup for compatibility with older custom runtimes during rollout
- generated Go and Python gRPC stubs are updated

## Testing

- `UV_CACHE_DIR=/tmp/uv-cache uv run python -m unittest server_test -v`
- `GOCACHE=/tmp/go-build make test`

## Checklist

- [x] Tests cover new or changed behavior.
- [x] User-facing documentation is updated where needed.
- [x] Generated files are current.
- [x] Security and compatibility implications were considered.
