### PR TITLE
fix(controller): harden stale run reaping

### DIFF
--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -151,9 +151,9 @@
 
 ## P1: Correctness and Operability
 
-- [ ] Stale reaper 同时检查 Kubernetes `PodReady` 和
+- [x] Stale reaper 同时检查 Kubernetes `PodReady` 和
   `kruntimes.io/RuntimedReady` heartbeat。
-- [ ] Stale reaper 返回 status update 错误，并统一 terminal condition 更新。
+- [x] Stale reaper 返回 status update 错误，并统一 terminal condition 更新。
 - [x] 修复 scheduler 在检查 `NewManager` 错误前使用 `mgr` 的初始化顺序。
 - [x] runtimed 主动区分 transient Status 错误和 execution `NotFound`。
 - [x] `krt run --wait` 正确处理 `Timeout` 和 `Cancelled`。

--- a/internal/controller/stale_reaper.go
+++ b/internal/controller/stale_reaper.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -17,6 +18,8 @@ import (
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 	runretry "github.com/kruntimes/kruntimes/internal/retry"
+	"github.com/kruntimes/kruntimes/internal/runstatus"
+	"github.com/kruntimes/kruntimes/internal/runtimepod"
 )
 
 // StaleRunReaper watches Running Runs and detects those assigned to
@@ -68,16 +71,20 @@ func (r *StaleRunReaper) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	err := r.Get(ctx, client.ObjectKey{Name: podName, Namespace: run.Namespace}, &pod)
 	if apierrors.IsNotFound(err) {
 		r.Log.Info("pod not found, marking run as stale", "run", run.Name, "pod", podName)
-		r.handleStaleRun(ctx, &run)
+		if err := r.handleStaleRun(ctx, &run, runretry.ReasonPodGone, "assigned pod was deleted"); err != nil {
+			return ctrl.Result{}, fmt.Errorf("update stale run status: %w", err)
+		}
 		return ctrl.Result{}, nil
 	}
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 
-	// Check if the pod is unhealthy and has been for longer than the threshold.
-	if r.isPodStale(&pod) {
-		r.handleStaleRun(ctx, &run)
+	stale, reason, message := r.stalePodState(&pod, time.Now())
+	if stale {
+		if err := r.handleStaleRun(ctx, &run, reason, message); err != nil {
+			return ctrl.Result{}, fmt.Errorf("update stale run status: %w", err)
+		}
 		return ctrl.Result{}, nil
 	}
 
@@ -85,39 +92,31 @@ func (r *StaleRunReaper) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	return ctrl.Result{RequeueAfter: r.StalenessThreshold}, nil
 }
 
