### PR TITLE
feat: add real readiness checks

### DIFF
--- a/Dockerfile.bash-runtime
+++ b/Dockerfile.bash-runtime
@@ -7,4 +7,5 @@ RUN CGO_ENABLED=0 go build -o bash-runtime ./runtimes/bash/cmd
 
 FROM ubuntu:latest
 COPY --from=builder /app/bash-runtime /bash-runtime
+USER 65532
 ENTRYPOINT ["/bash-runtime"]

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -7,4 +7,5 @@ RUN CGO_ENABLED=0 go build -o controller ./cmd/controller
 
 FROM scratch
 COPY --from=builder /app/controller /controller
+USER 65532
 ENTRYPOINT ["/controller"]

--- a/Dockerfile.python-runtime
+++ b/Dockerfile.python-runtime
@@ -29,4 +29,5 @@ COPY runtimes/python/server.py runtimes/python/cmd/main.py ./
 ENV PATH="/app/.venv/bin:$PATH"
 
 EXPOSE 9092
+USER 65532
 ENTRYPOINT ["python", "main.py"]

--- a/Dockerfile.scheduler
+++ b/Dockerfile.scheduler
@@ -7,4 +7,5 @@ RUN CGO_ENABLED=0 go build -o scheduler ./cmd/scheduler
 
 FROM scratch
 COPY --from=builder /app/scheduler /scheduler
+USER 65532
 ENTRYPOINT ["/scheduler"]

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"net/http"
 	"os"
 	"time"
 
