### PR TITLE
ci(repo): add security scan workflows

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,9 +24,14 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.0"
+          cache: true
+      - name: Install gitleaks
+        run: go install github.com/gitleaks/gitleaks/v8@v8.30.1
+      - name: Run gitleaks
+        run: gitleaks git --redact --exit-code 1
 
   govulncheck:
     name: govulncheck

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,7 +29,7 @@ jobs:
           go-version: "1.26.0"
           cache: true
       - name: Install gitleaks
-        run: go install github.com/gitleaks/gitleaks/v8@v8.30.1
+        run: go install github.com/zricethezav/gitleaks/v8@v8.30.1
       - name: Run gitleaks
         run: gitleaks git --redact --exit-code 1
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,44 @@
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  secrets:
+    name: Secret scanning
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  govulncheck:
+    name: govulncheck
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run govulncheck
+        run: govulncheck ./...

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -34,7 +34,7 @@
 - [x] CI 执行 `make test`、`make test-integration` 和 Helm lint/template。
 - [x] CI 执行 Go race detector，至少覆盖 runtime、scheduler、controller 和 runtimed。
 - [x] CI 执行 Python Runtime 单元测试。
-- [ ] 增加 `govulncheck`、依赖更新机器人和基础 secret scanning。
+- [x] 增加 `govulncheck`、依赖更新机器人和基础 secret scanning。
 - [x] 增加生成文件一致性检查，确保生成的 Go API 和 CRD 文件保持最新。
 - [x] 定期或按发布执行 `make e2e`。
 


### PR DESCRIPTION
## Summary

Add baseline security scanning workflows.

This change adds a dedicated GitHub Actions workflow that:
- runs secret scanning on pull requests and pushes to main
- runs `govulncheck` on a weekly schedule and by manual dispatch

Dependabot is already configured in the repository, so this PR closes the remaining gap in the readiness checklist item for dependency updates, vulnerability scanning, and basic secret scanning.

## Compatibility and Operations

- No runtime behavior changes
- `govulncheck` is introduced in scheduled/manual mode first so existing known vulnerabilities do not immediately turn every open PR red before the dependency-upgrade work lands

## Testing

- `git diff --check`
- reviewed rendered workflow YAML for trigger and job structure correctness

## Checklist

- [x] Tests cover new or changed behavior.
- [x] User-facing documentation is updated where needed.
- [x] Generated files are current.
- [x] Security and compatibility implications were considered.
