### PR TITLE
fix(runtimed): distinguish lost executions from status errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Failure reasons are stable machine-readable strings used by retry policy and con
 |--------|---------|
 | `RuntimeError` | The runtime executed the Run but the workload failed. |
 | `RuntimeExecute` | Runtimed could not call Runtime Server `Execute`. |
+| `ExecutionLost` | Runtime Server no longer has the execution while the Run is still `Running`. |
 | `PrepareSource` | Runtimed could not prepare inline or repository source. |
 | `Timeout` | The Run exceeded `spec.timeout` or the Runtime Server reported a timeout. |
 | `Cancelled` | The user requested cancellation. |

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -155,7 +155,7 @@
   `kruntimes.io/RuntimedReady` heartbeat。
 - [ ] Stale reaper 返回 status update 错误，并统一 terminal condition 更新。
 - [x] 修复 scheduler 在检查 `NewManager` 错误前使用 `mgr` 的初始化顺序。
-- [ ] runtimed 主动区分 transient Status 错误和 execution `NotFound`。
+- [x] runtimed 主动区分 transient Status 错误和 execution `NotFound`。
 - [x] `krt run --wait` 正确处理 `Timeout` 和 `Cancelled`。
 - [ ] `krt logs` 同时处理 stdout/stderr，避免 stderr 重复和 offset 越界。
 - [ ] CLI 使用 Cobra command context，支持 kubeconfig/context、当前 namespace 和

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -17,6 +17,7 @@ const (
 	ReasonPrepareSource  = "PrepareSource"
 	ReasonRuntimeExecute = "RuntimeExecute"
 	ReasonRuntimeError   = "RuntimeError"
+	ReasonExecutionLost  = "ExecutionLost"
 	ReasonCancelled      = "Cancelled"
 	ReasonPodGone        = "PodGone"
 	ReasonPodTerminating = "PodTerminating"

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -101,6 +101,7 @@ func TestShouldRetry(t *testing.T) {
 		{3, ReasonRuntimeError, false},
 		{1, ReasonCancelled, false},
 		{1, ReasonTimeout, true},
+		{1, ReasonExecutionLost, true},
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s_attempt=%d", tt.reason, tt.attempt), func(t *testing.T) {

--- a/internal/runtimed/controller.go
+++ b/internal/runtimed/controller.go
@@ -330,7 +330,11 @@ func (c *Controller) reconcileRunningRecovered(ctx context.Context, run *v1alpha
 	resp, err := c.pollStatus(ctx, string(run.UID))
 	if err != nil {
 		ar := c.buildActiveRun(run)
-		return c.applyFailure(ctx, ar, runretry.ReasonRuntimeExecute, fmt.Sprintf("runtime Status after runtimed restart: %v", err))
+		if status.Code(err) == codes.NotFound {
+			return c.applyFailure(ctx, ar, runretry.ReasonExecutionLost, "runtime execution not found after runtimed restart")
+		}
+		c.addRecoveredRun(run)
+		return ctrl.Result{}, fmt.Errorf("runtime Status after runtimed restart: %w", err)
 	}
 
 	ar := c.addRecoveredRun(run)
@@ -379,7 +383,10 @@ func (c *Controller) reconcileRunningActive(ctx context.Context, ar *activeRun) 
 
 	resp, err := c.pollStatus(ctx, string(ar.run.UID))
 	if err != nil {
-		return ctrl.Result{}, nil
+		if status.Code(err) == codes.NotFound {
+			return c.applyFailure(ctx, ar, runretry.ReasonExecutionLost, "runtime execution not found")
+		}
+		return ctrl.Result{}, fmt.Errorf("runtime Status: %w", err)
 	}
 
 	switch resp.State {

--- a/internal/runtimed/controller_test.go
+++ b/internal/runtimed/controller_test.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
@@ -649,6 +650,121 @@ func TestReconcileRunningFailsWhenRecoveredExecutionMissing(t *testing.T) {
 	}
 	if updated.Status.Attempt != 1 {
 		t.Fatalf("attempt = %d, want 1", updated.Status.Attempt)
+	}
+	condition := meta.FindStatusCondition(updated.Status.Conditions, "Running")
+	if condition == nil || condition.Reason != runretry.ReasonExecutionLost {
+		t.Fatalf("Running condition = %#v, want reason %s", condition, runretry.ReasonExecutionLost)
+	}
+}
+
+func TestReconcileRunningRecoveredKeepsRunActiveOnTransientStatusError(t *testing.T) {
+	run := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "transient",
+			Namespace: "default",
+			UID:       "transient-uid",
+		},
+		Spec: v1alpha1.RunSpec{Runtime: "bash"},
+		Status: v1alpha1.RunStatus{
+			Phase:       v1alpha1.RunRunning,
+			AssignedPod: "pod-a",
+			StartTime:   &metav1.Time{Time: time.Now().Add(-time.Second)},
+		},
+	}
+	c := &Controller{
+		Hostname:   "pod-a",
+		runtimeCli: &fakeRuntimeClient{statusErr: status.Error(codes.Unavailable, "runtime unavailable")},
+	}
+
+	if _, err := c.reconcileRunningRecovered(t.Context(), run); status.Code(err) != codes.Unavailable {
+		t.Fatalf("reconcileRunningRecovered error = %v, want Unavailable", err)
+	}
+	if run.Status.Phase != v1alpha1.RunRunning {
+		t.Fatalf("phase = %s, want Running", run.Status.Phase)
+	}
+	if run.Status.Attempt != 0 {
+		t.Fatalf("attempt = %d, want unchanged", run.Status.Attempt)
+	}
+	if _, ok := c.activeRuns.Load(string(run.UID)); !ok {
+		t.Fatal("transient Status error should keep the recovered Run under active monitoring")
+	}
+}
+
+func TestReconcileRunningActiveDistinguishesStatusErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusErr  error
+		wantErr    codes.Code
+		wantPhase  v1alpha1.RunPhase
+		wantReason string
+	}{
+		{
+			name:      "transient",
+			statusErr: status.Error(codes.Unavailable, "runtime unavailable"),
+			wantErr:   codes.Unavailable,
+			wantPhase: v1alpha1.RunRunning,
+		},
+		{
+			name:       "execution lost",
+			statusErr:  status.Error(codes.NotFound, "execution not found"),
+			wantErr:    codes.OK,
+			wantPhase:  v1alpha1.RunFailed,
+			wantReason: runretry.ReasonExecutionLost,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := v1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatalf("add scheme: %v", err)
+			}
+			run := &v1alpha1.Run{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "active",
+					Namespace: "default",
+					UID:       "active-uid",
+				},
+				Spec: v1alpha1.RunSpec{Runtime: "bash"},
+				Status: v1alpha1.RunStatus{
+					Phase:       v1alpha1.RunRunning,
+					AssignedPod: "pod-a",
+					StartTime:   &metav1.Time{Time: time.Now().Add(-time.Second)},
+				},
+			}
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithStatusSubresource(&v1alpha1.Run{}).
+				WithObjects(run).
+				Build()
+			c := &Controller{
+				Client:     k8sClient,
+				Hostname:   "pod-a",
+				runtimeCli: &fakeRuntimeClient{statusErr: tt.statusErr},
+			}
+			ar := c.addRecoveredRun(run)
+
+			_, err := c.reconcileRunningActive(t.Context(), ar)
+			if status.Code(err) != tt.wantErr {
+				t.Fatalf("error = %v, want code %s", err, tt.wantErr)
+			}
+
+			var updated v1alpha1.Run
+			if err := k8sClient.Get(t.Context(), client.ObjectKeyFromObject(run), &updated); err != nil {
+				t.Fatalf("get run: %v", err)
+			}
+			if updated.Status.Phase != tt.wantPhase {
+				t.Fatalf("phase = %s, want %s", updated.Status.Phase, tt.wantPhase)
+			}
+			condition := meta.FindStatusCondition(updated.Status.Conditions, "Running")
+			if tt.wantReason == "" {
+				if condition != nil {
+					t.Fatalf("Running condition changed on transient error: %#v", condition)
+				}
+			} else if condition == nil || condition.Reason != tt.wantReason {
+				t.Fatalf("Running condition = %#v, want reason %s", condition, tt.wantReason)
+			}
+		})
 	}
 }
 