-func (r *StaleRunReaper) isPodStale(pod *corev1.Pod) bool {
+func (r *StaleRunReaper) stalePodState(pod *corev1.Pod, now time.Time) (bool, string, string) {
 	if pod.DeletionTimestamp != nil {
-		return true
+		return true, runretry.ReasonPodTerminating, "assigned pod is terminating"
 	}
+
 	for _, cond := range pod.Status.Conditions {
-		if cond.Type == corev1.PodReady {
-			if cond.Status == corev1.ConditionTrue {
-				return false
-			}
-			return time.Since(cond.LastTransitionTime.Time) > r.StalenessThreshold
+		if cond.Type != corev1.PodReady {
+			continue
 		}
+		if cond.Status != corev1.ConditionTrue {
+			stale := r.StalenessThreshold <= 0 ||
+				now.Sub(cond.LastTransitionTime.Time) > r.StalenessThreshold
+			return stale, runretry.ReasonPodUnhealthy, "assigned pod is not ready"
+		}
+		if !runtimepod.FreshRuntimedReady(pod, now, r.StalenessThreshold) {
+			return true, runretry.ReasonPodUnhealthy, "assigned pod runtimed heartbeat is stale"
+		}
+		return false, "", ""
 	}
+
 	// No Ready condition yet — pod is initializing, not stale.
-	return false
+	return false, "", ""
 }
 
-func (r *StaleRunReaper) handleStaleRun(ctx context.Context, run *v1alpha1.Run) {
-	reason := runretry.ReasonPodGone
-	msg := "assigned pod was deleted"
-
-	// Determine failure reason.
-	var pod corev1.Pod
-	err := r.Get(ctx, client.ObjectKey{Name: run.Status.AssignedPod, Namespace: run.Namespace}, &pod)
-	if err == nil {
-		if pod.DeletionTimestamp != nil {
-			reason = runretry.ReasonPodTerminating
-			msg = "assigned pod is terminating"
-		} else {
-			reason = runretry.ReasonPodUnhealthy
-			msg = "assigned pod is not ready"
-		}
-	}
-
+func (r *StaleRunReaper) handleStaleRun(ctx context.Context, run *v1alpha1.Run, reason, msg string) error {
 	podName := run.Status.AssignedPod
 	policy := runretry.WithDefaults(run.Spec.RetryPolicy)
 	curAttempt := runretry.CurrentAttempt(run.Status.Attempt)
@@ -131,24 +130,25 @@ func (r *StaleRunReaper) handleStaleRun(ctx context.Context, run *v1alpha1.Run) 
 		meta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{
 			Type: "Running", Status: metav1.ConditionFalse, Reason: reason, Message: msg,
 		})
-		if r.Recorder != nil {
-			r.Recorder.Eventf(run, corev1.EventTypeWarning, "StaleRunRetrying",
-				"Pod %s is unhealthy (%s), rescheduling run for retry (attempt %d/%d, backoff %s)",
-				podName, reason, nextAttempt, policy.MaxAttempts, runretry.Backoff(policy, nextAttempt))
-		}
 	} else {
 		now := metav1.Now()
-		run.Status.Phase = v1alpha1.RunFailed
-		run.Status.Message = msg
-		run.Status.CompletionTime = &now
 		run.Status.Attempt = curAttempt
-		if r.Recorder != nil {
-			r.Recorder.Eventf(run, corev1.EventTypeWarning, "StaleRunFailed",
-				"Pod %s is unhealthy, marking run as failed: %s", podName, reason)
-		}
+		runstatus.SetTerminal(run, v1alpha1.RunFailed, reason, msg, now)
 	}
 
 	if err := r.Status().Update(ctx, run); err != nil {
-		r.Log.Error(err, "failed to update stale run", "run", run.Name)
+		return err
 	}
+	if r.Recorder == nil {
+		return nil
+	}
+	if run.Status.Phase == v1alpha1.RunPending {
+		r.Recorder.Eventf(run, corev1.EventTypeWarning, "StaleRunRetrying",
+			"Pod %s is unhealthy (%s), rescheduling run for retry (attempt %d/%d, backoff %s)",
+			podName, reason, run.Status.Attempt, policy.MaxAttempts, runretry.Backoff(policy, run.Status.Attempt))
+	} else {
+		r.Recorder.Eventf(run, corev1.EventTypeWarning, "StaleRunFailed",
+			"Pod %s is unhealthy, marking run as failed: %s", podName, reason)
+	}
+	return nil
 }

--- a/internal/controller/stale_reaper_test.go
+++ b/internal/controller/stale_reaper_test.go
@@ -2,13 +2,18 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 	runretry "github.com/kruntimes/kruntimes/internal/retry"
@@ -26,7 +31,9 @@ func TestStaleRunReaperRetriesUsingSharedRetryPolicy(t *testing.T) {
 		},
 	})
 
-	reaper.handleStaleRun(context.Background(), run)
+	if err := reaper.handleStaleRun(context.Background(), run, runretry.ReasonPodGone, "assigned pod was deleted"); err != nil {
+		t.Fatalf("handle stale run: %v", err)
+	}
 
 	updated := getRun(t, c, run)
 	if updated.Status.Phase != v1alpha1.RunPending {
@@ -58,7 +65,9 @@ func TestStaleRunReaperHonorsRetryableReasons(t *testing.T) {
 		},
 	})
 
