### PR TITLE
fix(workflow): propagate cancelled and timed out runs

### DIFF
--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -68,7 +68,7 @@
 
 ### 4. Workflow State Correctness
 
-- [ ] 将 child Run 的 `Timeout` 和 `Cancelled` 转换为终态 Step/Job/Workflow。
+- [x] 将 child Run 的 `Timeout` 和 `Cancelled` 转换为终态 Step/Job/Workflow。
 - [x] 未知 `needs` 必须在 admission 或 reconcile 阶段明确失败。
 - [x] 校验 step 必须包含一个当前支持的执行方式；不能静默接受未实现的 `uses`。
 - [x] 为 job/step 名称增加 Kubernetes 名称和 label 约束。

--- a/internal/controller/workflow_controller.go
+++ b/internal/controller/workflow_controller.go
@@ -171,17 +171,7 @@ func (r *WorkflowReconciler) runJobSteps(ctx context.Context, wf *v1alpha1.Workf
 		if !exists {
 			ss = v1alpha1.StepStatus{Phase: v1alpha1.StepPending}
 		}
-		switch run.Status.Phase {
-		case v1alpha1.RunSucceeded:
-			if ss.Phase == v1alpha1.StepRunning {
-				ss.Phase = v1alpha1.StepSucceeded
-				ss.Outputs = run.Status.Outputs
-			}
-		case v1alpha1.RunFailed:
-			if ss.Phase == v1alpha1.StepRunning {
-				ss.Phase = v1alpha1.StepFailed
-			}
-		}
+		ss = stepStatusFromRun(ss, run)
 		ss.RunName = run.Name
 		js.Steps[name] = ss
 	}
@@ -242,6 +232,20 @@ func (r *WorkflowReconciler) runJobSteps(ctx context.Context, wf *v1alpha1.Workf
 		}
 	}
 	js.Phase = v1alpha1.JobSucceeded
+}
+
+func stepStatusFromRun(ss v1alpha1.StepStatus, run *v1alpha1.Run) v1alpha1.StepStatus {
+	if ss.Phase != v1alpha1.StepPending && ss.Phase != v1alpha1.StepRunning {
+		return ss
+	}
+	switch run.Status.Phase {
+	case v1alpha1.RunSucceeded:
+		ss.Phase = v1alpha1.StepSucceeded
+		ss.Outputs = run.Status.Outputs
+	case v1alpha1.RunFailed, v1alpha1.RunTimeout, v1alpha1.RunCancelled:
+		ss.Phase = v1alpha1.StepFailed
+	}
+	return ss
 }
 
 func (r *WorkflowReconciler) buildRun(wf *v1alpha1.Workflow, jobName string, job *v1alpha1.JobSpec, step *v1alpha1.StepSpec, ctx *resolveContext) (*v1alpha1.Run, error) {

--- a/internal/controller/workflow_controller_test.go
+++ b/internal/controller/workflow_controller_test.go
@@ -1,10 +1,17 @@
 package controller
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestTopoSort_NoDeps(t *testing.T) {
@@ -144,6 +151,48 @@ func TestDetectImplicitNeeds_ExplicitAndImplicit(t *testing.T) {
 	}
 }
 
+func TestWorkflowChildRunTerminalPhasesFailWorkflow(t *testing.T) {
+	tests := []struct {
+		name  string
+		phase v1alpha1.RunPhase
+	}{
+		{name: "timeout", phase: v1alpha1.RunTimeout},
+		{name: "cancelled", phase: v1alpha1.RunCancelled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reconciler, c := newWorkflowTerminalTest(t, tt.phase)
+
+			_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: "wf", Namespace: "default"},
+			})
+			if err != nil {
+				t.Fatalf("reconcile: %v", err)
+			}
+
+			var wf v1alpha1.Workflow
+			if err := c.Get(context.Background(), types.NamespacedName{Name: "wf", Namespace: "default"}, &wf); err != nil {
+				t.Fatalf("get workflow: %v", err)
+			}
+			if wf.Status.Phase != v1alpha1.WorkflowFailed {
+				t.Fatalf("workflow phase = %s, want Failed", wf.Status.Phase)
+			}
+			job := wf.Status.Jobs["test"]
+			if job.Phase != v1alpha1.JobFailed {
+				t.Fatalf("job phase = %s, want Failed", job.Phase)
+			}
+			step := job.Steps["run"]
+			if step.Phase != v1alpha1.StepFailed {
+				t.Fatalf("step phase = %s, want Failed", step.Phase)
+			}
+			if step.RunName != "child-run" {
+				t.Fatalf("step runName = %q, want child-run", step.RunName)
+			}
+		})
+	}
+}
+
 func indexOf(s []string, v string) int {
 	for i, e := range s {
 		if e == v {
@@ -151,4 +200,65 @@ func indexOf(s []string, v string) int {
 		}
 	}
 	return -1
+}
+
+func newWorkflowTerminalTest(t *testing.T, phase v1alpha1.RunPhase) (*WorkflowReconciler, client.Client) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add kruntimes scheme: %v", err)
+	}
+
+	wf := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "wf", Namespace: "default"},
+		Spec: v1alpha1.WorkflowSpec{
+			Jobs: map[string]v1alpha1.JobSpec{
+				"test": {
+					RunsOn: "bash",
+					Steps: []v1alpha1.StepSpec{{
+						Name: "run",
+						Run:  "echo hello",
+					}},
+				},
+			},
+		},
+		Status: v1alpha1.WorkflowStatus{
+			Phase: v1alpha1.WorkflowRunning,
+			Jobs: map[string]v1alpha1.JobStatus{
+				"test": {
+					Phase: v1alpha1.JobRunning,
+					Steps: map[string]v1alpha1.StepStatus{
+						"run": {
+							Phase:   v1alpha1.StepRunning,
+							RunName: "child-run",
+						},
+					},
+				},
+			},
+		},
+	}
+	run := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "child-run",
+			Namespace: "default",
+			Labels: map[string]string{
+				"workflow": "wf",
+				"job":      "test",
+				"step":     "run",
+			},
+		},
+		Status: v1alpha1.RunStatus{Phase: phase},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.Workflow{}).
+		WithObjects(wf, run).
+		Build()
+
+	return &WorkflowReconciler{
+		Client: c,
+		Scheme: scheme,
+	}, c
 }


### PR DESCRIPTION
## Summary
- map child Run Timeout and Cancelled phases to failed workflow steps
- let failed steps fail the parent job and workflow instead of leaving them Running
- add controller coverage for Timeout and Cancelled child Runs
- mark the specific readiness item complete

## Tests
- GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/controller -count=1
- GOCACHE=/tmp/go-build make test

## Notes
- This PR adds controller coverage only; the broader roadmap item for controller + E2E coverage remains open.