### PR TITLE
docs(repo): clarify trusted runtime boundaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,6 @@ cd runtimes/python && uv sync                      # install deps (grpcio, grpci
 
 **Code generation:** `make proto-python` generates gRPC stubs in `runtimes/python/pb/` from `api/runtime/v1/runtime.proto`.
 
-**Tests:** `uv run python -m unittest server_test -v` (5 tests covering inline, handler, duplicate, cancel, failure).
+**Tests:** `uv run python -m unittest server_test -v`
 
-**How it works:** The runtimed daemon prepares user code on the shared `/workspace` volume (inline → dump to the `entrypoint` file, default `script`; repo → git clone), then sends `working_dir` + `entrypoint` + `handler` to the Python gRPC server. The server runs `python <working_dir>/<entrypoint>` or calls `handler(event)` in FaaS mode.
+**How it works:** The runtimed daemon prepares user code in a per-Run directory on the shared `/workspace` volume (inline → dump to the `entrypoint` file, default `script`; repo → git clone), then sends `working_dir` + `entrypoint` + `handler` to the Python gRPC server. The server runs `python <working_dir>/<entrypoint>` or executes `handler(event)` in FaaS mode. The built-in Python runtime is for trusted code only; handler mode is not a security boundary.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,13 @@ Instead of creating a new Pod for every request, kruntimes maintains pools of pr
 
 This removes the slowest parts of the critical path — Kubernetes scheduling, image pulling, and container startup — from request time. For lightweight Runs, dispatch latency can drop from seconds or minutes to milliseconds.
 
-Each Run executes in a clean workspace with explicit setup, teardown, timeout, cancellation, and resource cleanup. For untrusted workloads, Runtime implementations can add stronger isolation boundaries such as per-run containers, gVisor, Firecracker, nsjail, or other sandboxing mechanisms.
+Each Run executes in a per-Run workspace directory under the shared Runtime Pod
+workspace, with explicit setup, teardown, timeout, cancellation, and terminal
+state cleanup. The built-in bash and Python runtimes are intended for trusted
+code within a trusted namespace. They do not provide per-Run filesystem,
+process, or network isolation. For untrusted workloads, Runtime implementations
+must add stronger isolation boundaries such as per-run containers, gVisor,
+Firecracker, nsjail, or other sandboxing mechanisms.
 
 ### Two-layer scheduling
 
@@ -78,13 +84,21 @@ This separation lets kruntimes implement application-level queuing, prioritizati
 
 Runtime Pods continuously report health, capacity, supported Runtime labels, active Run count, and load. The application scheduler uses this information to place Runs onto hot pods without relying on Kubernetes scheduling for every execution.
 
-Because multiple Runs may share a Runtime Pod, kruntimes enforces per-Run concurrency, timeout, cancellation, and resource limits at the runtime layer.
+Because multiple Runs may share a Runtime Pod, kruntimes enforces scheduling
+capacity, timeout, cancellation, and retry behavior at the runtime layer.
+Per-Run CPU and memory isolation are not currently enforced by the built-in
+runtimes.
 
 ### Runtime abstraction
 
 Different execution environments — such as language runtimes like Go, Python, and Node.js, or specialized executors like BuildKit — are modeled as distinct **Runtime** types.
 
-Each Runtime is backed by an independent Deployment pool with a specific container image, toolchain, resource profile, and security policy. This provides natural environment isolation, guarantees consistency across Runs, and makes adding new environments an operational workflow: build a new Runtime image, deploy a pool, and register its labels and capabilities.
+Each Runtime is backed by an independent Deployment pool with a specific
+container image, toolchain, resource profile, and security policy. This
+provides environment separation between Runtime pools and keeps execution
+toolchains consistent across Runs. Multiple Runs assigned to the same Runtime
+Pod still share that pod's process, filesystem, and network namespaces unless a
+custom Runtime adds stronger isolation.
 
 ### Declarative CRDs, not P2P
 
@@ -539,7 +553,8 @@ The Python runtime is a standalone gRPC server (Python 3.13) deployed alongside 
 **Execution flow:**
 1. Runtimed prepares source on `/workspace/<uid>/` — inline code dumped to the `entrypoint` file (default `"script"`), or git clone to `repo/`
 2. Runtimed calls gRPC `Execute` with `working_dir` set to the prepared directory, `entrypoint` to the script name, and `handler` (if FaaS mode)
-3. If `handler` is set (e.g. `"app.handler"`), the Python runtime imports the module and calls `handler(event)` with `args` as the event payload
+3. If `handler` is set (e.g. `"app.handler"`), the Python runtime executes that handler within the prepared workspace and passes `args` as the event payload
+4. Python handler mode is for trusted code only. It is an execution convenience, not a security boundary
 4. Otherwise, it runs `python <working_dir>/<entrypoint> <args>` as a script
 
 | Mode | Example |

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -54,7 +54,7 @@
 - [x] Run 完成后清理 `/workspace/<runUID>`，同时保留制品上传所需顺序。
 - [ ] 对 Bash/Python 的取消和超时终止整个进程组，并等待退出。
 - [ ] 修复 Python Runtime 中共享 task 状态的并发访问。
-- [ ] 明确 Python handler 模式的隔离方案；在未隔离前标记为 trusted-code only。
+- [x] 明确 Python handler 模式的隔离方案；在未隔离前标记为 trusted-code only。
 - [ ] 将 `workspace.sizeLimit` 实际应用到 Runtime Pod 的 `emptyDir`。
 
 验收标准：
@@ -87,7 +87,7 @@
 - [ ] 禁止默认 privilege escalation，启用 seccomp，按容器能力设置只读根文件系统。
 - [ ] 编写 threat model，明确同一 Runtime Pod 内多个 Run 共享进程、网络和 workspace
   所带来的限制。
-- [ ] 修正 README 中“per-Run resource limits”和“clean workspace”等超出当前实现的声明。
+- [x] 修正 README 中“per-Run resource limits”和“clean workspace”等超出当前实现的声明。
 
 验收标准：
 


### PR DESCRIPTION
## Summary

Clarify the current trust and isolation boundaries of the built-in runtimes.

This change updates the README and local contributor guidance to match the code as it exists today:
- built-in bash and Python runtimes are for trusted code only
- Python handler mode is an execution convenience, not a security boundary
- Runs use per-Run directories inside a shared Runtime Pod workspace, not isolated filesystems
- the built-in runtimes do not currently enforce per-Run CPU or memory isolation

It also marks the matching open-source-readiness checklist items complete.

## Compatibility and Operations

- No runtime behavior changes
- Documentation now explicitly warns against treating built-in runtimes as untrusted-code sandboxes

## Testing

- `git diff --check`
- searched updated docs for remaining overstated isolation/resource-limit claims

## Checklist

- [x] Tests cover new or changed behavior.
- [x] User-facing documentation is updated where needed.
- [x] Generated files are current.
- [x] Security and compatibility implications were considered.
