### PR TITLE
fix(python): install image dependencies from lockfile

### DIFF
--- a/Dockerfile.python-runtime
+++ b/Dockerfile.python-runtime
@@ -1,15 +1,32 @@
+FROM ghcr.io/astral-sh/uv:0.11.16 AS uv
+
+FROM python:3.14-slim AS dependencies
+
+COPY --from=uv /uv /bin/uv
+
+WORKDIR /app
+
+COPY runtimes/python/pyproject.toml runtimes/python/uv.lock ./
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=never
+
+RUN uv sync --locked --no-dev --no-install-project
+
 FROM python:3.14-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir grpcio protobuf
-
 WORKDIR /app
 
+COPY --from=dependencies /app/.venv ./.venv
 COPY runtimes/python/pb ./pb
 COPY runtimes/python/server.py runtimes/python/cmd/main.py ./
+
+ENV PATH="/app/.venv/bin:$PATH"
 
 EXPOSE 9092
 ENTRYPOINT ["python", "main.py"]

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -139,7 +139,7 @@
 
 - [ ] 升级 Go toolchain 和受影响依赖，并让 `govulncheck` 通过。
 - [ ] Docker 基础镜像固定到明确 patch version 和 digest。
-- [ ] Python 镜像通过 `uv.lock` 安装依赖，不直接安装未固定版本。
+- [x] Python 镜像通过 `uv.lock` 安装依赖，不直接安装未固定版本。
 - [ ] 固定 Makefile 中 controller-gen、setup-envtest、golangci-lint、
   protoc plugins 和 uv 的版本。
 - [ ] 发布镜像生成 SBOM，并使用 cosign 或等价机制签名。

--- a/runtimes/python/pyproject.toml
+++ b/runtimes/python/pyproject.toml
@@ -5,5 +5,10 @@ description = "Add your description here"
 requires-python = ">=3.12"
 dependencies = [
     "grpcio>=1.80.0",
+    "protobuf>=6.33.6",
+]
+
+[dependency-groups]
+dev = [
     "grpcio-tools>=1.80.0",
 ]

--- a/runtimes/python/uv.lock
+++ b/runtimes/python/uv.lock
@@ -107,14 +107,22 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "grpcio" },
+    { name = "protobuf" },
+]
+
+[package.dev-dependencies]
+dev = [
     { name = "grpcio-tools" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "grpcio", specifier = ">=1.80.0" },
-    { name = "grpcio-tools", specifier = ">=1.80.0" },
+    { name = "protobuf", specifier = ">=6.33.6" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "grpcio-tools", specifier = ">=1.80.0" }]
 
 [[package]]
 name = "setuptools"


### PR DESCRIPTION
## Summary
- build the Python runtime virtualenv with pinned uv and uv sync --locked --no-dev
- copy only the production virtualenv into the final image
- make protobuf an explicit runtime dependency and move grpcio-tools to the dev dependency group
- mark locked Python image dependencies complete in the readiness checklist

## Verification
- UV_CACHE_DIR=/tmp/uv-cache uv lock --check
- UV_CACHE_DIR=/tmp/uv-cache uv run python -m unittest server_test -v
- make docker-build-python-runtime
- docker image assertion: grpcio 1.80.0, protobuf 6.33.6, grpcio-tools absent
- git diff --check