### PR TITLE
fix(krt): track stdout and stderr log offsets

### DIFF
--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -157,7 +157,7 @@
 - [x] 修复 scheduler 在检查 `NewManager` 错误前使用 `mgr` 的初始化顺序。
 - [ ] runtimed 主动区分 transient Status 错误和 execution `NotFound`。
 - [x] `krt run --wait` 正确处理 `Timeout` 和 `Cancelled`。
-- [ ] `krt logs` 同时处理 stdout/stderr，避免 stderr 重复和 offset 越界。
+- [x] `krt logs` 同时处理 stdout/stderr，避免 stderr 重复和 offset 越界。
 - [ ] CLI 使用 Cobra command context，支持 kubeconfig/context、当前 namespace 和
   `json`/`yaml` 输出。
 - [ ] 增加真实 readiness check，而不是固定返回成功。

--- a/internal/krt/logs.go
+++ b/internal/krt/logs.go
@@ -3,7 +3,7 @@ package krt
 import (
 	"context"
 	"fmt"
-	"os"
+	"io"
 	"strings"
 	"time"
 
@@ -61,9 +61,9 @@ func NewLogsCmd(k8sClient client.Client, restConfig *rest.Config) *cobra.Command
 			uid := string(run.UID)
 
 			if !follow {
-				return showLogsOnce(cmd.Context(), cli, uid, tailLines)
+				return showLogsOnce(cmd.Context(), cli, uid, tailLines, cmd.OutOrStdout(), cmd.ErrOrStderr())
 			}
-			return followLogs(cmd.Context(), cli, uid, tailLines)
+			return followLogs(cmd.Context(), cli, uid, tailLines, cmd.OutOrStdout(), cmd.ErrOrStderr())
 		},
 	}
 
@@ -74,21 +74,36 @@ func NewLogsCmd(k8sClient client.Client, restConfig *rest.Config) *cobra.Command
 	return cmd
 }
 
