### PR TITLE
fix(python): harden execution lifecycle

### DIFF
--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -49,14 +49,14 @@
 `Execute` 之间存在真实数据竞争，已由 `go test -race` 复现。
 
 - [x] 为 Bash Runtime 每个 execution 建立完整的并发保护和不可变状态快照。
-- [ ] 为 Python Runtime 每个 execution 建立完整的并发保护和不可变状态快照。
+- [x] 为 Python Runtime 每个 execution 建立完整的并发保护和不可变状态快照。
 - [x] 为 Bash Runtime stdout/stderr 设置有界缓冲，禁止无限内存增长。
 - [ ] 为 Python Runtime stdout/stderr 设置有界缓冲，禁止无限内存增长。
 - [x] 为 Runtime API 增加 execution `Forget` 生命周期。
 - [x] Run 完成后清理 `/workspace/<runUID>`，同时保留制品上传所需顺序。
 - [x] 对 Bash Runtime 的取消和超时终止整个进程组，并等待退出。
-- [ ] 对 Python Runtime 的取消和超时终止整个进程组，并等待退出。
-- [ ] 修复 Python Runtime 中共享 task 状态的并发访问。
+- [x] 对 Python Runtime 的取消和超时终止整个进程组，并等待退出。
+- [x] 修复 Python Runtime 中共享 task 状态的并发访问。
 - [x] 明确 Python handler 模式的隔离方案；在未隔离前标记为 trusted-code only。
 - [x] 将 `workspace.sizeLimit` 实际应用到 Runtime Pod 的 `emptyDir`。
 

--- a/runtimes/python/server.py
+++ b/runtimes/python/server.py
@@ -73,13 +73,13 @@ class PythonRuntime(runtime_pb2_grpc.RuntimeServicer):
             task["_cancelled"] = True
             proc = task.get("_proc")
             done = task["_done"]
-            if proc is not None and proc.poll() is None:
+            if proc is not None:
                 self._signal_process_group(proc, signal.SIGTERM)
 
         if not done.wait(timeout=2):
             with self._lock:
                 proc = task.get("_proc")
-                if proc is not None and proc.poll() is None:
+                if proc is not None:
                     self._signal_process_group(proc, signal.SIGKILL)
             done.wait()
 
@@ -120,11 +120,13 @@ class PythonRuntime(runtime_pb2_grpc.RuntimeServicer):
             error_message=task["error_message"],
         )
 
-    def _update_task(self, task_id, **updates):
+    def _finish_task(self, task_id, **updates):
         with self._lock:
             task = self._tasks.get(task_id)
             if task is not None:
                 task.update(updates)
+                task["_proc"] = None
+                task["_done"].set()
 
     @staticmethod
     def _signal_process_group(proc, sig):
@@ -146,20 +148,15 @@ class PythonRuntime(runtime_pb2_grpc.RuntimeServicer):
     def _execute(self, task_id, task_dir, request):
         try:
             if request.handler:
-                self._run_handler(task_id, task_dir, request)
+                result = self._run_handler(task_id, task_dir, request)
             else:
-                self._run_entrypoint(task_id, task_dir, request)
+                result = self._run_entrypoint(task_id, task_dir, request)
         except Exception as e:
