### PR TITLE
fix(runtimed): harden git source preparation

### DIFF
--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -80,7 +80,7 @@
 ### 5. Security and Trust Boundary
 
 - [x] 拒绝绝对路径和包含 `..` 的 entrypoint，确保源码写入不逃逸 Run workspace。
-- [ ] 限制 Git source 协议，增加 clone/checkout 超时、大小和输出限制。
+- [x] 限制 Git source 协议，增加 clone/checkout 超时、大小和输出限制。
 - [ ] 明确 Runtime、Run 创建权限及其安全含义。
 - [ ] 为 runtimed status/artifact gRPC 增加网络访问控制；至少提供默认 NetworkPolicy。
 - [ ] 为所有平台和内置 Runtime 容器提供安全的默认 security context。

--- a/internal/runtimed/controller.go
+++ b/internal/runtimed/controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"sync"
@@ -859,26 +858,7 @@ func prepareSource(run *v1alpha1.Run) (string, error) {
 		return runDir, nil
 	}
 	if run.Spec.Source.RepoURL != "" {
-		cloneDir := filepath.Join(runDir, "repo")
-		args := []string{"clone", run.Spec.Source.RepoURL, cloneDir}
-		if run.Spec.Source.CommitSHA == "" {
-			args = append(args, "--depth=1")
-		}
-		cmd := exec.Command("git", args...)
-		cmd.Dir = runDir
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			return "", fmt.Errorf("git clone: %w\n%s", err, string(out))
-		}
-		if run.Spec.Source.CommitSHA != "" {
-			cmd := exec.Command("git", "checkout", run.Spec.Source.CommitSHA)
-			cmd.Dir = cloneDir
-			out, err := cmd.CombinedOutput()
-			if err != nil {
-				return "", fmt.Errorf("git checkout: %w\n%s", err, string(out))
-			}
-		}
-		return cloneDir, nil
+		return prepareGitSource(runDir, run.Spec.Source.RepoURL, run.Spec.Source.CommitSHA)
 	}
 	return "", nil
 }

