### PR TITLE
fix(runtimed): keep active runs progressing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,3 +32,14 @@ jobs:
         with:
           cluster_name: kruntimes-e2e
       - run: make e2e
+      - name: Dump Kubernetes diagnostics
+        if: failure()
+        run: |
+          kubectl get nodes -o wide
+          kubectl get pods,deployments,replicasets,runtimes,runs,workflows -A -o wide
+          kubectl describe pods -A
+          kubectl describe runtimes -A
+          kubectl describe runs -A
+          kubectl get events -A --sort-by=.lastTimestamp
+          kubectl logs deploy/kruntimes-controller --all-containers --tail=300 || true
+          kubectl logs -l app=kruntimes-scheduler --all-containers --tail=300 || true

--- a/api/v1alpha1/workflow_types.go
+++ b/api/v1alpha1/workflow_types.go
@@ -38,7 +38,7 @@ const (
 
 // +kubebuilder:object:generate=true
 // WorkflowSpec defines the desired state of Workflow.
-// +kubebuilder:validation:XValidation:rule="self.jobs.all(name, self.jobs[name].needs.all(need, need in self.jobs && need != name))",message="each dependency must name another job in this workflow"
+// +kubebuilder:validation:XValidation:rule="self.jobs.all(name, !has(self.jobs[name].needs) || self.jobs[name].needs.all(need, need in self.jobs && need != name))",message="each dependency must name another job in this workflow"
 type WorkflowSpec struct {
 	// Jobs is a map of job names to job specs. Jobs run in parallel unless
 	// constrained by needs; the map order is not significant.

--- a/charts/kruntimes/crds/kruntimes.io_workflows.yaml
+++ b/charts/kruntimes/crds/kruntimes.io_workflows.yaml
@@ -148,8 +148,8 @@ spec:
             type: object
             x-kubernetes-validations:
             - message: each dependency must name another job in this workflow
-              rule: self.jobs.all(name, self.jobs[name].needs.all(need, need in self.jobs
-                && need != name))
+              rule: self.jobs.all(name, !has(self.jobs[name].needs) || self.jobs[name].needs.all(need,
+                need in self.jobs && need != name))
           status:
             description: WorkflowStatus defines the observed state of Workflow.
             properties:

--- a/internal/runtimed/controller.go
+++ b/internal/runtimed/controller.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -72,6 +73,7 @@ type activeRun struct {
 	workDir  string
 	deadline time.Time
 	start    time.Time
+	started  atomic.Bool
 }
 
 // Controller reconciles Runs assigned to this pod.
@@ -167,8 +169,11 @@ func (c *Controller) runFilter() predicate.Predicate {
 			return ok && c.matchesRuntimeNamespace(run) &&
 				(run.Status.AssignedPod == c.Hostname || c.shouldCleanupArtifacts(run))
 		},
-		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
-		GenericFunc: func(e event.GenericEvent) bool { return false },
+		DeleteFunc: func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool {
+			run, ok := e.Object.(*v1alpha1.Run)
+			return ok && c.matchesRuntimeNamespace(run) && run.Status.AssignedPod == c.Hostname
+		},
 	}
 }
 
@@ -235,11 +240,8 @@ func (c *Controller) reconcileScheduled(ctx context.Context, run *v1alpha1.Run) 
 		return c.applyFailure(ctx, ar, runretry.ReasonPrepareSource, fmt.Sprintf("prepare source: %v", err))
 	}
 	ar.workDir = workDir