@@ -11,11 +10,13 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 	"github.com/kruntimes/kruntimes/internal/controller"
+	"github.com/kruntimes/kruntimes/internal/healthcheck"
 )
 
 var (
@@ -62,8 +63,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	_ = mgr.AddHealthzCheck("healthz", func(_ *http.Request) error { return nil })
-	_ = mgr.AddReadyzCheck("readyz", func(_ *http.Request) error { return nil })
+	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to register health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck(
+		"kubernetes-api",
+		healthcheck.KubernetesAPI(mgr.GetAPIReader(), &v1alpha1.RuntimeList{}),
+	); err != nil {
+		setupLog.Error(err, "unable to register readiness check")
+		os.Exit(1)
+	}
 
 	reconciler := &controller.RuntimeReconciler{
 		Client:             mgr.GetClient(),

--- a/cmd/runtimed/main.go
+++ b/cmd/runtimed/main.go
@@ -8,19 +8,25 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	pb "github.com/kruntimes/kruntimes/api/runtime/v1"
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 	"github.com/kruntimes/kruntimes/internal/artifact"
 	artifactfs "github.com/kruntimes/kruntimes/internal/artifact/filesystem"
 	artifacts3 "github.com/kruntimes/kruntimes/internal/artifact/s3"
+	"github.com/kruntimes/kruntimes/internal/healthcheck"
 	"github.com/kruntimes/kruntimes/internal/runtimed"
 )
 
@@ -95,6 +101,33 @@ func main() {
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+	runtimeHealthConn, err := grpc.NewClient(
+		runtimeEndpoint,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		setupLog.Error(err, "unable to create runtime health client")
+		os.Exit(1)
+	}
+	defer runtimeHealthConn.Close()
+	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to register health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck(
+		"kubernetes-api",
+		healthcheck.KubernetesAPI(mgr.GetAPIReader(), &v1alpha1.RunList{}),
+	); err != nil {
+		setupLog.Error(err, "unable to register Kubernetes readiness check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck(
+		"runtime",
+		healthcheck.Runtime(pb.NewRuntimeClient(runtimeHealthConn), 2*time.Second),
+	); err != nil {
+		setupLog.Error(err, "unable to register runtime readiness check")
 		os.Exit(1)
 	}
 

--- a/cmd/scheduler/main.go
+++ b/cmd/scheduler/main.go
@@ -2,17 +2,18 @@ package main
 
 import (
 	"flag"
-	"net/http"
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	"github.com/kruntimes/kruntimes/internal/healthcheck"
 	"github.com/kruntimes/kruntimes/internal/scheduler"
 )
 
@@ -51,11 +52,14 @@ func main() {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
 	}
-	if err := mgr.AddHealthzCheck("healthz", func(_ *http.Request) error { return nil }); err != nil {
+	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to register health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", func(_ *http.Request) error { return nil }); err != nil {
+	if err := mgr.AddReadyzCheck(
+		"kubernetes-api",
+		healthcheck.KubernetesAPI(mgr.GetAPIReader(), &v1alpha1.RunList{}),
+	); err != nil {
 		setupLog.Error(err, "unable to register readiness check")
 		os.Exit(1)
 	}

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -160,7 +160,7 @@
 - [x] `krt logs` 同时处理 stdout/stderr，避免 stderr 重复和 offset 越界。
 - [ ] CLI 使用 Cobra command context，支持 kubeconfig/context、当前 namespace 和
   `json`/`yaml` 输出。
-- [ ] 增加真实 readiness check，而不是固定返回成功。
+- [x] 增加真实 readiness check，而不是固定返回成功。
 - [ ] 为 CRD 增加 CEL 校验和字段大小限制。
 - [ ] 为 Run/Workflow conditions 使用 Kubernetes list-map markers。
 - [ ] 补齐 queue time、dispatch latency、retry、failure 和 active Run metrics。

--- a/internal/controller/runtime_controller.go
+++ b/internal/controller/runtime_controller.go
@@ -170,6 +170,23 @@ func (r *RuntimeReconciler) buildDeployment(rt *v1alpha1.Runtime) *appsv1.Deploy
 			fmt.Sprintf("--runtime-endpoint=127.0.0.1:%d", port),
 			"--status-addr=:9093",
 		},
+		Ports: []corev1.ContainerPort{
+			{Name: "health", ContainerPort: 9094, Protocol: corev1.ProtocolTCP},
+		},
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromInt32(9094)},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       10,
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{Path: "/readyz", Port: intstr.FromInt32(9094)},
+			},
+			InitialDelaySeconds: 1,
+			PeriodSeconds:       5,
+		},
 		Env: []corev1.EnvVar{
 			{
 				Name: "HOSTNAME",

--- a/internal/controller/runtime_controller_test.go
+++ b/internal/controller/runtime_controller_test.go
@@ -47,6 +47,19 @@ func TestBuildDeploymentAddsCapacityAnnotationsAndWorkers(t *testing.T) {
 	if !slices.Contains(daemon.Args, "--runtime-name=bash") {
 		t.Fatalf("daemon args = %v, want runtime name", daemon.Args)
 	}
+	if len(daemon.Ports) != 1 || daemon.Ports[0].Name != "health" || daemon.Ports[0].ContainerPort != 9094 {
+		t.Fatalf("daemon ports = %v, want health port 9094", daemon.Ports)
+	}
+	if daemon.LivenessProbe == nil ||
+		daemon.LivenessProbe.HTTPGet == nil ||
+		daemon.LivenessProbe.HTTPGet.Path != "/healthz" {
+		t.Fatalf("daemon liveness probe = %#v, want /healthz", daemon.LivenessProbe)
+	}
+	if daemon.ReadinessProbe == nil ||
+		daemon.ReadinessProbe.HTTPGet == nil ||
+		daemon.ReadinessProbe.HTTPGet.Path != "/readyz" {
+		t.Fatalf("daemon readiness probe = %#v, want /readyz", daemon.ReadinessProbe)
+	}
 
 	for _, container := range deploy.Spec.Template.Spec.Containers {
 		if container.SecurityContext == nil {

--- a/internal/healthcheck/checks.go
+++ b/internal/healthcheck/checks.go
@@ -1,0 +1,56 @@
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"google.golang.org/grpc"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+
+	pb "github.com/kruntimes/kruntimes/api/runtime/v1"
+)
+
+type runtimeHealthClient interface {
+	Health(context.Context, *pb.HealthRequest, ...grpc.CallOption) (*pb.HealthResponse, error)
+}
+
+// KubernetesAPI checks that the component can read its primary API resource.
+func KubernetesAPI(reader client.Reader, prototype client.ObjectList) healthz.Checker {
+	return func(req *http.Request) error {
+		list, ok := prototype.DeepCopyObject().(client.ObjectList)
+		if !ok {
+			return fmt.Errorf("copy readiness list %T", prototype)
+		}
+		if err := reader.List(req.Context(), list, client.Limit(1)); err != nil {
+			return fmt.Errorf("query Kubernetes API: %w", err)
+		}
+		return nil
+	}
+}
+
+// Runtime checks that the local Runtime Server answers its Health RPC.
+func Runtime(runtimeClient runtimeHealthClient, timeout time.Duration) healthz.Checker {
+	return func(req *http.Request) error {
+		ctx := req.Context()
+		cancel := func() {}
+		if timeout > 0 {
+			ctx, cancel = context.WithTimeout(ctx, timeout)
+		}
+		defer cancel()
+
+		resp, err := runtimeClient.Health(ctx, &pb.HealthRequest{})
+		if err != nil {
+			return fmt.Errorf("runtime Health: %w", err)
+		}
+		if resp == nil {
+			return fmt.Errorf("runtime Health returned nil response")
+		}
+		if !resp.GetHealthy() {
+			return fmt.Errorf("runtime unhealthy: %s", resp.GetMessage())
+		}
+		return nil
+	}
+}

--- a/internal/healthcheck/checks_test.go
+++ b/internal/healthcheck/checks_test.go
@@ -1,0 +1,80 @@
+package healthcheck
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	pb "github.com/kruntimes/kruntimes/api/runtime/v1"
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+func TestKubernetesAPI(t *testing.T) {
+	wantErr := errors.New("api unavailable")
+	reader := &readerStub{listErr: wantErr}
+	check := KubernetesAPI(reader, &v1alpha1.RunList{})
+
+	err := check(httptest.NewRequest("GET", "/readyz", nil))
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("check error = %v, want %v", err, wantErr)
+	}
+	if reader.list == nil {
+		t.Fatal("readiness check did not list a resource")
+	}
+}
+
+func TestRuntime(t *testing.T) {
+	tests := []struct {
+		name    string
+		resp    *pb.HealthResponse
+		err     error
+		wantErr bool
+	}{
+		{name: "healthy", resp: &pb.HealthResponse{Healthy: true}},
+		{name: "nil response", wantErr: true},
+		{name: "unhealthy", resp: &pb.HealthResponse{Message: "not ready"}, wantErr: true},
+		{name: "rpc error", err: errors.New("connection refused"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			check := Runtime(&runtimeHealthStub{resp: tt.resp, err: tt.err}, time.Second)
+			err := check(httptest.NewRequest("GET", "/readyz", nil))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("check error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+type readerStub struct {
+	listErr error
+	list    client.ObjectList
+}
+
+func (r *readerStub) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	return nil
+}
+
+func (r *readerStub) List(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
+	r.list = list
+	return r.listErr
+}
+
+type runtimeHealthStub struct {
+	resp *pb.HealthResponse
+	err  error
+}
+
+func (r *runtimeHealthStub) Health(
+	context.Context,
+	*pb.HealthRequest,
+	...grpc.CallOption,
+) (*pb.HealthResponse, error) {
+	return r.resp, r.err
+}


### PR DESCRIPTION
## Summary
- replace placeholder health checks with Kubernetes API readiness checks for controller/scheduler/runtimed
- add runtimed health/readiness probes that also check the local runtime Health RPC
- set USER 65532 on controller, scheduler, bash runtime, and python runtime images so runAsNonRoot pods start under the hardened chart securityContext
- mark the readiness roadmap item done

## Validation
- GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/healthcheck ./internal/controller ./cmd/scheduler ./cmd/controller ./cmd/runtimed -count=1
- GOCACHE=/tmp/go-build make test
- GOCACHE=/tmp/go-build make e2e

## Notes
- The scheduled E2E failure was caused by deployments timing out because images did not declare a non-root USER while pods require runAsNonRoot. This PR fixes that class of failure.