### PR TITLE
fix(helm): scope platform resource names by release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: azure/setup-helm@v5.0.0
-      - run: helm lint ./charts/kruntimes ./charts/kruntimes-runtimes
-      - run: helm template kruntimes ./charts/kruntimes --namespace kruntimes-system
-      - run: helm template kruntimes-runtimes ./charts/kruntimes-runtimes --namespace default
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: make test-helm
 
   generated:
     name: Generated files

--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,13 @@ docker-push: ## Push Docker images.
 template: manifests ## Render Helm chart to stdout for validation.
 	$(HELM) template kruntimes ./charts/kruntimes --namespace $(NAMESPACE)
 
+.PHONY: test-helm
+test-helm: manifests ## Validate Helm charts and multi-release rendering.
+	$(HELM) lint ./charts/kruntimes ./charts/kruntimes-runtimes
+	$(HELM) template kruntimes ./charts/kruntimes --namespace kruntimes-system
+	$(HELM) template kruntimes-runtimes ./charts/kruntimes-runtimes --namespace default
+	./hack/verify-helm-multi-release.py
+
 ##@ Deployment
 
 .PHONY: deploy

--- a/api/v1alpha1/runtime_types.go
+++ b/api/v1alpha1/runtime_types.go
@@ -62,6 +62,13 @@ type RuntimeSpec struct {
 	// +kubebuilder:validation:MaxLength=2048
 	DaemonImage string `json:"daemonImage,omitempty"`
 
+	// RuntimedServiceAccountName overrides the ServiceAccount used by Runtime Pods.
+	// The ServiceAccount must exist in the Runtime namespace.
+	// +optional
+	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
+	RuntimedServiceAccountName string `json:"runtimedServiceAccountName,omitempty"`
+
 	// Capacity declares the per-pod capacity for this runtime.
 	// +optional
 	Capacity *RuntimeCapacity `json:"capacity,omitempty"`

--- a/charts/kruntimes/crds/kruntimes.io_runtimes.yaml
+++ b/charts/kruntimes/crds/kruntimes.io_runtimes.yaml
@@ -393,6 +393,13 @@ spec:
                       More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                     type: object
                 type: object
+              runtimedServiceAccountName:
+                description: |-
+                  RuntimedServiceAccountName overrides the ServiceAccount used by Runtime Pods.
+                  The ServiceAccount must exist in the Runtime namespace.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                type: string
               workspace:
                 description: Workspace configures the shared workspace volume mounted
                   into the runtime pod.

--- a/charts/kruntimes/templates/_helpers.tpl
+++ b/charts/kruntimes/templates/_helpers.tpl
@@ -22,11 +22,44 @@ app.kubernetes.io/version: {{ .Chart.AppVersion }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
+{{- define "kruntimes.controller.name" -}}
+{{- printf "%s-controller" ((include "kruntimes.fullname" .) | trunc 52 | trimSuffix "-") }}
+{{- end }}
+
+{{- define "kruntimes.scheduler.name" -}}
+{{- printf "%s-scheduler" ((include "kruntimes.fullname" .) | trunc 53 | trimSuffix "-") }}
+{{- end }}
+
+{{- define "kruntimes.runtimed.name" -}}
+{{- printf "%s-runtimed" ((include "kruntimes.fullname" .) | trunc 54 | trimSuffix "-") }}
+{{- end }}
+
+{{- define "kruntimes.controller.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kruntimes.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: controller
+{{- end }}
+
+{{- define "kruntimes.scheduler.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kruntimes.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: scheduler
+{{- end }}
+
+{{- define "kruntimes.controller.labels" -}}
+{{ include "kruntimes.labels" . }}
+app.kubernetes.io/component: controller
+app: kruntimes-controller
+{{- end }}
+
 {{- define "kruntimes.scheduler.labels" -}}
 {{ include "kruntimes.labels" . }}
+app.kubernetes.io/component: scheduler
 app: kruntimes-scheduler
 {{- end }}
 
 {{- define "kruntimes.runtimed.labels" -}}
 {{ include "kruntimes.labels" . }}
+app.kubernetes.io/component: runtimed
+app: kruntimes-runtimed
 {{- end }}

--- a/charts/kruntimes/templates/controller-deployment.yaml
+++ b/charts/kruntimes/templates/controller-deployment.yaml
@@ -1,22 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kruntimes-controller
+  name: {{ include "kruntimes.controller.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: kruntimes-controller
-    {{- include "kruntimes.labels" . | nindent 4 }}
+    {{- include "kruntimes.controller.labels" . | nindent 4 }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: kruntimes-controller
+      {{- include "kruntimes.controller.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: kruntimes-controller
+        {{- include "kruntimes.controller.labels" . | nindent 8 }}
     spec:
-      serviceAccountName: kruntimes-controller
+      serviceAccountName: {{ include "kruntimes.controller.name" . }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault
@@ -36,6 +35,7 @@ spec:
             - --metrics-bind-address=:8082
             - --health-probe-bind-address=:8083
             - --default-daemon-image={{ .Values.runtimed.image }}
+            - --runtimed-service-account-name={{ include "kruntimes.runtimed.name" . }}
           ports:
             - containerPort: 8082
               name: metrics

--- a/charts/kruntimes/templates/controller-rbac.yaml
+++ b/charts/kruntimes/templates/controller-rbac.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kruntimes-controller
+  name: {{ include "kruntimes.controller.name" . }}
   labels:
-    {{- include "kruntimes.labels" . | nindent 4 }}
+    {{- include "kruntimes.controller.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - kruntimes.io
@@ -105,14 +105,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kruntimes-controller
+  name: {{ include "kruntimes.controller.name" . }}
   labels:
-    {{- include "kruntimes.labels" . | nindent 4 }}
+    {{- include "kruntimes.controller.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kruntimes-controller
+  name: {{ include "kruntimes.controller.name" . }}
 subjects:
   - kind: ServiceAccount
-    name: kruntimes-controller
+    name: {{ include "kruntimes.controller.name" . }}
     namespace: {{ .Release.Namespace }}

--- a/charts/kruntimes/templates/runtimed-rbac.yaml
+++ b/charts/kruntimes/templates/runtimed-rbac.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kruntimes-runtimed
+  name: {{ include "kruntimes.runtimed.name" . }}
   labels:
-    {{- include "kruntimes.labels" . | nindent 4 }}
+    {{- include "kruntimes.runtimed.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - kruntimes.io
@@ -47,14 +47,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kruntimes-runtimed
+  name: {{ include "kruntimes.runtimed.name" . }}
   labels:
-    {{- include "kruntimes.labels" . | nindent 4 }}
+    {{- include "kruntimes.runtimed.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kruntimes-runtimed
+  name: {{ include "kruntimes.runtimed.name" . }}
 subjects:
   - kind: ServiceAccount
-    name: kruntimes-runtimed
+    name: {{ include "kruntimes.runtimed.name" . }}
     namespace: {{ .Release.Namespace }}

--- a/charts/kruntimes/templates/scheduler-deployment.yaml
+++ b/charts/kruntimes/templates/scheduler-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kruntimes-scheduler
+  name: {{ include "kruntimes.scheduler.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kruntimes.scheduler.labels" . | nindent 4 }}
@@ -9,13 +9,13 @@ spec:
   replicas: {{ .Values.scheduler.replicas }}
   selector:
     matchLabels:
-      app: kruntimes-scheduler
+      {{- include "kruntimes.scheduler.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: kruntimes-scheduler
+        {{- include "kruntimes.scheduler.labels" . | nindent 8 }}
     spec:
-      serviceAccountName: kruntimes-scheduler
+      serviceAccountName: {{ include "kruntimes.scheduler.name" . }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/charts/kruntimes/templates/scheduler-rbac.yaml
+++ b/charts/kruntimes/templates/scheduler-rbac.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: kruntimes-scheduler
+  name: {{ include "kruntimes.scheduler.name" . }}
   labels:
-    {{- include "kruntimes.labels" . | nindent 4 }}
+    {{- include "kruntimes.scheduler.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - kruntimes.io
@@ -48,14 +48,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kruntimes-scheduler
+  name: {{ include "kruntimes.scheduler.name" . }}
   labels:
-    {{- include "kruntimes.labels" . | nindent 4 }}
+    {{- include "kruntimes.scheduler.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kruntimes-scheduler
+  name: {{ include "kruntimes.scheduler.name" . }}
 subjects:
   - kind: ServiceAccount
-    name: kruntimes-scheduler
+    name: {{ include "kruntimes.scheduler.name" . }}
     namespace: {{ .Release.Namespace }}

--- a/charts/kruntimes/templates/serviceaccount.yaml
+++ b/charts/kruntimes/templates/serviceaccount.yaml
@@ -1,26 +1,23 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kruntimes-scheduler
+  name: {{ include "kruntimes.scheduler.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: kruntimes-scheduler
-    {{- include "kruntimes.labels" . | nindent 4 }}
+    {{- include "kruntimes.scheduler.labels" . | nindent 4 }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kruntimes-runtimed
+  name: {{ include "kruntimes.runtimed.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: kruntimes-runtimed
-    {{- include "kruntimes.labels" . | nindent 4 }}
+    {{- include "kruntimes.runtimed.labels" . | nindent 4 }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kruntimes-controller
+  name: {{ include "kruntimes.controller.name" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: kruntimes-controller
-    {{- include "kruntimes.labels" . | nindent 4 }}
+    {{- include "kruntimes.controller.labels" . | nindent 4 }}

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -31,11 +31,12 @@ func init() {
 
 func main() {
 	var (
-		metricsAddr          string
-		probeAddr            string
-		enableLeaderElection bool
-		staleThreshold       time.Duration
-		defaultDaemonImage   string
+		metricsAddr                string
+		probeAddr                  string
+		enableLeaderElection       bool
+		staleThreshold             time.Duration
+		defaultDaemonImage         string
+		runtimedServiceAccountName string
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8082", "The address the metric endpoint binds to.")
@@ -43,6 +44,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager.")
 	flag.DurationVar(&staleThreshold, "stale-threshold", 30*time.Second, "Threshold for marking a Run as stale when its assigned pod is unhealthy.")
 	flag.StringVar(&defaultDaemonImage, "default-daemon-image", "", "Default runtimed daemon image injected into Runtime Pods.")
+	flag.StringVar(&runtimedServiceAccountName, "runtimed-service-account-name", "", "ServiceAccount name injected into Runtime Pods for the runtimed sidecar.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
@@ -76,10 +78,11 @@ func main() {
 	}
 
 	reconciler := &controller.RuntimeReconciler{
-		Client:             mgr.GetClient(),
-		Log:                ctrl.Log.WithName("controllers").WithName("Runtime"),
-		Scheme:             mgr.GetScheme(),
-		DefaultDaemonImage: defaultDaemonImage,
+		Client:                     mgr.GetClient(),
+		Log:                        ctrl.Log.WithName("controllers").WithName("Runtime"),
+		Scheme:                     mgr.GetScheme(),
+		DefaultDaemonImage:         defaultDaemonImage,
+		RuntimedServiceAccountName: runtimedServiceAccountName,
 	}
 	if err := reconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Runtime")

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -102,15 +102,23 @@
 
 - [ ] 明确选择 cluster-wide 或 single-namespace 安装模型。
 - [ ] Runtime Deployment 引用的 runtimed ServiceAccount 必须存在于 Runtime namespace。
-- [ ] 所有 Helm 资源名称使用 release fullname，支持多个 release 共存。
+- [ ] 为自定义 `Runtime.spec.runtimedServiceAccountName` 增加 namespace-scoped RBAC
+  controller 或等价机制，确保对应 ServiceAccount 拥有 runtimed 所需最小权限。
+- [ ] 明确 Runtime Pod customization API：评估是否用 `PodTemplateSpec` 风格的
+  template 取代当前 Runtime spec 中逐步复制的 PodSpec-like 字段。
+- [x] 所有 Helm 资源名称使用 release fullname，支持多个 release 共存。
 - [ ] 移除未使用 values，并让 replicas、leader election、ports、imagePullSecrets、
   security context、scheduling constraints 等可配置。
 - [ ] 避免默认使用 `latest`，镜像 tag 应跟随 chart appVersion。
-- [ ] 增加多 namespace 和第二个 Helm release 的模板/安装测试。
+- [ ] 增加多 namespace 模板/安装测试。
+- [x] 增加第二个 Helm release 的模板测试。
 
 验收标准：
 
 - 文档声明的 namespace 模型可真实工作。
+- 使用自定义 Runtime ServiceAccount 时，权限授予是 namespace-scoped、最小权限且
+  可审计的。
+- Runtime Pod 自定义模型在公开前有明确边界，不需要在未来兼容两套重叠 API。
 - 同一集群可以安装两个无资源命名冲突的 release。
 - chart 默认值能够引用公开发布的、不可变版本镜像。
 

--- a/hack/verify-helm-multi-release.py
+++ b/hack/verify-helm-multi-release.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Verify two kruntimes Helm releases can render into one namespace safely."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CHART = Path("charts/kruntimes")
+NAMESPACE = "kruntimes-system"
+RELEASES = ("kruntimes-a", "kruntimes-b")
+
+
+@dataclass(frozen=True)
+class Resource:
+    release: str
+    kind: str
+    name: str
+    namespace: str
+    deployment_selector: dict[str, str]
+    text: str
+
+
+def main() -> int:
+    resources: list[Resource] = []
+    for release in RELEASES:
+        rendered = subprocess.check_output(
+            ["helm", "template", release, str(CHART), "--namespace", NAMESPACE],
+            text=True,
+        )
+        resources.extend(parse_resources(release, rendered))
+
+    duplicates = duplicate_resource_keys(resources)
+    if duplicates:
+        print("duplicate rendered resource identities:", file=sys.stderr)
+        for key, owners in duplicates.items():
+            print(f"  {key}: {', '.join(owners)}", file=sys.stderr)
+        return 1
+
+    bad_selectors = [
+        r
+        for r in resources
+        if r.kind == "Deployment"
+        and r.deployment_selector.get("app.kubernetes.io/instance") != r.release
+    ]
+    if bad_selectors:
+        print("deployment selectors must include their release instance:", file=sys.stderr)
+        for resource in bad_selectors:
+            print(
+                f"  {resource.release}/{resource.name}: {resource.deployment_selector}",
+                file=sys.stderr,
+            )
+        return 1
+
+    for release in RELEASES:
+        expected = f"--runtimed-service-account-name={release}-runtimed"
+        controller = find_resource(resources, release, "Deployment", f"{release}-controller")
+        if controller is None or expected not in controller.text:
+            print(
+                f"controller deployment for {release} must pass {expected}",
+                file=sys.stderr,
+            )
+            return 1
+
+    return 0
+
+
+def parse_resources(release: str, rendered: str) -> list[Resource]:
+    docs = re.split(r"^---\s*$", rendered, flags=re.MULTILINE)
+    resources: list[Resource] = []
+    for doc in docs:
+        if not doc.strip():
+            continue
+        kind = field_at_indent(doc, "kind", 0)
+        name = metadata_field(doc, "name")
+        if not kind or not name:
+            continue
+        namespace = metadata_field(doc, "namespace") or "_cluster"
+        resources.append(
+            Resource(
+                release=release,
+                kind=kind,
+                name=name,
+                namespace=namespace,
+                deployment_selector=deployment_selector(doc) if kind == "Deployment" else {},
+                text=doc,
+            )
+        )
+    return resources
+
+
+def field_at_indent(doc: str, field: str, indent: int) -> str:
+    prefix = " " * indent + field + ":"
+    for line in doc.splitlines():
+        if line.startswith(prefix):
+            return line.split(":", 1)[1].strip().strip('"')
+    return ""
+
+
+def metadata_field(doc: str, field: str) -> str:
+    in_metadata = False
+    for line in doc.splitlines():
+        if line == "metadata:":
+            in_metadata = True
+            continue
+        if in_metadata and line and not line.startswith(" "):
+            return ""
+        if in_metadata and line.startswith(f"  {field}:"):
+            return line.split(":", 1)[1].strip().strip('"')
+    return ""
+
+
+def deployment_selector(doc: str) -> dict[str, str]:
+    labels: dict[str, str] = {}
+    in_selector = False
+    in_match_labels = False
+    for line in doc.splitlines():
+        if line == "  selector:":
+            in_selector = True
+            continue
+        if in_selector and line == "    matchLabels:":
+            in_match_labels = True
+            continue
+        if in_match_labels:
+            if not line.startswith("      "):
+                break
+            key, _, value = line.strip().partition(":")
+            labels[key] = value.strip().strip('"')
+    return labels
+
+
+def duplicate_resource_keys(resources: list[Resource]) -> dict[tuple[str, str, str], list[str]]:
+    owners_by_key: dict[tuple[str, str, str], list[str]] = {}
+    for resource in resources:
+        key = (resource.namespace, resource.kind, resource.name)
+        owners_by_key.setdefault(key, []).append(resource.release)
+    return {key: owners for key, owners in owners_by_key.items() if len(owners) > 1}
+
+
+def find_resource(
+    resources: list[Resource],
+    release: str,
+    kind: str,
+    name: str,
+) -> Resource | None:
+    for resource in resources:
+        if resource.release == release and resource.kind == kind and resource.name == name:
+            return resource
+    return None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/internal/controller/runtime_controller.go
+++ b/internal/controller/runtime_controller.go
@@ -26,6 +26,7 @@ import (
 const (
 	runtimeLabel         = "runtime"
 	runtimedDefaultImage = "kruntimes-runtimed:latest"
+	runtimedDefaultSA    = "kruntimes-runtimed"
 	workspaceVolume      = "workspace"
 	workspacePath        = "/workspace"
 	artifactStoreVolume  = "artifact-store"
@@ -38,7 +39,8 @@ type RuntimeReconciler struct {
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 
-	DefaultDaemonImage string
+	DefaultDaemonImage         string
+	RuntimedServiceAccountName string
 }
 
 // +kubebuilder:rbac:groups=kruntimes.io,resources=runtimes,verbs=get;list;watch;update;patch
@@ -108,6 +110,13 @@ func (r *RuntimeReconciler) buildDeployment(rt *v1alpha1.Runtime) *appsv1.Deploy
 	}
 	if r.DefaultDaemonImage != "" {
 		daemonImage = r.DefaultDaemonImage
+	}
+	runtimedServiceAccountName := rt.Spec.RuntimedServiceAccountName
+	if runtimedServiceAccountName == "" {
+		runtimedServiceAccountName = r.RuntimedServiceAccountName
+	}
+	if runtimedServiceAccountName == "" {
+		runtimedServiceAccountName = runtimedDefaultSA
 	}
 
 	labels := map[string]string{
@@ -243,7 +252,7 @@ func (r *RuntimeReconciler) buildDeployment(rt *v1alpha1.Runtime) *appsv1.Deploy
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: labels, Annotations: annotations},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: "kruntimes-runtimed",
+					ServiceAccountName: runtimedServiceAccountName,
 					SecurityContext:    podSecurityContext,
 					Containers:         []corev1.Container{runtimeContainer, daemonContainer},
 					Volumes:            volumes,

--- a/internal/controller/runtime_controller_test.go
+++ b/internal/controller/runtime_controller_test.go
@@ -122,6 +122,31 @@ func TestBuildDeploymentLeavesWorkspaceSizeLimitUnsetByDefault(t *testing.T) {
 	}
 }
 
+func TestBuildDeploymentUsesRuntimedServiceAccount(t *testing.T) {
+	rt := &v1alpha1.Runtime{
+		ObjectMeta: metav1.ObjectMeta{Name: "bash", Namespace: "default"},
+		Spec: v1alpha1.RuntimeSpec{
+			Image: "bash-runtime:latest",
+		},
+	}
+
+	defaultDeploy := (&RuntimeReconciler{}).buildDeployment(rt)
+	if got := defaultDeploy.Spec.Template.Spec.ServiceAccountName; got != runtimedDefaultSA {
+		t.Fatalf("default serviceAccountName = %q, want %q", got, runtimedDefaultSA)
+	}
+
+	deploy := (&RuntimeReconciler{RuntimedServiceAccountName: "team-a-kruntimes-runtimed"}).buildDeployment(rt)
+	if got := deploy.Spec.Template.Spec.ServiceAccountName; got != "team-a-kruntimes-runtimed" {
+		t.Fatalf("serviceAccountName = %q, want configured name", got)
+	}
+
+	rt.Spec.RuntimedServiceAccountName = "custom-runtime-runtimed"
+	deploy = (&RuntimeReconciler{RuntimedServiceAccountName: "team-a-kruntimes-runtimed"}).buildDeployment(rt)
+	if got := deploy.Spec.Template.Spec.ServiceAccountName; got != "custom-runtime-runtimed" {
+		t.Fatalf("serviceAccountName = %q, want Runtime spec override", got)
+	}
+}
+
 func TestBuildNetworkPolicyDeniesRuntimePodIngressByDefault(t *testing.T) {
 	rt := &v1alpha1.Runtime{
 		ObjectMeta: metav1.ObjectMeta{Name: "bash", Namespace: "default"},

--- a/internal/krt/runtime_get.go
+++ b/internal/krt/runtime_get.go
@@ -38,6 +38,9 @@ func NewRuntimeGetCmd(c client.Client) *cobra.Command {
 			if rt.Spec.DaemonImage != "" {
 				fmt.Fprintf(w, "Daemon Image:\t%s\n", rt.Spec.DaemonImage)
 			}
+			if rt.Spec.RuntimedServiceAccountName != "" {
+				fmt.Fprintf(w, "Runtimed ServiceAccount:\t%s\n", rt.Spec.RuntimedServiceAccountName)
+			}
 			if len(rt.Spec.Command) > 0 {
 				fmt.Fprintf(w, "Command:\t%v\n", rt.Spec.Command)
 			}

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -496,6 +496,22 @@ func TestCRDValidationRejectsInvalidRuntimeImage(t *testing.T) {
 	}
 }
 
+func TestCRDValidationRejectsInvalidRuntimeServiceAccountName(t *testing.T) {
+	ctx := context.Background()
+	ns := testNamespace(t, "test-runtime-sa-validation-")
+
+	rt := &v1alpha1.Runtime{
+		ObjectMeta: metav1.ObjectMeta{Name: "invalid-service-account", Namespace: ns.Name},
+		Spec: v1alpha1.RuntimeSpec{
+			Image:                      "runtime:latest",
+			RuntimedServiceAccountName: "Bad_Name",
+		},
+	}
+	if err := k8sClient.Create(ctx, rt); !apierrors.IsInvalid(err) {
+		t.Fatalf("invalid runtime serviceAccountName error = %v, want Invalid", err)
+	}
+}
+
 func testNamespace(t *testing.T, generateName string) *corev1.Namespace {
 	t.Helper()
 	ns := &corev1.Namespace{}


### PR DESCRIPTION
## Summary
- render platform Deployments, ServiceAccounts, ClusterRoles, and ClusterRoleBindings with release-scoped names
- include release instance labels in controller/scheduler selectors so multiple releases do not overlap
- pass the rendered runtimed ServiceAccount name into the controller for Runtime Pods
- add make test-helm with a two-release render verifier and wire it into CI

## Tests
- GOCACHE=/tmp/go-build make test-helm
- GOCACHE=/tmp/go-build make test