-	if err := c.startExecution(ctx, ar); err != nil {
-		return c.applyFailure(ctx, ar, runretry.ReasonRuntimeExecute, fmt.Sprintf("runtime Execute: %v", err))
-	}
-	c.rleg.AddRun(run)
-	return ctrl.Result{}, nil
+	c.startExecutionAsync(ar)
+	return ctrl.Result{RequeueAfter: activeRunRequeueAfter(ar)}, nil
 }
 
 func (c *Controller) heartbeat(ctx context.Context) {
@@ -358,7 +360,7 @@ func (c *Controller) reconcileRunningRecovered(ctx context.Context, run *v1alpha
 func (c *Controller) applyCancel(ctx context.Context, ar *activeRun) (ctrl.Result, error) {
 	run := ar.run
 	uid := string(run.UID)
-	_, _ = c.runtimeCli.Cancel(ctx, &pb.CancelRequest{Id: uid})
+	c.cancelRuntimeExecution(ctx, uid)
 	return c.applyTerminal(ctx, ar, v1alpha1.RunCancelled, runretry.ReasonCancelled, "cancelled by user")
 }
 
@@ -368,9 +370,18 @@ func (c *Controller) applyCancel(ctx context.Context, ar *activeRun) (ctrl.Resul
 
 func (c *Controller) handleTimeout(ctx context.Context, ar *activeRun) (ctrl.Result, error) {
 	uid := string(ar.run.UID)
-	_, _ = c.runtimeCli.Cancel(ctx, &pb.CancelRequest{Id: uid})
+	c.cancelRuntimeExecution(ctx, uid)
 	msg := fmt.Sprintf("timeout after %s", ar.run.Spec.Timeout.Duration)
 	return c.applyFailure(ctx, ar, runretry.ReasonTimeout, msg)
+}
+
+func (c *Controller) cancelRuntimeExecution(ctx context.Context, uid string) {
+	if c.runtimeCli == nil || uid == "" {
+		return
+	}
+	cancelCtx, cancel := context.WithTimeout(ctx, executionCleanupTimeout)
+	defer cancel()
+	_, _ = c.runtimeCli.Cancel(cancelCtx, &pb.CancelRequest{Id: uid})
 }
 
 // ===========================================================================
@@ -380,6 +391,9 @@ func (c *Controller) handleTimeout(ctx context.Context, ar *activeRun) (ctrl.Res
 func (c *Controller) reconcileRunningActive(ctx context.Context, ar *activeRun) (ctrl.Result, error) {
 	if !ar.deadline.IsZero() && time.Now().After(ar.deadline) {
 		return c.handleTimeout(ctx, ar)
+	}
+	if !ar.started.Load() {
+		return ctrl.Result{RequeueAfter: activeRunRequeueAfter(ar)}, nil
 	}
 
 	resp, err := c.pollStatus(ctx, string(ar.run.UID))
@@ -398,7 +412,21 @@ func (c *Controller) reconcileRunningActive(ctx context.Context, ar *activeRun) 
 		msg := summarizeRuntimeFailure(resp)
 		return c.applyFailureWithOutput(ctx, ar, reason, msg, outputFromStatus(resp))
 	}
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: activeRunRequeueAfter(ar)}, nil
+}
+
+func activeRunRequeueAfter(ar *activeRun) time.Duration {
+	if ar == nil || ar.deadline.IsZero() {
+		return rlegpkg.DefaultRelistInterval
+	}
+	untilDeadline := time.Until(ar.deadline)
+	if untilDeadline <= 0 {
+		return time.Nanosecond
+	}
+	if untilDeadline < rlegpkg.DefaultRelistInterval {
+		return untilDeadline
+	}
+	return rlegpkg.DefaultRelistInterval
 }
 
 // ===========================================================================
@@ -428,11 +456,8 @@ func (c *Controller) reconcileRetryBackoff(ctx context.Context, ar *activeRun) (
 	}
 	c.recordEvent(run, corev1.EventTypeNormal, "RunRetrying",
 		"Retry attempt %d/%d starting", run.Status.Attempt+1, policy.MaxAttempts)
-	if err := c.startExecution(ctx, ar); err != nil {
-		return c.applyFailure(ctx, ar, runretry.ReasonRuntimeExecute, fmt.Sprintf("runtime Execute: %v", err))
-	}
-	c.rleg.AddRun(run)
-	return ctrl.Result{}, nil
+	c.startExecutionAsync(ar)
+	return ctrl.Result{RequeueAfter: activeRunRequeueAfter(ar)}, nil
 }
 
 // ===========================================================================
@@ -642,6 +667,45 @@ func (c *Controller) releaseExecution(ctx context.Context, uid string) {
 // startExecution — common gRPC Execute call used for initial and retry.
 // ===========================================================================
 
+func (c *Controller) startExecutionAsync(ar *activeRun) {
+	ar.started.Store(false)
+	go func() {
+		ctx := context.Background()
+		if err := c.startExecution(ctx, ar); err != nil {
+			c.applyStartExecutionFailure(ctx, ar, err)
+			return
+		}
+		uid := string(ar.run.UID)
+		if val, ok := c.activeRuns.Load(uid); !ok || val != ar {
+			c.releaseExecution(ctx, uid)
+			return
+		}
+		ar.started.Store(true)
+		if c.rleg != nil {
+			c.rleg.AddRun(ar.run)
+		}
+	}()
+}
+
+func (c *Controller) applyStartExecutionFailure(ctx context.Context, ar *activeRun, startErr error) {
+	uid := string(ar.run.UID)
+	if val, ok := c.activeRuns.Load(uid); !ok || val != ar {
+		return
+	}
+	var run v1alpha1.Run
+	if err := c.Get(ctx, client.ObjectKeyFromObject(ar.run), &run); err != nil {
+		c.Log.Error(err, "failed to get Run after runtime Execute error", "run", client.ObjectKeyFromObject(ar.run))
+		return
+	}
+	if run.Status.Phase != v1alpha1.RunRunning || run.Status.AssignedPod != c.Hostname {
+		return
+	}
+	ar.run = &run
+	if _, err := c.applyFailure(ctx, ar, runretry.ReasonRuntimeExecute, fmt.Sprintf("runtime Execute: %v", startErr)); err != nil {
+		c.Log.Error(err, "failed to mark Run failed after runtime Execute error", "run", client.ObjectKeyFromObject(ar.run))
+	}
+}
+
 func (c *Controller) startExecution(ctx context.Context, ar *activeRun) error {
 	run := ar.run
 	env := make(map[string]string)
@@ -801,6 +865,7 @@ func (c *Controller) addRecoveredRun(run *v1alpha1.Run) *activeRun {
 	if val, ok := c.activeRuns.Load(uid); ok {
 		ar := val.(*activeRun)
 		ar.run = run
+		ar.started.Store(true)
 		if c.rleg != nil {
 			c.rleg.UpdateRun(run)
 		}
@@ -808,6 +873,7 @@ func (c *Controller) addRecoveredRun(run *v1alpha1.Run) *activeRun {
 	}
 
 	ar := c.buildActiveRun(run)
+	ar.started.Store(true)
 	c.activeRuns.Store(uid, ar)
 	if c.rleg != nil {
 		c.rleg.AddRun(run)

--- a/internal/runtimed/controller_test.go
+++ b/internal/runtimed/controller_test.go
@@ -21,10 +21,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 	"github.com/kruntimes/kruntimes/internal/artifact"
 	runretry "github.com/kruntimes/kruntimes/internal/retry"
+	rlegpkg "github.com/kruntimes/kruntimes/internal/runtimed/rleg"
 )
 
 func TestPrepareSource_NoSource(t *testing.T) {
@@ -334,6 +336,33 @@ func TestReconcileScheduledRespectsLocalCapacity(t *testing.T) {
 	}
 	if run.Status.Phase != v1alpha1.RunScheduled {
 		t.Fatalf("phase = %s, want Scheduled", run.Status.Phase)
+	}
+}
+
+func TestRunFilterAllowsRLEGGenericEventsForAssignedRuns(t *testing.T) {
+	c := &Controller{Hostname: "runtime-pod", RuntimeNamespace: "default"}
+	filter := c.runFilter()
+
+	assigned := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "assigned", Namespace: "default"},
+		Status:     v1alpha1.RunStatus{AssignedPod: "runtime-pod"},
+	}
+	if !filter.Generic(event.GenericEvent{Object: assigned}) {
+		t.Fatal("assigned Run generic event was filtered")
+	}
+
+	otherPod := assigned.DeepCopy()
+	otherPod.Name = "other-pod"
+	otherPod.Status.AssignedPod = "other-runtime-pod"
+	if filter.Generic(event.GenericEvent{Object: otherPod}) {
+		t.Fatal("Run assigned to another pod was accepted")
+	}
+
+	otherNamespace := assigned.DeepCopy()
+	otherNamespace.Name = "other-namespace"
+	otherNamespace.Namespace = "other"
+	if filter.Generic(event.GenericEvent{Object: otherNamespace}) {
+		t.Fatal("Run from another namespace was accepted")
 	}
 }
 
@@ -765,6 +794,42 @@ func TestReconcileRunningActiveDistinguishesStatusErrors(t *testing.T) {
 				t.Fatalf("Running condition = %#v, want reason %s", condition, tt.wantReason)
 			}
 		})
+	}
+}
+
+func TestReconcileRunningActiveRequeuesWhileExecutionRunning(t *testing.T) {
+	run := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "active", Namespace: "default", UID: "active-uid"},
+		Spec:       v1alpha1.RunSpec{Runtime: "bash"},
+		Status: v1alpha1.RunStatus{
+			Phase:       v1alpha1.RunRunning,
+			AssignedPod: "pod-a",
+			StartTime:   &metav1.Time{Time: time.Now()},
+		},
+	}
+	c := &Controller{
+		Hostname: "pod-a",
+		runtimeCli: &fakeRuntimeClient{status: &pb.StatusResponse{
+			Id:    string(run.UID),
+			State: pb.ExecutionState_EXECUTION_STATE_RUNNING,
+		}},
+	}
+
+	ar := &activeRun{run: run, start: time.Now()}
+	ar.started.Store(true)
+	result, err := c.reconcileRunningActive(t.Context(), ar)
+	if err != nil {
+		t.Fatalf("reconcileRunningActive: %v", err)
+	}
+	if result.RequeueAfter != rlegpkg.DefaultRelistInterval {
+		t.Fatalf("RequeueAfter = %s, want %s", result.RequeueAfter, rlegpkg.DefaultRelistInterval)
+	}
+}
+
+func TestActiveRunRequeueAfterUsesSoonerDeadline(t *testing.T) {
+	got := activeRunRequeueAfter(&activeRun{deadline: time.Now().Add(25 * time.Millisecond)})
+	if got <= 0 || got > rlegpkg.DefaultRelistInterval {
+		t.Fatalf("activeRunRequeueAfter = %s, want positive duration <= %s", got, rlegpkg.DefaultRelistInterval)
 	}
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -96,10 +96,11 @@ func ensureRuntimeWithRunsCapacity(t *testing.T, name, image string, port int32,
 			Namespace: testNamespace,
 		},
 		Spec: v1alpha1.RuntimeSpec{
-			Image:    image,
-			Port:     port,
-			Replicas: 1,
-			Command:  []string{fmt.Sprintf("--port=%d", port), "--work-dir=/workspace"},
+			Image:     image,
+			Port:      port,
+			Replicas:  1,
+			Command:   []string{fmt.Sprintf("--port=%d", port), "--work-dir=/workspace"},
+			Resources: e2eRuntimeResources(),
 		},
 	}
 	if runsCapacity > 0 {
@@ -120,6 +121,7 @@ func ensureRuntimeWithRunsCapacity(t *testing.T, name, image string, port int32,
 		existing.Spec.Port = port
 		existing.Spec.Replicas = 1
 		existing.Spec.Command = []string{fmt.Sprintf("--port=%d", port), "--work-dir=/workspace"}
+		existing.Spec.Resources = e2eRuntimeResources()
 		if runsCapacity > 0 {
 			existing.Spec.Capacity = rt.Spec.Capacity
 		}
@@ -127,6 +129,7 @@ func ensureRuntimeWithRunsCapacity(t *testing.T, name, image string, port int32,
 			t.Fatalf("update runtime: %v", updateErr)
 		}
 	}
+	cleanupRuntime(t, name)
 
 	waitForRuntimePod(t, name, image, runtimedImage(), runsCapacity, "runtime pods")
 }
