### PR TITLE
ci(repo): add go race detector check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,17 @@ jobs:
           cache: true
       - run: make test-integration
 
+  race:
+    name: Go race detector
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: make test-race
+
   python:
     name: Python Runtime tests
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ test-integration: generate manifests setup-envtest ## Run integration tests (req
 	KUBEBUILDER_ASSETS="$$($(SETUP_ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" \
 	go test ./test/integration/... -v -count=1 -failfast
 
+.PHONY: test-race
+test-race: generate manifests proto ## Run focused Go race-detector coverage for runtime and control-plane packages.
+	go test -race ./internal/controller ./internal/scheduler ./internal/runtimed ./runtimes/bash -count=1
+
 .PHONY: test-s3-integration
 test-s3-integration: ## Run S3 ArtifactStore integration tests against MinIO.
 	CONTAINER_TOOL=$(CONTAINER_TOOL) ./hack/test-s3-integration.sh

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -32,7 +32,7 @@
 ### 2. Required CI
 
 - [x] CI 执行 `make test`、`make test-integration` 和 Helm lint/template。
-- [ ] CI 执行 Go race detector，至少覆盖 runtime、scheduler、controller 和 runtimed。
+- [x] CI 执行 Go race detector，至少覆盖 runtime、scheduler、controller 和 runtimed。
 - [x] CI 执行 Python Runtime 单元测试。
 - [ ] 增加 `govulncheck`、依赖更新机器人和基础 secret scanning。
 - [x] 增加生成文件一致性检查，确保生成的 Go API 和 CRD 文件保持最新。


### PR DESCRIPTION
## Summary

Add a dedicated Go race-detector check to CI.

This change adds a reusable `make test-race` target and wires it into the GitHub Actions workflow so CI now covers the main runtime and control-plane packages with `go test -race`:
- `internal/controller`
- `internal/scheduler`
- `internal/runtimed`
- `runtimes/bash`

It also marks the matching open-source-readiness checklist item complete.

## Compatibility and Operations

- No runtime behavior changes
- CI duration increases because of the added race-detector job

## Testing

- `GOCACHE=/tmp/go-build make test-race`
- `git diff --check`

## Checklist

- [x] Tests cover new or changed behavior.
- [x] User-facing documentation is updated where needed.
- [x] Generated files are current.
- [x] Security and compatibility implications were considered.
