### PR TITLE
fix(scheduler): validate manager before probe setup

### DIFF
--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -47,10 +47,16 @@ func main() {
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "kruntimes-scheduler.kruntimes.com",
 	})
-	_ = mgr.AddHealthzCheck("healthz", func(_ *http.Request) error { return nil })
-	_ = mgr.AddReadyzCheck("readyz", func(_ *http.Request) error { return nil })
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+	if err := mgr.AddHealthzCheck("healthz", func(_ *http.Request) error { return nil }); err != nil {
+		setupLog.Error(err, "unable to register health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", func(_ *http.Request) error { return nil }); err != nil {
+		setupLog.Error(err, "unable to register readiness check")
 		os.Exit(1)
 	}
 

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -154,7 +154,7 @@
 - [ ] Stale reaper 同时检查 Kubernetes `PodReady` 和
   `kruntimes.io/RuntimedReady` heartbeat。
 - [ ] Stale reaper 返回 status update 错误，并统一 terminal condition 更新。
-- [ ] 修复 scheduler 在检查 `NewManager` 错误前使用 `mgr` 的初始化顺序。
+- [x] 修复 scheduler 在检查 `NewManager` 错误前使用 `mgr` 的初始化顺序。
 - [ ] runtimed 主动区分 transient Status 错误和 execution `NotFound`。
 - [ ] `krt run --wait` 正确处理 `Timeout` 和 `Cancelled`。
 - [ ] `krt logs` 同时处理 stdout/stderr，避免 stderr 重复和 offset 越界。


### PR DESCRIPTION
## Summary
- check the controller-runtime manager construction error before using the manager
- handle health and readiness check registration errors instead of discarding them
- mark the corresponding readiness task complete

## Verification
- GOCACHE=/tmp/go-build make test
- git diff --check