### PR TITLE
feat(security): add hardened container defaults

### DIFF
--- a/charts/kruntimes/templates/controller-deployment.yaml
+++ b/charts/kruntimes/templates/controller-deployment.yaml
@@ -17,10 +17,20 @@ spec:
         app: kruntimes-controller
     spec:
       serviceAccountName: kruntimes-controller
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: controller
           image: {{ .Values.controller.image }}
           imagePullPolicy: {{ .Values.controller.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
           args:
             - --leader-elect=true
             - --metrics-bind-address=:8082

--- a/charts/kruntimes/templates/scheduler-deployment.yaml
+++ b/charts/kruntimes/templates/scheduler-deployment.yaml
@@ -16,10 +16,20 @@ spec:
         app: kruntimes-scheduler
     spec:
       serviceAccountName: kruntimes-scheduler
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: scheduler
           image: {{ .Values.scheduler.image }}
           imagePullPolicy: {{ .Values.scheduler.imagePullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
           args:
             - --leader-elect={{ .Values.scheduler.leaderElect }}
             - --metrics-bind-address={{ .Values.scheduler.metricsBindAddress }}

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -83,8 +83,8 @@
 - [x] 限制 Git source 协议，增加 clone/checkout 超时、大小和输出限制。
 - [ ] 明确 Runtime、Run 创建权限及其安全含义。
 - [x] 为 runtimed status/artifact gRPC 增加网络访问控制；至少提供默认 NetworkPolicy。
-- [ ] 为所有平台和内置 Runtime 容器提供安全的默认 security context。
-- [ ] 禁止默认 privilege escalation，启用 seccomp，按容器能力设置只读根文件系统。
+- [x] 为所有平台和内置 Runtime 容器提供安全的默认 security context。
+- [x] 禁止默认 privilege escalation，启用 seccomp，按容器能力设置只读根文件系统。
 - [ ] 编写 threat model，明确同一 Runtime Pod 内多个 Run 共享进程、网络和 workspace
   所带来的限制。
 - [x] 修正 README 中“per-Run resource limits”和“clean workspace”等超出当前实现的声明。

--- a/internal/controller/runtime_controller.go
+++ b/internal/controller/runtime_controller.go
@@ -147,6 +147,7 @@ func (r *RuntimeReconciler) buildDeployment(rt *v1alpha1.Runtime) *appsv1.Deploy
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: workspaceVolume, MountPath: workspacePath},
 		},
+		SecurityContext: defaultContainerSecurityContext(),
 	}
 	if runtimeContainer.Resources.Requests == nil {
 		runtimeContainer.Resources.Requests = corev1.ResourceList{
@@ -186,11 +187,7 @@ func (r *RuntimeReconciler) buildDeployment(rt *v1alpha1.Runtime) *appsv1.Deploy
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: workspaceVolume, MountPath: workspacePath},
 		},
-		SecurityContext: &corev1.SecurityContext{
-			ReadOnlyRootFilesystem:   ptr(true),
-			RunAsNonRoot:             ptr(true),
-			AllowPrivilegeEscalation: ptr(false),
-		},
+		SecurityContext: defaultContainerSecurityContext(),
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -257,6 +254,20 @@ func (r *RuntimeReconciler) buildNetworkPolicy(rt *v1alpha1.Runtime) *networking
 			PolicyTypes: []networkingv1.PolicyType{
 				networkingv1.PolicyTypeIngress,
 			},
+		},
+	}
+}
+
+func defaultContainerSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		ReadOnlyRootFilesystem:   ptr(true),
+		RunAsNonRoot:             ptr(true),
+		AllowPrivilegeEscalation: ptr(false),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},
 	}
 }

--- a/internal/controller/runtime_controller_test.go
+++ b/internal/controller/runtime_controller_test.go
@@ -47,6 +47,27 @@ func TestBuildDeploymentAddsCapacityAnnotationsAndWorkers(t *testing.T) {
 	if !slices.Contains(daemon.Args, "--runtime-name=bash") {
 		t.Fatalf("daemon args = %v, want runtime name", daemon.Args)
 	}
+
+	for _, container := range deploy.Spec.Template.Spec.Containers {
+		if container.SecurityContext == nil {
+			t.Fatalf("container %s missing security context", container.Name)
+		}
+		if container.SecurityContext.RunAsNonRoot == nil || !*container.SecurityContext.RunAsNonRoot {
+			t.Fatalf("container %s runAsNonRoot = %#v, want true", container.Name, container.SecurityContext.RunAsNonRoot)
+		}
+		if container.SecurityContext.AllowPrivilegeEscalation == nil || *container.SecurityContext.AllowPrivilegeEscalation {
+			t.Fatalf("container %s allowPrivilegeEscalation = %#v, want false", container.Name, container.SecurityContext.AllowPrivilegeEscalation)
+		}
+		if container.SecurityContext.ReadOnlyRootFilesystem == nil || !*container.SecurityContext.ReadOnlyRootFilesystem {
+			t.Fatalf("container %s readOnlyRootFilesystem = %#v, want true", container.Name, container.SecurityContext.ReadOnlyRootFilesystem)
+		}
+		if container.SecurityContext.SeccompProfile == nil || container.SecurityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+			t.Fatalf("container %s seccomp = %#v, want RuntimeDefault", container.Name, container.SecurityContext.SeccompProfile)
+		}
+		if container.SecurityContext.Capabilities == nil || len(container.SecurityContext.Capabilities.Drop) != 1 || container.SecurityContext.Capabilities.Drop[0] != corev1.Capability("ALL") {
+			t.Fatalf("container %s capabilities = %#v, want drop ALL", container.Name, container.SecurityContext.Capabilities)
+		}
+	}
 }
 
 func TestBuildDeploymentAppliesWorkspaceSizeLimit(t *testing.T) {


### PR DESCRIPTION
## Summary

Add safer default security contexts for platform and runtime containers.

This change hardens the default deployments by:
- setting `allowPrivilegeEscalation: false`
- setting `readOnlyRootFilesystem: true`
- setting `runAsNonRoot: true`
- dropping all Linux capabilities
- enabling `seccompProfile: RuntimeDefault`

The runtime controller now applies these defaults to both the generated runtime container and the runtimed sidecar. The platform Helm chart applies matching defaults to the scheduler and controller Deployments.

## Compatibility and Operations

- No API changes
- Platform and generated runtime pods now run with stricter default container security settings
- Workloads that implicitly relied on writable root filesystems or added capabilities will need explicit follow-up changes rather than receiving those privileges by default

## Testing

- `GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/controller -count=1`
- `helm template kruntimes ./charts/kruntimes --namespace kruntimes-system`
- `git diff --check`

## Checklist

- [x] Tests cover new or changed behavior.
- [x] User-facing documentation is updated where needed.
- [x] Generated files are current.
- [x] Security and compatibility implications were considered.
