### PR TITLE
fix(runtime): reject escaping entrypoints

### DIFF
--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -79,7 +79,7 @@
 
 ### 5. Security and Trust Boundary
 
-- [ ] 拒绝绝对路径和包含 `..` 的 entrypoint，确保源码写入不逃逸 Run workspace。
+- [x] 拒绝绝对路径和包含 `..` 的 entrypoint，确保源码写入不逃逸 Run workspace。
 - [ ] 限制 Git source 协议，增加 clone/checkout 超时、大小和输出限制。
 - [ ] 明确 Runtime、Run 创建权限及其安全含义。
 - [ ] 为 runtimed status/artifact gRPC 增加网络访问控制；至少提供默认 NetworkPolicy。

--- a/internal/execpath/entrypoint.go
+++ b/internal/execpath/entrypoint.go
@@ -1,0 +1,24 @@
+package execpath
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ResolveEntrypoint normalizes an entrypoint and rejects any path that would
+// escape the execution workspace.
+func ResolveEntrypoint(entrypoint, fallback string) (string, error) {
+	if entrypoint == "" {
+		entrypoint = fallback
+	}
+
+	clean := filepath.Clean(entrypoint)
+	if clean == "." {
+		return "", fmt.Errorf("entrypoint must reference a file within the workspace")
+	}
+	if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("entrypoint must be a relative path within the workspace")
+	}
+	return clean, nil
+}

