### PR TITLE
fix(bash): harden execution lifecycle

### DIFF
--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -48,11 +48,14 @@
 当前 Bash Runtime 在执行 goroutine 与 `Status`、`List`、`Cancel`、重复
 `Execute` 之间存在真实数据竞争，已由 `go test -race` 复现。
 
-- [ ] 为每个 execution 建立完整的并发保护和不可变状态快照。
-- [ ] 为 stdout/stderr 设置有界缓冲，禁止无限内存增长。
+- [x] 为 Bash Runtime 每个 execution 建立完整的并发保护和不可变状态快照。
+- [ ] 为 Python Runtime 每个 execution 建立完整的并发保护和不可变状态快照。
+- [x] 为 Bash Runtime stdout/stderr 设置有界缓冲，禁止无限内存增长。
+- [ ] 为 Python Runtime stdout/stderr 设置有界缓冲，禁止无限内存增长。
 - [x] 为 Runtime API 增加 execution `Forget` 生命周期。
 - [x] Run 完成后清理 `/workspace/<runUID>`，同时保留制品上传所需顺序。
-- [ ] 对 Bash/Python 的取消和超时终止整个进程组，并等待退出。
+- [x] 对 Bash Runtime 的取消和超时终止整个进程组，并等待退出。
+- [ ] 对 Python Runtime 的取消和超时终止整个进程组，并等待退出。
 - [ ] 修复 Python Runtime 中共享 task 状态的并发访问。
 - [x] 明确 Python handler 模式的隔离方案；在未隔离前标记为 trusted-code only。
 - [x] 将 `workspace.sizeLimit` 实际应用到 Runtime Pod 的 `emptyDir`。