-	reaper.handleStaleRun(context.Background(), run)
+	if err := reaper.handleStaleRun(context.Background(), run, runretry.ReasonPodGone, "assigned pod was deleted"); err != nil {
+		t.Fatalf("handle stale run: %v", err)
+	}
 
 	updated := getRun(t, c, run)
 	if updated.Status.Phase != v1alpha1.RunFailed {
@@ -67,6 +76,7 @@ func TestStaleRunReaperHonorsRetryableReasons(t *testing.T) {
 	if updated.Status.Attempt != 1 {
 		t.Fatalf("attempt = %d, want 1", updated.Status.Attempt)
 	}
+	assertFailedTerminalConditions(t, &updated, runretry.ReasonPodGone)
 }
 
 func TestStaleRunReaperDoesNotRetryWhenAttemptsExhausted(t *testing.T) {
@@ -82,7 +92,9 @@ func TestStaleRunReaperDoesNotRetryWhenAttemptsExhausted(t *testing.T) {
 		},
 	})
 
-	reaper.handleStaleRun(context.Background(), run)
+	if err := reaper.handleStaleRun(context.Background(), run, runretry.ReasonPodGone, "assigned pod was deleted"); err != nil {
+		t.Fatalf("handle stale run: %v", err)
+	}
 
 	updated := getRun(t, c, run)
 	if updated.Status.Phase != v1alpha1.RunFailed {
@@ -91,9 +103,150 @@ func TestStaleRunReaperDoesNotRetryWhenAttemptsExhausted(t *testing.T) {
 	if updated.Status.Attempt != 3 {
 		t.Fatalf("attempt = %d, want 3", updated.Status.Attempt)
 	}
+	assertFailedTerminalConditions(t, &updated, runretry.ReasonPodGone)
+}
+
+func TestStaleRunReaperChecksPodAndRuntimedReadiness(t *testing.T) {
+	now := time.Date(2026, time.June, 12, 12, 0, 0, 0, time.UTC)
+	threshold := 30 * time.Second
+	ready := metav1.NewTime(now.Add(-time.Minute))
+	freshProbe := metav1.NewTime(now.Add(-10 * time.Second))
+	staleProbe := metav1.NewTime(now.Add(-time.Minute))
+
+	tests := []struct {
+		name       string
+		conditions []corev1.PodCondition
+		wantStale  bool
+		wantMsg    string
+	}{
+		{
+			name: "both ready",
+			conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: ready},
+				{Type: v1alpha1.RuntimePodRuntimedReadyCondition, Status: corev1.ConditionTrue, LastProbeTime: freshProbe},
+			},
+		},
+		{
+			name: "stale runtimed heartbeat",
+			conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: ready},
+				{Type: v1alpha1.RuntimePodRuntimedReadyCondition, Status: corev1.ConditionTrue, LastProbeTime: staleProbe},
+			},
+			wantStale: true,
+			wantMsg:   "assigned pod runtimed heartbeat is stale",
+		},
+		{
+			name: "missing runtimed heartbeat",
+			conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: ready},
+			},
+			wantStale: true,
+			wantMsg:   "assigned pod runtimed heartbeat is stale",
+		},
+		{
+			name: "pod recently became unready",
+			conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse, LastTransitionTime: metav1.NewTime(now.Add(-10 * time.Second))},
+			},
+		},
+		{
+			name: "pod remained unready",
+			conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionFalse, LastTransitionTime: staleProbe},
+			},
+			wantStale: true,
+			wantMsg:   "assigned pod is not ready",
+		},
+	}
+
+	reaper := &StaleRunReaper{StalenessThreshold: threshold}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{Status: corev1.PodStatus{Conditions: tt.conditions}}
+			stale, reason, msg := reaper.stalePodState(pod, now)
+			if stale != tt.wantStale {
+				t.Fatalf("stale = %t, want %t", stale, tt.wantStale)
+			}
+			if !tt.wantStale {
+				return
+			}
+			if reason != runretry.ReasonPodUnhealthy {
+				t.Fatalf("reason = %q, want %q", reason, runretry.ReasonPodUnhealthy)
+			}
+			if msg != tt.wantMsg {
+				t.Fatalf("message = %q, want %q", msg, tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestStaleRunReaperReturnsStatusUpdateError(t *testing.T) {
+	statusErr := errors.New("status update failed")
+	run := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "run-a", Namespace: "default"},
+		Status: v1alpha1.RunStatus{
+			Phase:       v1alpha1.RunRunning,
+			AssignedPod: "runtime-a",
+		},
+	}
+	now := metav1.Now()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "runtime-a", Namespace: "default"},
+		Status: corev1.PodStatus{Conditions: []corev1.PodCondition{
+			{Type: corev1.PodReady, Status: corev1.ConditionTrue, LastTransitionTime: now},
+			{
+				Type:          v1alpha1.RuntimePodRuntimedReadyCondition,
+				Status:        corev1.ConditionTrue,
+				LastProbeTime: metav1.NewTime(now.Add(-time.Minute)),
+			},
+		}},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(staleReaperScheme(t)).
+		WithStatusSubresource(&v1alpha1.Run{}).
+		WithObjects(run, pod).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(
+				_ context.Context,
+				_ client.Client,
+				subResourceName string,
+				_ client.Object,
+				_ ...client.SubResourceUpdateOption,
+			) error {
+				if subResourceName == "status" {
+					return statusErr
+				}
+				return nil
+			},
+		}).
+		Build()
+	reaper := &StaleRunReaper{
+		Client:             c,
+		StalenessThreshold: 30 * time.Second,
+	}
+
+	_, err := reaper.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: run.Name, Namespace: run.Namespace},
+	})
+	if !errors.Is(err, statusErr) {
+		t.Fatalf("Reconcile error = %v, want %v", err, statusErr)
+	}
 }
 
 func newStaleReaperTest(t *testing.T, run *v1alpha1.Run) (*StaleRunReaper, client.Client, *v1alpha1.Run) {
+	t.Helper()
+
+	c := fake.NewClientBuilder().
+		WithScheme(staleReaperScheme(t)).
+		WithStatusSubresource(&v1alpha1.Run{}).
+		WithObjects(run).
+		Build()
+
+	return &StaleRunReaper{Client: c}, c, run
+}
+
+func staleReaperScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 
 	scheme := runtime.NewScheme()