--- a/internal/runtimed/rleg/generic.go
+++ b/internal/runtimed/rleg/generic.go
@@ -7,6 +7,8 @@ import (
 
 	pb "github.com/kruntimes/kruntimes/api/runtime/v1"
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/klog/v2"
 )
 
@@ -151,6 +153,13 @@ func (g *GenericRLEG) relist(ctx context.Context) {
 		resp, err := g.statusProvider.Status(rctx, uid)
 		cancel()
 		if err != nil {
+			if status.Code(err) == codes.NotFound {
+				g.emit(&RunEvent{
+					Run:       rec.run,
+					EventType: RunExecutionLost,
+					OldState:  rec.lastState,
+				})
+			}
 			klog.V(4).Infof("RLEG Status(%s): %v", uid, err)
 			continue
 		}

--- a/internal/runtimed/rleg/generic_test.go
+++ b/internal/runtimed/rleg/generic_test.go
@@ -7,6 +7,8 @@ import (
 
 	pb "github.com/kruntimes/kruntimes/api/runtime/v1"
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -204,19 +206,44 @@ func TestRelist_NoChange(t *testing.T) {
 	}
 }
 
-func TestRelist_StatusError(t *testing.T) {
+func TestRelist_TransientStatusErrorDoesNotEmitEvent(t *testing.T) {
 	provider := &mockStatusProvider{
-		errors: map[string]error{"uid-1": context.DeadlineExceeded},
+		errors: map[string]error{"uid-1": status.Error(codes.Unavailable, "runtime unavailable")},
 	}
 	g := NewGenericRLEG(provider, 0)
 	run := newRun("test-run", "uid-1", 0)
 	g.AddRun(run)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
+	g.relist(t.Context())
 
-	// Should not panic on error.
-	g.relist(ctx)
+	select {
+	case ev := <-g.Events():
+		t.Fatalf("unexpected event for transient Status error: %#v", ev)
+	default:
+	}
+}
+
+func TestRelist_NotFoundEmitsExecutionLost(t *testing.T) {
+	provider := &mockStatusProvider{
+		errors: map[string]error{"uid-1": status.Error(codes.NotFound, "execution not found")},
+	}
+	g := NewGenericRLEG(provider, 0)
+	run := newRun("test-run", "uid-1", 0)
+	g.AddRun(run)
+
+	g.relist(t.Context())
+
+	select {
+	case ev := <-g.Events():
+		if ev.EventType != RunExecutionLost {
+			t.Fatalf("event type = %s, want %s", ev.EventType, RunExecutionLost)
+		}
+		if ev.Run != run {
+			t.Fatalf("event run = %p, want %p", ev.Run, run)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected execution-lost event")
+	}
 }
 
 func TestHealthy(t *testing.T) {

--- a/internal/runtimed/rleg/rleg.go
+++ b/internal/runtimed/rleg/rleg.go
@@ -19,6 +19,8 @@ const (
 	RunStateTransition RunEventType = "StateTransition"
 	// RunTimeout indicates a run exceeded its deadline.
 	RunTimeout RunEventType = "RunTimeout"
+	// RunExecutionLost indicates the runtime no longer knows the execution.
+	RunExecutionLost RunEventType = "ExecutionLost"
 )
 
 // RunEvent is emitted when a run's lifecycle state changes.


### PR DESCRIPTION
## Summary
- classify runtime Status NotFound as ExecutionLost and route it through the shared retry engine
- keep Runs active and return transient gRPC errors for controller-runtime backoff instead of marking executions failed
- trigger reconciliation when RLEG observes a missing execution while ignoring transient Status failures
- document the new failure reason and mark the readiness task complete

## Verification
- GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/runtimed/... ./internal/retry -count=1
- GOCACHE=/tmp/go-build make test
- git diff --check