--- a/runtimes/bash/server.go
+++ b/runtimes/bash/server.go
@@ -28,7 +28,6 @@ const (
 )
 
 type boundedBuffer struct {
-	mu        sync.RWMutex
 	buffer    bytes.Buffer
 	limit     int
 	truncated bool
@@ -39,9 +38,6 @@ func newBoundedBuffer(limit int) boundedBuffer {
 }
 
 func (b *boundedBuffer) Write(p []byte) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
 	if b.limit <= 0 {
 		b.truncated = b.truncated || len(p) > 0
 		return len(p), nil
@@ -58,9 +54,6 @@ func (b *boundedBuffer) Write(p []byte) (int, error) {
 }
 
 func (b *boundedBuffer) String() string {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-
 	output := b.buffer.String()
 	if b.truncated {
 		output += outputTruncatedMarker
@@ -77,6 +70,20 @@ type executionEntry struct {
 	stderr   boundedBuffer
 	cancel   context.CancelFunc
 	done     chan struct{}
+}
+
+type executionOutput struct {
+	entry  *executionEntry
+	stderr bool
+}
+
+func (w executionOutput) Write(p []byte) (int, error) {
+	w.entry.mu.Lock()
+	defer w.entry.mu.Unlock()
+	if w.stderr {
+		return w.entry.stderr.Write(p)
+	}
+	return w.entry.stdout.Write(p)
 }
 
 func newExecutionEntry(cancel context.CancelFunc, outputLimit int) *executionEntry {
@@ -99,18 +106,15 @@ func (e *executionEntry) complete(state pb.ExecutionState, exitCode int32, errMs
 
 func (e *executionEntry) snapshot(id string) *pb.StatusResponse {
 	e.mu.RLock()
-	state := e.state
-	exitCode := e.exitCode
-	errMsg := e.errMsg
-	e.mu.RUnlock()
+	defer e.mu.RUnlock()
 
 	return &pb.StatusResponse{
 		Id:           id,
-		State:        state,
-		ExitCode:     exitCode,
+		State:        e.state,
+		ExitCode:     e.exitCode,
 		Stdout:       e.stdout.String(),
 		Stderr:       e.stderr.String(),
-		ErrorMessage: errMsg,
+		ErrorMessage: e.errMsg,
 	}
 }
 
@@ -261,8 +265,8 @@ func (s *Server) execute(ctx context.Context, req *pb.ExecuteRequest, entry *exe
 		return
 	}
 	cmd.Dir = workDir
-	cmd.Stdout = &entry.stdout
-	cmd.Stderr = &entry.stderr
+	cmd.Stdout = executionOutput{entry: entry}
+	cmd.Stderr = executionOutput{entry: entry, stderr: true}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	for k, v := range req.Env {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
@@ -288,21 +292,7 @@ func (s *Server) execute(ctx context.Context, req *pb.ExecuteRequest, entry *exe
 	case runErr = <-waitCh:
 		entry.complete(commandResult(runErr))
 	case <-ctx.Done():
-		terminateProcessGroup(cmd.Process.Pid, syscall.SIGTERM)
-		timer := time.NewTimer(processTerminationGrace)
-		select {
-		case runErr = <-waitCh:
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
-		case <-timer.C:
-			terminateProcessGroup(cmd.Process.Pid, syscall.SIGKILL)
-			runErr = <-waitCh
-		}
-		_ = runErr
+		runErr = terminateProcessGroupAndWait(cmd.Process.Pid, waitCh, processTerminationGrace)
 		entry.complete(cancelledResult(ctx.Err()))
 	}
 
@@ -370,4 +360,42 @@ func terminateProcessGroup(pid int, signal syscall.Signal) {
 	if err := syscall.Kill(-pid, signal); err != nil && !errors.Is(err, syscall.ESRCH) {
 		klog.V(2).Infof("Failed to signal process group %d: %v", pid, err)
 	}
+}
+
+func terminateProcessGroupAndWait(pid int, waitCh <-chan error, grace time.Duration) error {
+	terminateProcessGroup(pid, syscall.SIGTERM)
+
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	var (
+		commandDone bool
+		groupDone   bool
+		waitErr     error
+		graceC      = timer.C
+	)
+	for !commandDone || !groupDone {
+		select {
+		case waitErr = <-waitCh:
+			commandDone = true
+			waitCh = nil
+			groupDone = !processGroupExists(pid)
+		case <-ticker.C:
+			groupDone = !processGroupExists(pid)
+		case <-graceC:
+			terminateProcessGroup(pid, syscall.SIGKILL)
+			graceC = nil
+		}
+	}
+	return waitErr
+}
+
+func processGroupExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(-pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
 }

--- a/runtimes/bash/server_test.go
+++ b/runtimes/bash/server_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -315,8 +316,11 @@ func TestOutputIsBounded(t *testing.T) {
 
 	ctx := context.Background()
 	if _, err := client.Execute(ctx, &pb.ExecuteRequest{
-		Id:   "bounded-output",
-		Args: []string{"head -c 4096 /dev/zero | tr '\\0' x"},
+		Id: "bounded-output",
+		Args: []string{
+			"head -c 4096 /dev/zero | tr '\\0' x",
+			"head -c 4096 /dev/zero | tr '\\0' y >&2",
+		},
 	}); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -330,6 +334,99 @@ func TestOutputIsBounded(t *testing.T) {
 	}
 	if got, want := len(strings.TrimSuffix(resp.Stdout, outputTruncatedMarker)), outputLimit; got != want {
 		t.Fatalf("retained stdout bytes = %d, want %d", got, want)
+	}
+	if !strings.HasSuffix(resp.Stderr, outputTruncatedMarker) {
+		t.Fatalf("stderr does not contain truncation marker: %q", resp.Stderr)
+	}
+	if got, want := len(strings.TrimSuffix(resp.Stderr, outputTruncatedMarker)), outputLimit; got != want {
+		t.Fatalf("retained stderr bytes = %d, want %d", got, want)
+	}
+}
+
+func TestStatusSnapshotIsImmutable(t *testing.T) {
+	_, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	entry := newExecutionEntry(cancel, 64)
+	stdout := executionOutput{entry: entry}
+
+	if _, err := stdout.Write([]byte("before")); err != nil {
+		t.Fatalf("write initial output: %v", err)
+	}
+	snapshot := entry.snapshot("immutable")
+	if _, err := stdout.Write([]byte("-after")); err != nil {
+		t.Fatalf("write later output: %v", err)
+	}
+	entry.complete(pb.ExecutionState_EXECUTION_STATE_SUCCEEDED, 0, "")
+
+	if snapshot.State != pb.ExecutionState_EXECUTION_STATE_RUNNING {
+		t.Fatalf("snapshot state = %v, want running", snapshot.State)
+	}
+	if snapshot.Stdout != "before" {
+		t.Fatalf("snapshot stdout = %q, want immutable initial output", snapshot.Stdout)
+	}
+	current := entry.snapshot("immutable")
+	if current.State != pb.ExecutionState_EXECUTION_STATE_SUCCEEDED {
+		t.Fatalf("current state = %v, want succeeded", current.State)
+	}
+	if current.Stdout != "before-after" {
+		t.Fatalf("current stdout = %q, want all output", current.Stdout)
+	}
+}
+
+func TestConcurrentStatusListAndReplacement(t *testing.T) {
+	client, cleanup := startTestServerWithOutputLimit(t, 256)
+	defer cleanup()
+
+	ctx := context.Background()
+	if _, err := client.Execute(ctx, &pb.ExecuteRequest{
+		Id:   "concurrent",
+		Args: []string{"while :; do echo stdout; echo stderr >&2; done"},
+	}); err != nil {
+		t.Fatalf("initial Execute: %v", err)
+	}
+
+	start := make(chan struct{})
+	errCh := make(chan error, 16)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(list bool) {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 100; j++ {
+				var err error
+				if list {
+					_, err = client.List(ctx, &pb.ListRequest{})
+				} else {
+					_, err = client.Status(ctx, &pb.StatusRequest{Id: "concurrent"})
+				}
+				if err != nil {
+					errCh <- err
+					return
+				}
+			}
+		}(i%2 == 0)
+	}
+	close(start)
+
+	if _, err := client.Execute(ctx, &pb.ExecuteRequest{
+		Id:   "concurrent",
+		Args: []string{"printf replacement"},
+	}); err != nil {
+		t.Fatalf("replacement Execute: %v", err)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Errorf("concurrent status operation: %v", err)
+	}
+
+	resp := waitForTerminalStatus(t, client, "concurrent")
+	if resp.State != pb.ExecutionState_EXECUTION_STATE_SUCCEEDED {
+		t.Fatalf("replacement state = %v, want succeeded: %s", resp.State, resp.ErrorMessage)
+	}
+	if resp.Stdout != "replacement" {
+		t.Fatalf("replacement stdout = %q", resp.Stdout)
 	}
 }
 
@@ -377,6 +474,60 @@ func TestCancelTerminatesProcessGroup(t *testing.T) {
 	t.Fatalf("child process %d still exists after cancellation", childPID)
 }
 
+func TestCancelKillsProcessIgnoringSIGTERM(t *testing.T) {
+	client, cleanup := startTestServer(t)
+	defer cleanup()
+
+	workDir := t.TempDir()
+	ctx := context.Background()
+	if _, err := client.Execute(ctx, &pb.ExecuteRequest{
+		Id:         "cancel-stubborn-process",
+		WorkingDir: workDir,
+		Args:       []string{"(trap '' TERM; while :; do sleep 30; done) & echo $! > child.pid; wait"},
+	}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	childPID := waitForPIDFile(t, filepath.Join(workDir, "child.pid"))
+
+	started := time.Now()
+	if _, err := client.Cancel(ctx, &pb.CancelRequest{Id: "cancel-stubborn-process"}); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if elapsed := time.Since(started); elapsed < processTerminationGrace {
+		t.Fatalf("Cancel returned after %v, before termination grace %v", elapsed, processTerminationGrace)
+	}
+	waitForProcessExit(t, childPID)
+}
+
+func TestTimeoutKillsProcessGroupAndWaits(t *testing.T) {
+	client, cleanup := startTestServer(t)
+	defer cleanup()
+
+	workDir := t.TempDir()
+	ctx := context.Background()
+	if _, err := client.Execute(ctx, &pb.ExecuteRequest{
+		Id:             "timeout-process-group",
+		WorkingDir:     workDir,
+		TimeoutSeconds: 1,
+		Args:           []string{"(trap '' TERM; while :; do sleep 30; done) & echo $! > child.pid; wait"},
+	}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	childPID := waitForPIDFile(t, filepath.Join(workDir, "child.pid"))
+
+	resp := waitForTerminalStatus(t, client, "timeout-process-group")
+	if resp.State != pb.ExecutionState_EXECUTION_STATE_FAILED {
+		t.Fatalf("state = %v, want failed", resp.State)
+	}
+	if resp.ErrorMessage != "timeout" {
+		t.Fatalf("error message = %q, want timeout", resp.ErrorMessage)
+	}
+	if resp.ExitCode != -1 {
+		t.Fatalf("exit code = %d, want -1", resp.ExitCode)
+	}
+	waitForProcessExit(t, childPID)
+}
+
 func TestRejectsEscapingEntrypoint(t *testing.T) {
 	client, cleanup := startTestServer(t)
 	defer cleanup()
@@ -419,4 +570,32 @@ func waitForTerminalStatus(t *testing.T, client pb.RuntimeClient, id string) *pb
 	}
 	t.Fatalf("timed out waiting for execution %s", id)
 	return nil
+}
+
+func waitForPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); {
+		content, err := os.ReadFile(path)
+		if err == nil {
+			pid, err := strconv.Atoi(strings.TrimSpace(string(content)))
+			if err != nil {
+				t.Fatalf("parse pid from %s: %v", path, err)
+			}
+			return pid
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("pid file %s was not written", path)
+	return 0
+}
+
+func waitForProcessExit(t *testing.T, pid int) {
+	t.Helper()
+	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); {
+		if err := syscall.Kill(pid, 0); errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("process %d still exists", pid)
 }


### PR DESCRIPTION
## Summary
- serialize Bash execution output through the execution lock so Status/List snapshots are immutable and race-free
- keep bounded stdout and stderr buffers under the same execution lock
- make cancellation and timeout terminate the whole process group, escalate to SIGKILL after the grace period, and wait for the group to exit
- split the roadmap checklist so this PR marks only the Bash runtime portions done; Python runtime items remain open

## Validation
- GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./runtimes/bash -count=1
- GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test -race ./runtimes/bash -count=1
- GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./runtimes/bash ./runtimes/bash/cmd ./internal/runtimed -count=1
- GOCACHE=/tmp/go-build make test