@@ -103,14 +256,7 @@ func newStaleReaperTest(t *testing.T, run *v1alpha1.Run) (*StaleRunReaper, clien
 	if err := v1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add kruntimes scheme: %v", err)
 	}
-
-	c := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithStatusSubresource(&v1alpha1.Run{}).
-		WithObjects(run).
-		Build()
-
-	return &StaleRunReaper{Client: c}, c, run
+	return scheme
 }
 
 func getRun(t *testing.T, c client.Client, run *v1alpha1.Run) v1alpha1.Run {
@@ -130,4 +276,18 @@ func findCondition(conditions []metav1.Condition, typ string) *metav1.Condition 
 		}
 	}
 	return nil
+}
+
+func assertFailedTerminalConditions(t *testing.T, run *v1alpha1.Run, reason string) {
+	t.Helper()
+
+	if run.Status.CompletionTime == nil {
+		t.Fatal("completionTime is nil")
+	}
+	for _, typ := range []string{"Running", "Completed"} {
+		cond := findCondition(run.Status.Conditions, typ)
+		if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != reason {
+			t.Fatalf("%s condition = %#v, want false/%s", typ, cond, reason)
+		}
+	}
 }

--- a/internal/runstatus/status.go
+++ b/internal/runstatus/status.go
@@ -1,0 +1,27 @@
+package runstatus
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+const (
+	ConditionRunning   = "Running"
+	ConditionCompleted = "Completed"
+)
+
+// SetTerminal applies the common status fields and lifecycle conditions for a
+// terminal Run transition.
+func SetTerminal(run *v1alpha1.Run, phase v1alpha1.RunPhase, reason, message string, now metav1.Time) {
+	run.Status.Phase = phase
+	run.Status.Message = message
+	run.Status.CompletionTime = &now
+	meta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{
+		Type: ConditionRunning, Status: metav1.ConditionFalse, Reason: reason, Message: message,
+	})
+	meta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{
+		Type: ConditionCompleted, Status: metav1.ConditionFalse, Reason: reason, Message: message,
+	})
+}