-            self._update_task(
-                task_id,
-                state=runtime_pb2.EXECUTION_STATE_FAILED,
-                error_message=str(e),
-            )
-        finally:
-            with self._lock:
-                task = self._tasks.get(task_id)
-                if task is not None:
-                    task["_done"].set()
+            result = {
+                "state": runtime_pb2.EXECUTION_STATE_FAILED,
+                "error_message": str(e),
+            }
+        self._finish_task(task_id, **(result or {}))
 
     def _run_handler(self, task_id, task_dir, request):
         handler_script = """
@@ -180,7 +177,7 @@ if result is not None:
             request.handler,
             json.dumps({"args": list(request.args)}),
         ]
-        self._run_process(task_id, task_dir, request, cmd)
+        return self._run_process(task_id, task_dir, request, cmd)
 
     def _run_entrypoint(self, task_id, task_dir, request):
         entrypoint = self._resolve_entrypoint(request.entrypoint)
@@ -190,14 +187,12 @@ if result is not None:
         elif request.args:
             cmd = [sys.executable] + list(request.args)
         else:
-            self._update_task(
-                task_id,
-                state=runtime_pb2.EXECUTION_STATE_FAILED,
-                error_message="no script or args provided",
-            )
-            return
+            return {
+                "state": runtime_pb2.EXECUTION_STATE_FAILED,
+                "error_message": "no script or args provided",
+            }
 
-        self._run_process(task_id, task_dir, request, cmd)
+        return self._run_process(task_id, task_dir, request, cmd)
 
     def _run_process(self, task_id, task_dir, request, cmd):
         env = os.environ.copy()
@@ -216,24 +211,22 @@ if result is not None:
                 )
                 task["_proc"] = proc
             stdout, stderr = proc.communicate(timeout=timeout)
-            self._update_task(
-                task_id,
-                stdout=stdout,
-                stderr=stderr,
-                exit_code=proc.returncode,
-                state=(
+            return {
+                "stdout": stdout,
+                "stderr": stderr,
+                "exit_code": proc.returncode,
+                "state": (
                     runtime_pb2.EXECUTION_STATE_SUCCEEDED
                     if proc.returncode == 0
                     else runtime_pb2.EXECUTION_STATE_FAILED
                 ),
-            )
+            }
         except subprocess.TimeoutExpired:
             self._signal_process_group(proc, signal.SIGKILL)
             stdout, stderr = proc.communicate()
-            self._update_task(
-                task_id,
-                stdout=stdout or "",
-                stderr=stderr or "",
-                state=runtime_pb2.EXECUTION_STATE_FAILED,
-                error_message="timeout",
-            )
+            return {
+                "stdout": stdout or "",
+                "stderr": stderr or "",
+                "state": runtime_pb2.EXECUTION_STATE_FAILED,
+                "error_message": "timeout",
+            }

--- a/runtimes/python/server_test.py
+++ b/runtimes/python/server_test.py
@@ -44,6 +44,47 @@ class TestPythonRuntime(unittest.TestCase):
         (td / filename).write_text(code)
         return str(td)
 
+    def _prepare_process_tree(self, child_pid_file):
+        child_code = f"""
+import os
+import signal
+import time
+from pathlib import Path
+
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+Path({str(child_pid_file)!r}).write_text(str(os.getpid()))
+time.sleep(30)
+"""
+        return self._prepare_inline(f"""
+import subprocess
+import sys
+import time
+
+subprocess.Popen([sys.executable, "-c", {child_code!r}])
+time.sleep(30)
+""")
+
+    def _wait_for_file(self, path, timeout=5):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if path.exists():
+                return
+            time.sleep(0.05)
+        self.fail(f"timed out waiting for {path}")
+
+    def _assert_process_exits(self, pid, timeout=5):
+        deadline = time.time() + timeout
+        stat_path = Path(f"/proc/{pid}/stat")
+        while time.time() < deadline:
+            try:
+                stat = stat_path.read_text()
+            except FileNotFoundError:
+                return
+            if stat.rsplit(")", 1)[1].split()[0] == "Z":
+                return
+            time.sleep(0.05)
+        self.fail(f"process {pid} is still running")
+
     def test_inline_success(self):
         wd = self._prepare_inline("print(42)")
         resp = self.stub.Execute(runtime_pb2.ExecuteRequest(
@@ -110,6 +151,80 @@ def handler(event):
         with self.assertRaises(grpc.RpcError) as ctx:
             self.stub.Status(runtime_pb2.StatusRequest(id="cancel-handler"))
         self.assertEqual(ctx.exception.code(), grpc.StatusCode.NOT_FOUND)
+
+    def test_cancel_terminates_process_tree_and_waits(self):
+        child_pid_file = self.work_dir / "cancel-child.pid"
+        wd = self._prepare_process_tree(child_pid_file)
+        self.stub.Execute(runtime_pb2.ExecuteRequest(
+            id="cancel-process-tree",
+            working_dir=wd,
+        ))
+        self._wait_for_file(child_pid_file)
+        child_pid = int(child_pid_file.read_text())
+
+        self.stub.Cancel(
+            runtime_pb2.CancelRequest(id="cancel-process-tree"),
+            timeout=5,
+        )
+
+        self._assert_process_exits(child_pid)
+        with self.assertRaises(grpc.RpcError) as ctx:
+            self.stub.Status(runtime_pb2.StatusRequest(id="cancel-process-tree"))
+        self.assertEqual(ctx.exception.code(), grpc.StatusCode.NOT_FOUND)
+
+    def test_timeout_terminates_process_tree_and_waits(self):
+        child_pid_file = self.work_dir / "timeout-child.pid"
+        wd = self._prepare_process_tree(child_pid_file)
+        self.stub.Execute(runtime_pb2.ExecuteRequest(
+            id="timeout-process-tree",
+            working_dir=wd,
+            timeout_seconds=1,
+        ))
+        self._wait_for_file(child_pid_file)
+        child_pid = int(child_pid_file.read_text())
+
+        status = self._wait("timeout-process-tree")
+
+        self.assertEqual(status.state, runtime_pb2.EXECUTION_STATE_FAILED)
+        self.assertEqual(status.error_message, "timeout")
+        self._assert_process_exits(child_pid)
+
+    def test_concurrent_status_and_list_observe_consistent_results(self):
+        task_count = 20
+        for index in range(task_count):
+            wd = self._prepare_inline(f"print('result-{index}')")
+            self.stub.Execute(runtime_pb2.ExecuteRequest(
+                id=f"concurrent-{index}",
+                working_dir=wd,
+            ))
+
+        def read_status(index):
+            status = self._wait(f"concurrent-{index}")
+            return index, status
+
+        def read_list():
+            while True:
+                entries = self.stub.List(runtime_pb2.ListRequest()).entries
+                if all(
+                    entry.state != runtime_pb2.EXECUTION_STATE_RUNNING
+                    for entry in entries
+                ):
+                    return entries
+                time.sleep(0.01)
+
+        with ThreadPoolExecutor(max_workers=12) as executor:
+            list_future = executor.submit(read_list)
+            results = list(executor.map(read_status, range(task_count)))
+            listed = list_future.result(timeout=10)
+
+        self.assertEqual(len(listed), task_count)
+        for index, status in results:
+            self.assertEqual(
+                status.state,
+                runtime_pb2.EXECUTION_STATE_SUCCEEDED,
+            )
+            self.assertEqual(status.stdout, f"result-{index}\n")
+            self.assertEqual(status.stderr, "")
 
     def test_duplicate_id(self):
         wd = self._prepare_inline("print(1)")


### PR DESCRIPTION
## Summary
- finish Python execution state updates under the task lock and publish immutable Status/List responses
- ensure cancellation and timeout signal the full process group and wait for completion before returning terminal state/removing tasks
- add Python runtime tests for process-tree cancellation, timeout cleanup, and concurrent Status/List reads
- mark the Python roadmap items done for concurrency/state snapshots, shared task state, and process-group termination; bounded Python output remains open

## Validation
- uv run python -m unittest server_test -v
- GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/runtimed ./internal/krt -count=1
- GOCACHE=/tmp/go-build make test