### PR TITLE
fix(krt): stop waiting on timeout and cancellation

### DIFF
--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -156,7 +156,7 @@
 - [ ] Stale reaper 返回 status update 错误，并统一 terminal condition 更新。
 - [ ] 修复 scheduler 在检查 `NewManager` 错误前使用 `mgr` 的初始化顺序。
 - [ ] runtimed 主动区分 transient Status 错误和 execution `NotFound`。
-- [ ] `krt run --wait` 正确处理 `Timeout` 和 `Cancelled`。
+- [x] `krt run --wait` 正确处理 `Timeout` 和 `Cancelled`。
 - [ ] `krt logs` 同时处理 stdout/stderr，避免 stderr 重复和 offset 越界。
 - [ ] CLI 使用 Cobra command context，支持 kubeconfig/context、当前 namespace 和
   `json`/`yaml` 输出。

--- a/internal/krt/run.go
+++ b/internal/krt/run.go
@@ -126,13 +126,12 @@ func NewRunCmd(c client.Client) *cobra.Command {
 					return fmt.Errorf("get run: %w", err)
 				}
 
+				if done, err := runTerminalResult(latest.Status.Phase); done {
+					fmt.Println(latest.Status.Message)
+					return err
+				}
+
 				switch latest.Status.Phase {
-				case v1alpha1.RunSucceeded:
-					fmt.Println(latest.Status.Message)
-					return nil
-				case v1alpha1.RunFailed:
-					fmt.Println(latest.Status.Message)
-					return fmt.Errorf("run failed")
 				case v1alpha1.RunRunning:
 					fmt.Printf("\rRunning on %s...", latest.Status.AssignedPod)
 				case v1alpha1.RunScheduled:
@@ -156,4 +155,19 @@ func NewRunCmd(c client.Client) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.Namespace, "namespace", "n", "default", "Kubernetes namespace")
 
 	return cmd
+}
+
+func runTerminalResult(phase v1alpha1.RunPhase) (bool, error) {
+	switch phase {
+	case v1alpha1.RunSucceeded:
+		return true, nil
+	case v1alpha1.RunFailed:
+		return true, fmt.Errorf("run failed")
+	case v1alpha1.RunTimeout:
+		return true, fmt.Errorf("run timed out")
+	case v1alpha1.RunCancelled:
+		return true, fmt.Errorf("run cancelled")
+	default:
+		return false, nil
+	}
 }

--- a/internal/krt/run_test.go
+++ b/internal/krt/run_test.go
@@ -1,0 +1,42 @@
+package krt
+
+import (
+	"testing"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+func TestRunTerminalResult(t *testing.T) {
+	tests := []struct {
+		name    string
+		phase   v1alpha1.RunPhase
+		done    bool
+		wantErr string
+	}{
+		{name: "pending", phase: v1alpha1.RunPending},
+		{name: "scheduled", phase: v1alpha1.RunScheduled},
+		{name: "running", phase: v1alpha1.RunRunning},
+		{name: "succeeded", phase: v1alpha1.RunSucceeded, done: true},
+		{name: "failed", phase: v1alpha1.RunFailed, done: true, wantErr: "run failed"},
+		{name: "timeout", phase: v1alpha1.RunTimeout, done: true, wantErr: "run timed out"},
+		{name: "cancelled", phase: v1alpha1.RunCancelled, done: true, wantErr: "run cancelled"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			done, err := runTerminalResult(tt.phase)
+			if done != tt.done {
+				t.Fatalf("done = %v, want %v", done, tt.done)
+			}
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- treat Timeout and Cancelled as terminal phases in krt run --wait
- return distinct non-zero errors for failed, timed out, and cancelled Runs
- add table-driven coverage for all active and terminal Run phases

## Verification
- GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/krt -count=1
- GOCACHE=/tmp/go-build make test
- git diff --check