--- a/internal/execpath/entrypoint_test.go
+++ b/internal/execpath/entrypoint_test.go
@@ -1,0 +1,39 @@
+package execpath
+
+import "testing"
+
+func TestResolveEntrypoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		entrypoint string
+		fallback   string
+		want       string
+		wantErr    bool
+	}{
+		{name: "default", fallback: "script", want: "script"},
+		{name: "clean relative", entrypoint: "./run.sh", fallback: "script", want: "run.sh"},
+		{name: "nested relative", entrypoint: "scripts/../run.sh", fallback: "script", want: "run.sh"},
+		{name: "absolute", entrypoint: "/tmp/run.sh", fallback: "script", wantErr: true},
+		{name: "parent traversal", entrypoint: "../run.sh", fallback: "script", wantErr: true},
+		{name: "cleaned traversal", entrypoint: "scripts/../../run.sh", fallback: "script", wantErr: true},
+		{name: "dot", entrypoint: ".", fallback: "script", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveEntrypoint(tt.entrypoint, tt.fallback)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveEntrypoint: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/runtimed/controller.go
+++ b/internal/runtimed/controller.go
@@ -35,6 +35,7 @@ import (
 	pb "github.com/kruntimes/kruntimes/api/runtime/v1"
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 	"github.com/kruntimes/kruntimes/internal/artifact"
+	"github.com/kruntimes/kruntimes/internal/execpath"
 	runretry "github.com/kruntimes/kruntimes/internal/retry"
 	rlegpkg "github.com/kruntimes/kruntimes/internal/runtimed/rleg"
 	"github.com/kruntimes/kruntimes/internal/runtimepod"
@@ -664,9 +665,9 @@ func (c *Controller) startExecution(ctx context.Context, ar *activeRun) error {
 	if run.Spec.Timeout != nil {
 		timeoutSec = int64(run.Spec.Timeout.Duration.Seconds())
 	}
-	entrypoint := run.Spec.Entrypoint
-	if entrypoint == "" {
-		entrypoint = "script"
+	entrypoint, err := execpath.ResolveEntrypoint(run.Spec.Entrypoint, "script")
+	if err != nil {
+		return err
 	}
 	rctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -840,13 +841,16 @@ func prepareSource(run *v1alpha1.Run) (string, error) {
 	if err := os.MkdirAll(runDir, 0o755); err != nil {
 		return "", fmt.Errorf("mkdir %s: %w", runDir, err)
 	}
+	if _, err := execpath.ResolveEntrypoint(run.Spec.Entrypoint, "script"); err != nil {
+		return "", err
+	}
 	if run.Spec.Source == nil {
 		return runDir, nil
 	}
 	if run.Spec.Source.Inline != nil {
-		fileName := run.Spec.Entrypoint
-		if fileName == "" {
-			fileName = "script"
+		fileName, err := execpath.ResolveEntrypoint(run.Spec.Entrypoint, "script")
+		if err != nil {
+			return "", err
 		}
 		scriptPath := filepath.Join(runDir, fileName)
 		if err := os.WriteFile(scriptPath, []byte(*run.Spec.Source.Inline), 0o644); err != nil {

--- a/internal/runtimed/controller_test.go
+++ b/internal/runtimed/controller_test.go
@@ -96,6 +96,27 @@ func TestPrepareSource_InlineDefaultEntrypoint(t *testing.T) {
 	}
 }
 
+func TestPrepareSource_RejectsEscapingEntrypoint(t *testing.T) {
+	dir := t.TempDir()
+	workspacePath = dir
+
+	inline := "echo escape"
+	run := &v1alpha1.Run{
+		Spec: v1alpha1.RunSpec{
+			Entrypoint: "../escape.sh",
+			Source:     &v1alpha1.CodeSource{Inline: &inline},
+		},
+	}
+	run.UID = "test-uid"
+
+	if _, err := prepareSource(run); err == nil || !strings.Contains(err.Error(), "entrypoint") {
+		t.Fatalf("prepareSource error = %v, want entrypoint validation error", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "escape.sh")); !os.IsNotExist(err) {
+		t.Fatalf("escape target should not exist, stat err = %v", err)
+	}
+}
+
 func TestReadOutputs_Empty(t *testing.T) {
 	outputs, err := readOutputs("")
 	if err != nil {

--- a/runtimes/bash/server.go
+++ b/runtimes/bash/server.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/kruntimes/kruntimes/internal/execpath"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
@@ -310,9 +311,9 @@ func (s *Server) execute(ctx context.Context, req *pb.ExecuteRequest, entry *exe
 }
 
 func buildCommand(req *pb.ExecuteRequest, workDir string) (*exec.Cmd, error) {
-	entrypoint := req.Entrypoint
-	if entrypoint == "" {
-		entrypoint = "script"
+	entrypoint, err := execpath.ResolveEntrypoint(req.Entrypoint, "script")
+	if err != nil {
+		return nil, err
 	}
 	scriptPath := filepath.Join(workDir, entrypoint)
 	if _, err := os.Stat(scriptPath); err == nil {

--- a/runtimes/bash/server_test.go
+++ b/runtimes/bash/server_test.go
@@ -377,6 +377,32 @@ func TestCancelTerminatesProcessGroup(t *testing.T) {
 	t.Fatalf("child process %d still exists after cancellation", childPID)
 }
 
+func TestRejectsEscapingEntrypoint(t *testing.T) {
+	client, cleanup := startTestServer(t)
+	defer cleanup()
+
+	workDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workDir, "script"), []byte("echo ok\n"), 0o644); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	if _, err := client.Execute(context.Background(), &pb.ExecuteRequest{
+		Id:         "bad-entrypoint",
+		WorkingDir: workDir,
+		Entrypoint: "../escape.sh",
+	}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	resp := waitForTerminalStatus(t, client, "bad-entrypoint")
+	if resp.State != pb.ExecutionState_EXECUTION_STATE_FAILED {
+		t.Fatalf("state = %v, want failed", resp.State)
+	}
+	if !strings.Contains(resp.ErrorMessage, "entrypoint") {
+		t.Fatalf("error message = %q, want entrypoint validation", resp.ErrorMessage)
+	}
+}
+
 func waitForTerminalStatus(t *testing.T, client pb.RuntimeClient, id string) *pb.StatusResponse {
 	t.Helper()
 	ctx := context.Background()

--- a/runtimes/python/server.py
+++ b/runtimes/python/server.py
@@ -133,6 +133,16 @@ class PythonRuntime(runtime_pb2_grpc.RuntimeServicer):
         except ProcessLookupError:
             pass
 
+    @staticmethod
+    def _resolve_entrypoint(entrypoint, fallback="script"):
+        candidate = Path(entrypoint or fallback)
+        if candidate.is_absolute():
+            raise ValueError("entrypoint must be a relative path within the workspace")
+        cleaned = Path(os.path.normpath(str(candidate)))
+        if cleaned == Path(".") or ".." in cleaned.parts:
+            raise ValueError("entrypoint must be a relative path within the workspace")
+        return cleaned
+
     def _execute(self, task_id, task_dir, request):
         try:
             if request.handler:
@@ -173,7 +183,7 @@ if result is not None:
         self._run_process(task_id, task_dir, request, cmd)
 
     def _run_entrypoint(self, task_id, task_dir, request):
-        entrypoint = request.entrypoint or "script"
+        entrypoint = self._resolve_entrypoint(request.entrypoint)
         script = task_dir / entrypoint
         if script.exists():
             cmd = [sys.executable, str(script)] + list(request.args)

--- a/runtimes/python/server_test.py
+++ b/runtimes/python/server_test.py
@@ -147,6 +147,17 @@ def handler(event):
         self.assertEqual(ctx.exception.code(), grpc.StatusCode.FAILED_PRECONDITION)
         self.stub.Cancel(runtime_pb2.CancelRequest(id="forget-running"))
 
+    def test_rejects_escaping_entrypoint(self):
+        wd = self._prepare_inline("print(1)")
+        self.stub.Execute(runtime_pb2.ExecuteRequest(
+            id="bad-entrypoint",
+            working_dir=wd,
+            entrypoint="../escape.py",
+        ))
+        status = self._wait("bad-entrypoint")
+        self.assertEqual(status.state, runtime_pb2.EXECUTION_STATE_FAILED)
+        self.assertIn("entrypoint", status.error_message)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Reject absolute and parent-traversing `entrypoint` values before they can escape the Run workspace.

This change hardens all three layers involved in execution:
- runtimed validates `Run.spec.entrypoint` before writing inline source or calling Runtime `Execute`
- the bash runtime rejects escaping `entrypoint` values on direct gRPC execution
- the python runtime does the same for direct gRPC execution

A shared Go helper normalizes relative paths so valid values like `./script` and `scripts/../script` still work.

## Compatibility and Operations

- Escaping `entrypoint` values now fail execution instead of being interpreted relative to the filesystem outside the Run workspace
- Normal relative entrypoints remain supported

## Testing

- `GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/execpath ./internal/runtimed ./runtimes/bash -count=1`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python -m unittest server_test -v`

## Checklist

- [x] Tests cover new or changed behavior.
- [x] User-facing documentation is updated where needed.
- [x] Generated files are current.
- [x] Security and compatibility implications were considered.
