### PR TITLE
ci(repo): schedule e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,34 @@
+name: E2E
+
+on:
+  schedule:
+    - cron: "0 3 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: make e2e
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          working-directory: runtimes/python
+          python-version: "3.12"
+          enable-cache: true
+      - uses: azure/setup-helm@v5.0.0
+      - uses: helm/kind-action@v1.12.0
+        with:
+          cluster_name: kruntimes-e2e
+      - run: make e2e

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -36,7 +36,7 @@
 - [x] CI 执行 Python Runtime 单元测试。
 - [ ] 增加 `govulncheck`、依赖更新机器人和基础 secret scanning。
 - [x] 增加生成文件一致性检查，确保生成的 Go API 和 CRD 文件保持最新。
-- [ ] 定期或按发布执行 `make e2e`。
+- [x] 定期或按发布执行 `make e2e`。
 
 验收标准：
 


### PR DESCRIPTION
## Summary

Add a dedicated scheduled/manual E2E workflow that runs `make e2e`.

This satisfies the readiness requirement to execute full E2E periodically or at release time without making every pull request pay the cost of a full kind-based deployment test.

## Compatibility and Operations

- No runtime behavior changes
- Adds a weekly scheduled E2E workflow plus manual dispatch
- Uses the existing `make e2e` entrypoint, so local and CI E2E execution stay aligned

## Testing

- `git diff --check`
- reviewed workflow triggers and step sequence against the existing `make e2e` prerequisites

## Checklist

- [x] Tests cover new or changed behavior.
- [x] User-facing documentation is updated where needed.
- [x] Generated files are current.
- [x] Security and compatibility implications were considered.