--- a/internal/runstatus/status_test.go
+++ b/internal/runstatus/status_test.go
@@ -1,0 +1,37 @@
+package runstatus
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+func TestSetTerminalSetsCommonFieldsAndConditions(t *testing.T) {
+	run := &v1alpha1.Run{}
+	now := metav1.NewTime(time.Date(2026, time.June, 12, 12, 0, 0, 0, time.UTC))
+
+	SetTerminal(run, v1alpha1.RunFailed, "PodGone", "assigned pod was deleted", now)
+
+	if run.Status.Phase != v1alpha1.RunFailed {
+		t.Fatalf("phase = %s, want Failed", run.Status.Phase)
+	}
+	if run.Status.Message != "assigned pod was deleted" {
+		t.Fatalf("message = %q", run.Status.Message)
+	}
+	if run.Status.CompletionTime == nil || !run.Status.CompletionTime.Equal(&now) {
+		t.Fatalf("completionTime = %v, want %v", run.Status.CompletionTime, now)
+	}
+	for _, conditionType := range []string{ConditionRunning, ConditionCompleted} {
+		condition := meta.FindStatusCondition(run.Status.Conditions, conditionType)
+		if condition == nil ||
+			condition.Status != metav1.ConditionFalse ||
+			condition.Reason != "PodGone" ||
+			condition.Message != "assigned pod was deleted" {
+			t.Fatalf("%s condition = %#v", conditionType, condition)
+		}
+	}
+}

--- a/internal/runtimed/controller.go
+++ b/internal/runtimed/controller.go
@@ -36,6 +36,7 @@ import (
 	"github.com/kruntimes/kruntimes/internal/artifact"
 	"github.com/kruntimes/kruntimes/internal/execpath"
 	runretry "github.com/kruntimes/kruntimes/internal/retry"
+	"github.com/kruntimes/kruntimes/internal/runstatus"
 	rlegpkg "github.com/kruntimes/kruntimes/internal/runtimed/rleg"
 	"github.com/kruntimes/kruntimes/internal/runtimepod"
 )
@@ -586,15 +587,7 @@ func (c *Controller) applyTerminalWithOutput(
 	}
 
 	now := metav1.Now()
-	run.Status.Phase = phase
-	run.Status.Message = msg
-	run.Status.CompletionTime = &now
-	meta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{
-		Type: "Running", Status: metav1.ConditionFalse, Reason: reason, Message: msg,
-	})
-	meta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{
-		Type: "Completed", Status: metav1.ConditionFalse, Reason: reason, Message: msg,
-	})
+	runstatus.SetTerminal(run, phase, reason, msg, now)
 
 	if err := c.Status().Update(ctx, run); err != nil {
 		return ctrl.Result{}, err

--- a/internal/scheduler/reconciler.go
+++ b/internal/scheduler/reconciler.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 	runretry "github.com/kruntimes/kruntimes/internal/retry"
+	"github.com/kruntimes/kruntimes/internal/runstatus"
 	"github.com/kruntimes/kruntimes/internal/runtimepod"
 )
 
@@ -171,15 +172,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 func (r *RunReconciler) applyCancelled(ctx context.Context, run *v1alpha1.Run) (ctrl.Result, error) {
 	now := metav1.Now()
-	run.Status.Phase = v1alpha1.RunCancelled
-	run.Status.Message = "cancelled by user"
-	run.Status.CompletionTime = &now
-	meta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{
-		Type: "Running", Status: metav1.ConditionFalse, Reason: runretry.ReasonCancelled, Message: "cancelled by user",
-	})
-	meta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{
-		Type: "Completed", Status: metav1.ConditionFalse, Reason: runretry.ReasonCancelled, Message: "cancelled by user",
-	})
+	runstatus.SetTerminal(run, v1alpha1.RunCancelled, runretry.ReasonCancelled, "cancelled by user", now)
 	if err := r.Status().Update(ctx, run); err != nil {
 		if apierrors.IsConflict(err) {
 			return ctrl.Result{Requeue: true}, nil


### PR DESCRIPTION
## Summary
- require both Kubernetes PodReady and a fresh kruntimes.io/RuntimedReady heartbeat before treating assigned Runtime Pods as healthy
- propagate stale Run status update failures to controller-runtime and emit events only after persistence succeeds
- normalize failure and cancellation terminal conditions through a shared runstatus helper
- add direct and caller-level regression coverage

## Verification
- GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/controller ./internal/runstatus ./internal/runtimed ./internal/scheduler -count=1
- GOCACHE=/tmp/go-build make test
- git diff --check