--- a/internal/runtimed/source_git.go
+++ b/internal/runtimed/source_git.go
@@ -1,0 +1,154 @@
+package runtimed
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"net/url"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	gitCloneTimeout          = 30 * time.Second
+	gitCheckoutTimeout       = 15 * time.Second
+	gitCommandOutputLimit    = 64 << 10
+	gitSourceSizeLimitBytes  = 100 << 20
+	gitOutputTruncatedMarker = "\n[git output truncated]\n"
+)
+
+var gitCommandContext = exec.CommandContext //nolint:gochecknoglobals
+
+func prepareGitSource(runDir string, sourceURL string, commitSHA string) (string, error) {
+	if err := validateGitSourceURL(sourceURL); err != nil {
+		return "", err
+	}
+
+	cloneDir := filepath.Join(runDir, "repo")
+	args := []string{"clone", sourceURL, cloneDir}
+	if commitSHA == "" {
+		args = append(args, "--depth=1")
+	}
+	if err := runGitCommand(runDir, gitCloneTimeout, "git clone", args...); err != nil {
+		return "", err
+	}
+	if commitSHA != "" {
+		if err := runGitCommand(cloneDir, gitCheckoutTimeout, "git checkout", "checkout", commitSHA); err != nil {
+			return "", err
+		}
+	}
+	if err := enforceDirectorySizeLimit(cloneDir, gitSourceSizeLimitBytes); err != nil {
+		return "", fmt.Errorf("git source size limit exceeded: %w", err)
+	}
+	return cloneDir, nil
+}
+
+func validateGitSourceURL(sourceURL string) error {
+	if sourceURL == "" {
+		return fmt.Errorf("repoURL is required")
+	}
+
+	if strings.HasPrefix(sourceURL, "git@") {
+		if strings.Contains(sourceURL, ":") {
+			return nil
+		}
+		return fmt.Errorf("repoURL uses unsupported SSH syntax")
+	}
+
+	u, err := url.Parse(sourceURL)
+	if err == nil && u.Scheme != "" {
+		switch u.Scheme {
+		case "https", "ssh":
+			return nil
+		default:
+			return fmt.Errorf("repoURL scheme %q is not allowed", u.Scheme)
+		}
+	}
+
+	return fmt.Errorf("repoURL must use https or ssh")
+}
+
+func runGitCommand(dir string, timeout time.Duration, prefix string, args ...string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := gitCommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+
+	output := &limitedCommandOutput{limit: gitCommandOutputLimit}
+	cmd.Stdout = output
+	cmd.Stderr = output
+
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("%s: timed out after %s", prefix, timeout)
+		}
+		if text := output.String(); text != "" {
+			return fmt.Errorf("%s: %w\n%s", prefix, err, text)
+		}
+		return fmt.Errorf("%s: %w", prefix, err)
+	}
+	return nil
+}
+
+func enforceDirectorySizeLimit(root string, limit int64) error {
+	var total int64
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		total += info.Size()
+		if total > limit {
+			return fmt.Errorf("directory size %d exceeds limit %d", total, limit)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type limitedCommandOutput struct {
+	buffer    bytes.Buffer
+	limit     int
+	truncated bool
+}
+
+func (b *limitedCommandOutput) Write(p []byte) (int, error) {
+	if b.limit <= 0 {
+		return len(p), nil
+	}
+	remaining := b.limit - b.buffer.Len()
+	if remaining > 0 {
+		if len(p) > remaining {
+			_, _ = b.buffer.Write(p[:remaining])
+			b.truncated = true
+		} else {
+			_, _ = b.buffer.Write(p)
+		}
+	} else {
+		b.truncated = true
+	}
+	return len(p), nil
+}
+
+func (b *limitedCommandOutput) String() string {
+	if !b.truncated {
+		return b.buffer.String()
+	}
+	return b.buffer.String() + gitOutputTruncatedMarker
+}

--- a/internal/runtimed/source_git_test.go
+++ b/internal/runtimed/source_git_test.go
@@ -1,0 +1,176 @@
+package runtimed
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+func TestValidateGitSourceURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{name: "https", url: "https://github.com/kruntimes/kruntimes.git"},
+		{name: "ssh scheme", url: "ssh://git@github.com/kruntimes/kruntimes.git"},
+		{name: "scp style", url: "git@github.com:kruntimes/kruntimes.git"},
+		{name: "file scheme", url: "file:///tmp/repo.git", wantErr: true},
+		{name: "git scheme", url: "git://github.com/kruntimes/kruntimes.git", wantErr: true},
+		{name: "local path", url: "/tmp/repo.git", wantErr: true},
+		{name: "relative path", url: "../repo.git", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGitSourceURL(tt.url)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validateGitSourceURL: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunGitCommandTimeout(t *testing.T) {
+	restore := stubGitCommandContext(t, "sleep")
+	defer restore()
+
+	err := runGitCommand(t.TempDir(), 20*time.Millisecond, "git clone", "clone", "https://example.invalid/repo.git", "repo")
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("runGitCommand error = %v, want timeout", err)
+	}
+}
+
+func TestRunGitCommandOutputLimit(t *testing.T) {
+	restore := stubGitCommandContext(t, "stderr-large")
+	defer restore()
+
+	err := runGitCommand(t.TempDir(), time.Second, "git clone", "clone", "https://example.invalid/repo.git", "repo")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), gitOutputTruncatedMarker) {
+		t.Fatalf("error = %q, want truncation marker", err.Error())
+	}
+}
+
+func TestEnforceDirectorySizeLimit(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "small.txt"), []byte("1234"), 0o644); err != nil {
+		t.Fatalf("write small file: %v", err)
+	}
+	if err := enforceDirectorySizeLimit(root, 16); err != nil {
+		t.Fatalf("enforceDirectorySizeLimit: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "big.txt"), []byte(strings.Repeat("x", 32)), 0o644); err != nil {
+		t.Fatalf("write big file: %v", err)
+	}
+	if err := enforceDirectorySizeLimit(root, 16); err == nil {
+		t.Fatal("expected size limit error")
+	}
+}
+
+func TestPrepareSourceRejectsDisallowedRepoURL(t *testing.T) {
+	dir := t.TempDir()
+	workspacePath = dir
+
+	run := testRunWithRepoURL("file:///tmp/repo.git")
+	_, err := prepareSource(run)
+	if err == nil || !strings.Contains(err.Error(), "repoURL") {
+		t.Fatalf("prepareSource error = %v, want repoURL validation", err)
+	}
+}
+
+func TestPrepareSourceRejectsOversizedRepository(t *testing.T) {
+	restore := stubGitCommandContext(t, "create-large-repo")
+	defer restore()
+
+	dir := t.TempDir()
+	workspacePath = dir
+
+	run := testRunWithRepoURL("https://github.com/kruntimes/kruntimes.git")
+	_, err := prepareSource(run)
+	if err == nil || !strings.Contains(err.Error(), "size limit") {
+		t.Fatalf("prepareSource error = %v, want size limit", err)
+	}
+}
+
+func testRunWithRepoURL(url string) *v1alpha1.Run {
+	run := &v1alpha1.Run{
+		Spec: v1alpha1.RunSpec{
+			Source: &v1alpha1.CodeSource{RepoURL: url},
+		},
+	}
+	run.UID = "test-uid"
+	return run
+}
+
+func stubGitCommandContext(t *testing.T, mode string) func() {
+	t.Helper()
+	previous := gitCommandContext
+	gitCommandContext = func(ctx context.Context, _ string, args ...string) *exec.Cmd {
+		cmdArgs := []string{"-test.run=TestGitHelperProcess", "--"}
+		cmdArgs = append(cmdArgs, args...)
+		cmd := exec.CommandContext(ctx, os.Args[0], cmdArgs...)
+		cmd.Env = append(os.Environ(), "GO_WANT_GIT_HELPER_PROCESS=1", "GIT_HELPER_MODE="+mode)
+		return cmd
+	}
+	return func() {
+		gitCommandContext = previous
+	}
+}
+
+func TestGitHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_GIT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := os.Args
+	for i, arg := range args {
+		if arg == "--" {
+			args = args[i+1:]
+			break
+		}
+	}
+
+	switch os.Getenv("GIT_HELPER_MODE") {
+	case "sleep":
+		time.Sleep(200 * time.Millisecond)
+		os.Exit(0)
+	case "stderr-large":
+		fmt.Fprint(os.Stderr, strings.Repeat("x", gitCommandOutputLimit+128))
+		os.Exit(1)
+	case "create-large-repo":
+		if len(args) < 3 || args[0] != "clone" {
+			fmt.Fprint(os.Stderr, "unexpected clone args")
+			os.Exit(2)
+		}
+		cloneDir := args[2]
+		if err := os.MkdirAll(cloneDir, 0o755); err != nil {
+			fmt.Fprintf(os.Stderr, "mkdir: %v", err)
+			os.Exit(1)
+		}
+		content := strings.Repeat("x", int(gitSourceSizeLimitBytes)+1)
+		if err := os.WriteFile(filepath.Join(cloneDir, "large.txt"), []byte(content), 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "write: %v", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	default:
+		fmt.Fprint(os.Stderr, "unknown helper mode")
+		os.Exit(2)
+	}
+}


### PR DESCRIPTION
## Summary

Harden Git-based Run source preparation in runtimed.

This change closes the current Git-source security gap by:
- allowing only `https`, `ssh://`, and scp-style `git@host:repo.git` repository URLs
- rejecting local paths, `file://`, `git://`, and other unsupported schemes
- enforcing timeouts for both `git clone` and `git checkout`
- bounding captured git command output so error messages cannot grow without limit
- rejecting prepared repositories whose checked-out workspace exceeds the configured size limit

## Compatibility and Operations

- Runs using unsupported repository URL schemes now fail during source preparation
- Git clone and checkout failures now return bounded output and timeout-specific errors
- Checked-out repository content must fit inside the configured source size limit

## Testing

- `GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/runtimed -run 'Test(ValidateGitSourceURL|RunGitCommandTimeout|RunGitCommandOutputLimit|EnforceDirectorySizeLimit|PrepareSourceRejectsDisallowedRepoURL|PrepareSourceRejectsOversizedRepository)' -count=1`
- `GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/runtimed -count=1`

## Checklist

- [x] Tests cover new or changed behavior.
- [x] User-facing documentation is updated where needed.
- [x] Generated files are current.
- [x] Security and compatibility implications were considered.