-func showLogsOnce(ctx context.Context, cli pb.RuntimeClient, uid string, tailLines int) error {
+func showLogsOnce(
+	ctx context.Context,
+	cli pb.RuntimeClient,
+	uid string,
+	tailLines int,
+	stdout,
+	stderr io.Writer,
+) error {
 	resp, err := cli.Status(ctx, &pb.StatusRequest{Id: uid})
 	if err != nil {
 		return fmt.Errorf("status: %w", err)
 	}
-	output := resp.Stdout
-	if output == "" {
-		output = resp.Stderr
+	if err := writeLogOutput(stdout, tailOutput(resp.Stdout, tailLines)); err != nil {
+		return fmt.Errorf("write stdout: %w", err)
 	}
-	out := tailOutput(output, tailLines)
-	if out != "" && !strings.HasSuffix(out, "\n") {
-		out += "\n"
+	if err := writeLogOutput(stderr, tailOutput(resp.Stderr, tailLines)); err != nil {
+		return fmt.Errorf("write stderr: %w", err)
 	}
-	fmt.Print(out)
 	return nil
+}
+
+func writeLogOutput(w io.Writer, output string) error {
+	if output == "" {
+		return nil
+	}
+	if !strings.HasSuffix(output, "\n") {
+		output += "\n"
+	}
+	_, err := io.WriteString(w, output)
+	return err
 }
 
 func tailOutput(output string, n int) string {
@@ -106,19 +121,28 @@ func tailOutput(output string, n int) string {
 	return strings.Join(lines, "\n")
 }
 
-func followLogs(ctx context.Context, cli pb.RuntimeClient, uid string, tailLines int) error {
-	// Where to start slicing: 0 = from beginning, or skip first N bytes for tail.
-	seen := 0
+func followLogs(
+	ctx context.Context,
+	cli pb.RuntimeClient,
+	uid string,
+	tailLines int,
+	stdout,
+	stderr io.Writer,
+) error {
+	stdoutOffset := 0
+	stderrOffset := 0
 
 	if tailLines > 0 {
 		resp, err := cli.Status(ctx, &pb.StatusRequest{Id: uid})
 		if err == nil {
-			tail := tailOutput(resp.Stdout, tailLines)
-			if tail != "" && !strings.HasSuffix(tail, "\n") {
-				tail += "\n"
+			if err := writeLogOutput(stdout, tailOutput(resp.Stdout, tailLines)); err != nil {
+				return fmt.Errorf("write stdout: %w", err)
 			}
-			fmt.Print(tail)
-			seen = len(resp.Stdout)
+			if err := writeLogOutput(stderr, tailOutput(resp.Stderr, tailLines)); err != nil {
+				return fmt.Errorf("write stderr: %w", err)
+			}
+			stdoutOffset = len(resp.Stdout)
+			stderrOffset = len(resp.Stderr)
 		}
 	}
 
@@ -135,13 +159,17 @@ func followLogs(ctx context.Context, cli pb.RuntimeClient, uid string, tailLines
 			continue
 		}
 
-		if newOut := resp.Stdout[seen:]; newOut != "" {
-			fmt.Print(newOut)
-			seen = len(resp.Stdout)
+		newStdout, nextStdoutOffset := logOutputSince(resp.Stdout, stdoutOffset)
+		if _, err := io.WriteString(stdout, newStdout); err != nil {
+			return fmt.Errorf("write stdout: %w", err)
 		}
-		if resp.Stderr != "" {
-			fmt.Fprint(os.Stderr, resp.Stderr)
+		stdoutOffset = nextStdoutOffset
+
+		newStderr, nextStderrOffset := logOutputSince(resp.Stderr, stderrOffset)
+		if _, err := io.WriteString(stderr, newStderr); err != nil {
+			return fmt.Errorf("write stderr: %w", err)
 		}
+		stderrOffset = nextStderrOffset
 
 		if resp.State == pb.ExecutionState_EXECUTION_STATE_SUCCEEDED ||
 			resp.State == pb.ExecutionState_EXECUTION_STATE_FAILED {
@@ -150,4 +178,11 @@ func followLogs(ctx context.Context, cli pb.RuntimeClient, uid string, tailLines
 
 		time.Sleep(500 * time.Millisecond)
 	}
+}
+
+func logOutputSince(output string, offset int) (string, int) {
+	if offset < 0 || offset > len(output) {
+		offset = 0
+	}
+	return output[offset:], len(output)
 }

--- a/internal/krt/logs_test.go
+++ b/internal/krt/logs_test.go
@@ -1,0 +1,86 @@
+package krt
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"google.golang.org/grpc"
+
+	pb "github.com/kruntimes/kruntimes/api/runtime/v1"
+)
+
+func TestShowLogsOnceWritesStdoutAndStderr(t *testing.T) {
+	cli := &statusSequenceClient{
+		responses: []*pb.StatusResponse{{
+			Stdout: "stdout",
+			Stderr: "stderr",
+		}},
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	if err := showLogsOnce(context.Background(), cli, "run-uid", 0, &stdout, &stderr); err != nil {
+		t.Fatalf("showLogsOnce() error = %v", err)
+	}
+	if got := stdout.String(); got != "stdout\n" {
+		t.Fatalf("stdout = %q, want %q", got, "stdout\n")
+	}
+	if got := stderr.String(); got != "stderr\n" {
+		t.Fatalf("stderr = %q, want %q", got, "stderr\n")
+	}
+}
+
+func TestFollowLogsTracksStdoutAndStderrOffsets(t *testing.T) {
+	cli := &statusSequenceClient{
+		responses: []*pb.StatusResponse{
+			{
+				Stdout: "old stdout\nstdout one\n",
+				Stderr: "old stderr\nstderr one\n",
+				State:  pb.ExecutionState_EXECUTION_STATE_RUNNING,
+			},
+			{
+				Stdout: "old stdout\nstdout one\nstdout two\n",
+				Stderr: "old stderr\nstderr one\nstderr two\n",
+				State:  pb.ExecutionState_EXECUTION_STATE_SUCCEEDED,
+			},
+		},
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	if err := followLogs(context.Background(), cli, "run-uid", 1, &stdout, &stderr); err != nil {
+		t.Fatalf("followLogs() error = %v", err)
+	}
+	if got := stdout.String(); got != "stdout one\nstdout two\n" {
+		t.Fatalf("stdout = %q, want each line once", got)
+	}
+	if got := stderr.String(); got != "stderr one\nstderr two\n" {
+		t.Fatalf("stderr = %q, want each line once", got)
+	}
+}
+
+func TestLogOutputSinceResetsInvalidOffset(t *testing.T) {
+	got, offset := logOutputSince("short", 10)
+	if got != "short" || offset != len("short") {
+		t.Fatalf("logOutputSince() = %q, %d; want %q, %d", got, offset, "short", len("short"))
+	}
+}
+
+type statusSequenceClient struct {
+	pb.RuntimeClient
+	responses []*pb.StatusResponse
+	index     int
+}
+
+func (c *statusSequenceClient) Status(
+	context.Context,
+	*pb.StatusRequest,
+	...grpc.CallOption,
+) (*pb.StatusResponse, error) {
+	response := c.responses[c.index]
+	if c.index < len(c.responses)-1 {
+		c.index++
+	}
+	return response, nil
+}


### PR DESCRIPTION
## Summary
- emit stdout and stderr independently for one-shot logs
- track separate stdout and stderr offsets in follow mode
- reset invalid offsets when retained runtime output shrinks instead of slicing out of bounds
- route output through Cobra writers and add regression coverage

## Verification
- GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/krt -count=1
- GOCACHE=/tmp/go-build make test
- git diff --check