@@ -151,10 +154,11 @@ func ensureFilesystemRuntime(t *testing.T, name, claimName string) {
 	rt := &v1alpha1.Runtime{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
 		Spec: v1alpha1.RuntimeSpec{
-			Image:    bashRuntimeImage(),
-			Port:     9091,
-			Replicas: 1,
-			Command:  []string{"--port=9091", "--work-dir=/workspace"},
+			Image:     bashRuntimeImage(),
+			Port:      9091,
+			Replicas:  1,
+			Command:   []string{"--port=9091", "--work-dir=/workspace"},
+			Resources: e2eRuntimeResources(),
 			ArtifactStore: &v1alpha1.RuntimeArtifactStoreSpec{
 				Driver: v1alpha1.ArtifactDriverFilesystem,
 				Filesystem: &v1alpha1.FilesystemArtifactStoreSpec{
@@ -176,8 +180,32 @@ func ensureFilesystemRuntime(t *testing.T, name, claimName string) {
 			t.Fatalf("update filesystem runtime: %v", updateErr)
 		}
 	}
+	cleanupRuntime(t, name)
 
 	waitForRuntimePod(t, name, bashRuntimeImage(), runtimedImage(), 0, "filesystem runtime pod")
+}
+
+func e2eRuntimeResources() corev1.ResourceRequirements {
+	return corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("25m"),
+			corev1.ResourceMemory: resource.MustParse("64Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+}
+
+func cleanupRuntime(t *testing.T, name string) {
+	t.Helper()
+	t.Cleanup(func() {
+		rt := &v1alpha1.Runtime{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace}}
+		if err := k8sClient.Delete(context.Background(), rt); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("delete Runtime %s: %v", name, err)
+		}
+	})
 }
 
 func isRuntimePodReady(pod *corev1.Pod, runtimeImage, daemonImage string, runsCapacity int32) bool {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -13,10 +13,12 @@ import (
 	"testing"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -126,27 +128,7 @@ func ensureRuntimeWithRunsCapacity(t *testing.T, name, image string, port int32,
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
-
-	for {
-		var pods corev1.PodList
-		if err := k8sClient.List(ctx, &pods,
-			client.InNamespace(testNamespace),
-			client.MatchingLabels{"runtime": name},
-		); err == nil {
-			for _, p := range pods.Items {
-				if isRuntimePodReady(&p, image, runtimedImage(), runsCapacity) {
-					return
-				}
-			}
-		}
-		select {
-		case <-ctx.Done():
-			t.Fatal("timed out waiting for runtime pods")
-		case <-time.After(2 * time.Second):
-		}
-	}
+	waitForRuntimePod(t, name, image, runtimedImage(), runsCapacity, "runtime pods")
 }
 
 func ensureFilesystemRuntime(t *testing.T, name, claimName string) {
@@ -195,26 +177,7 @@ func ensureFilesystemRuntime(t *testing.T, name, claimName string) {
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
-	for {
-		var pods corev1.PodList
-		if err := k8sClient.List(ctx, &pods,
-			client.InNamespace(testNamespace),
-			client.MatchingLabels{"runtime": name},
-		); err == nil {
-			for _, pod := range pods.Items {
-				if isRuntimePodReady(&pod, bashRuntimeImage(), runtimedImage(), 0) {
-					return
-				}
-			}
-		}
-		select {
-		case <-ctx.Done():
-			t.Fatal("timed out waiting for filesystem runtime pod")
-		case <-time.After(2 * time.Second):
-		}
-	}
+	waitForRuntimePod(t, name, bashRuntimeImage(), runtimedImage(), 0, "filesystem runtime pod")
 }
 
 func isRuntimePodReady(pod *corev1.Pod, runtimeImage, daemonImage string, runsCapacity int32) bool {
@@ -246,6 +209,124 @@ func containerImage(pod *corev1.Pod, name string) string {
 		}
 	}
 	return ""
+}
+
+func waitForRuntimePod(t *testing.T, name, runtimeImage, daemonImage string, runsCapacity int32, description string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	var lastErr error
+	for {
+		var pods corev1.PodList
+		err := k8sClient.List(ctx, &pods,
+			client.InNamespace(testNamespace),
+			client.MatchingLabels{"runtime": name},
+		)
+		if err == nil {
+			for _, pod := range pods.Items {
+				if isRuntimePodReady(&pod, runtimeImage, daemonImage, runsCapacity) {
+					return
+				}
+			}
+		} else {
+			lastErr = err
+		}
+
+		select {
+		case <-ctx.Done():
+			dumpRuntimeDiagnostics(t, name, runtimeImage, daemonImage, runsCapacity, lastErr)
+			t.Fatalf("timed out waiting for %s", description)
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+func dumpRuntimeDiagnostics(t *testing.T, name, runtimeImage, daemonImage string, runsCapacity int32, lastErr error) {
+	t.Helper()
+	t.Logf("Runtime %s diagnostics: expected runtime image=%s runtimed image=%s runsCapacity=%d", name, runtimeImage, daemonImage, runsCapacity)
+	if lastErr != nil {
+		t.Logf("last pod list error: %v", lastErr)
+	}
+
+	var rt v1alpha1.Runtime
+	if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: testNamespace, Name: name}, &rt); err != nil {
+		t.Logf("get Runtime %s: %v", name, err)
+	} else {
+		t.Logf("Runtime %s: generation=%d replicas=%d readyReplicas=%d image=%s daemonImage=%s port=%d",
+			name, rt.Generation, rt.Spec.Replicas, rt.Status.ReadyReplicas, rt.Spec.Image, rt.Spec.DaemonImage, rt.Spec.Port)
+		for _, cond := range rt.Status.Conditions {
+			t.Logf("  Runtime condition: type=%s status=%s reason=%s message=%s", cond.Type, cond.Status, cond.Reason, cond.Message)
+		}
+	}
+
+	var deploy appsv1.Deployment
+	if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: testNamespace, Name: "runtime-" + name}, &deploy); err != nil {
+		t.Logf("get Deployment runtime-%s: %v", name, err)
+	} else {
+		t.Logf("Deployment %s: generation=%d observedGeneration=%d replicas=%d ready=%d available=%d unavailable=%d",
+			deploy.Name, deploy.Generation, deploy.Status.ObservedGeneration, deploy.Status.Replicas, deploy.Status.ReadyReplicas, deploy.Status.AvailableReplicas, deploy.Status.UnavailableReplicas)
+		for _, cond := range deploy.Status.Conditions {
+			t.Logf("  Deployment condition: type=%s status=%s reason=%s message=%s", cond.Type, cond.Status, cond.Reason, cond.Message)
+		}
+	}
+
+	var pods corev1.PodList
+	if err := k8sClient.List(context.Background(), &pods, client.InNamespace(testNamespace), client.MatchingLabels{"runtime": name}); err != nil {
+		t.Logf("list Runtime pods: %v", err)
+		return
+	}
+	if len(pods.Items) == 0 {
+		t.Log("Runtime pod list is empty")
+	}
+	for i := range pods.Items {
+		logPodDiagnostics(t, &pods.Items[i])
+	}
+}
+
+func logPodDiagnostics(t *testing.T, pod *corev1.Pod) {
+	t.Helper()
+	t.Logf("Pod %s: phase=%s deletion=%v node=%s runtimeImage=%s runtimedImage=%s runsCapacity=%d",
+		pod.Name, pod.Status.Phase, pod.DeletionTimestamp != nil, pod.Spec.NodeName,
+		containerImage(pod, "runtime"), containerImage(pod, "runtimed"), runtimepod.RunsCapacity(pod, 0))
+	for _, cond := range pod.Status.Conditions {
+		t.Logf("  Pod condition: type=%s status=%s reason=%s message=%s lastProbe=%s lastTransition=%s",
+			cond.Type, cond.Status, cond.Reason, cond.Message, cond.LastProbeTime.Time.Format(time.RFC3339), cond.LastTransitionTime.Time.Format(time.RFC3339))
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		t.Logf("  Container %s: ready=%t restartCount=%d image=%s state=%s lastState=%s",
+			status.Name, status.Ready, status.RestartCount, status.Image, formatContainerState(status.State), formatContainerState(status.LastTerminationState))
+	}
+	listPodEvents(t, pod)
+}
+
+func listPodEvents(t *testing.T, pod *corev1.Pod) {
+	t.Helper()
+	if coreClientset == nil {
+		return
+	}
+	selector := fields.OneTermEqualSelector("involvedObject.name", pod.Name).String()
+	events, err := coreClientset.CoreV1().Events(pod.Namespace).List(context.Background(), metav1.ListOptions{FieldSelector: selector})
+	if err != nil {
+		t.Logf("  list pod events: %v", err)
+		return
+	}
+	for _, event := range events.Items {
+		t.Logf("  Event: type=%s reason=%s count=%d message=%s", event.Type, event.Reason, event.Count, event.Message)
+	}
+}
+
+func formatContainerState(state corev1.ContainerState) string {
+	switch {
+	case state.Running != nil:
+		return "running"
+	case state.Waiting != nil:
+		return fmt.Sprintf("waiting(%s: %s)", state.Waiting.Reason, state.Waiting.Message)
+	case state.Terminated != nil:
+		return fmt.Sprintf("terminated(%s exit=%d: %s)", state.Terminated.Reason, state.Terminated.ExitCode, state.Terminated.Message)
+	default:
+		return "unknown"
+	}
 }
 
 func waitForRun(t *testing.T, run *v1alpha1.Run, timeout time.Duration) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -200,6 +200,9 @@ func e2eRuntimeResources() corev1.ResourceRequirements {
 
 func cleanupRuntime(t *testing.T, name string) {
 	t.Helper()
+	if name == "bash" || name == "python" {
+		return
+	}
 	t.Cleanup(func() {
 		rt := &v1alpha1.Runtime{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace}}
 		if err := k8sClient.Delete(context.Background(), rt); err != nil && !apierrors.IsNotFound(err) {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -424,6 +424,26 @@ func TestCRDValidationRejectsInvalidWorkflowNeeds(t *testing.T) {
 	}
 }
 
+func TestCRDValidationAllowsWorkflowWithoutNeeds(t *testing.T) {
+	ctx := context.Background()
+	ns := testNamespace(t, "test-workflow-no-needs-")
+
+	workflow := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "no-needs", Namespace: ns.Name},
+		Spec: v1alpha1.WorkflowSpec{
+			Jobs: map[string]v1alpha1.JobSpec{
+				"test": {
+					RunsOn: "bash",
+					Steps:  []v1alpha1.StepSpec{{Name: "hello", Run: "echo hello"}},
+				},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, workflow); err != nil {
+		t.Fatalf("create workflow without needs: %v", err)
+	}
+}
+
 func TestCRDValidationRejectsUnsupportedWorkflowStepShape(t *testing.T) {
 	ctx := context.Background()
 	ns := testNamespace(t, "test-step-validation-")


### PR DESCRIPTION
## Summary
- keep Running Runs progressing with explicit requeues while runtime executions are active
- start runtime Execute calls asynchronously so a blocked Execute call cannot stall timeout/cancel reconciliation
- allow RLEG generic events for Runs assigned to the local runtimed pod
- bound runtime Cancel calls used by cancel/timeout handling
- fix Workflow CEL validation so jobs without needs are accepted

## Tests
- GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/runtimed -count=1
- GOCACHE=/tmp/go-build make test-integration
- GOCACHE=/tmp/go-build make e2e