### PR TITLE
fix(workflow): hash long child run names

### DIFF
--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -72,7 +72,7 @@
 - [x] 未知 `needs` 必须在 admission 或 reconcile 阶段明确失败。
 - [x] 校验 step 必须包含一个当前支持的执行方式；不能静默接受未实现的 `uses`。
 - [x] 为 job/step 名称增加 Kubernetes 名称和 label 约束。
-- [ ] 生成 child Run 名称时使用截断加稳定 hash，避免超长名称。
+- [x] 生成 child Run 名称时使用截断加稳定 hash，避免超长名称。
 - [ ] 为以上场景增加 controller 和 E2E 测试。
 
 验收标准：

--- a/internal/controller/workflow_controller.go
+++ b/internal/controller/workflow_controller.go
@@ -2,8 +2,11 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strings"
+	"unicode"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -15,6 +18,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+const (
+	childRunNameMaxLength  = 63
+	childRunNameHashLength = 10
 )
 
 // WorkflowReconciler watches Workflow CRs and orchestrates Runs.
@@ -277,7 +285,7 @@ func (r *WorkflowReconciler) buildRun(wf *v1alpha1.Workflow, jobName string, job
 
 	run := &v1alpha1.Run{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("wf-%s-%s-%s", wf.Name, jobName, step.Name),
+			Name:      workflowChildRunName(wf.Name, jobName, step.Name),
 			Namespace: wf.Namespace,
 			Labels: map[string]string{
 				"workflow": wf.Name,
@@ -297,6 +305,62 @@ func (r *WorkflowReconciler) buildRun(wf *v1alpha1.Workflow, jobName string, job
 	}
 
 	return run, nil
+}
+
+func workflowChildRunName(workflowName, jobName, stepName string) string {
+	raw := fmt.Sprintf("wf-%s-%s-%s", workflowName, jobName, stepName)
+	normalized := normalizeDNSLabel(raw)
+	if len(normalized) <= childRunNameMaxLength && normalized == raw {
+		return normalized
+	}
+
+	sum := sha256.Sum256([]byte(raw))
+	suffix := hex.EncodeToString(sum[:])[:childRunNameHashLength]
+	prefixLength := childRunNameMaxLength - childRunNameHashLength - 1
+	prefix := normalized
+	if len(prefix) > prefixLength {
+		prefix = prefix[:prefixLength]
+	}
+	prefix = strings.Trim(prefix, "-")
+	if prefix == "" {
+		prefix = "wf"
+	}
+	return prefix + "-" + suffix
+}
+
+func normalizeDNSLabel(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	lastDash := false
+	for _, r := range name {
+		var next rune
+		switch {
+		case r >= 'a' && r <= 'z':
+			next = r
+		case r >= 'A' && r <= 'Z':
+			next = unicode.ToLower(r)
+		case r >= '0' && r <= '9':
+			next = r
+		case r == '-':
+			next = r
+		default:
+			next = '-'
+		}
+		if next == '-' {
+			if lastDash {
+				continue
+			}
+			lastDash = true
+		} else {
+			lastDash = false
+		}
+		b.WriteRune(next)
+	}
+	normalized := strings.Trim(b.String(), "-")
+	if normalized == "" {
+		return "wf"
+	}
+	return normalized
 }
 
 func needsMet(needs []string, jobs map[string]v1alpha1.JobStatus) bool {

--- a/internal/controller/workflow_controller_test.go
+++ b/internal/controller/workflow_controller_test.go
@@ -3,12 +3,14 @@ package controller
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -190,6 +192,46 @@ func TestWorkflowChildRunTerminalPhasesFailWorkflow(t *testing.T) {
 				t.Fatalf("step runName = %q, want child-run", step.RunName)
 			}
 		})
+	}
+}
+
+func TestWorkflowChildRunNamePreservesShortNames(t *testing.T) {
+	got := workflowChildRunName("wf", "build", "compile")
+	if got != "wf-wf-build-compile" {
+		t.Fatalf("child run name = %q, want legacy short name", got)
+	}
+}
+
+func TestWorkflowChildRunNameTruncatesWithStableHash(t *testing.T) {
+	workflowName := "workflow-" + strings.Repeat("a", 55)
+	jobName := "job-" + strings.Repeat("b", 55)
+	stepName := "step-" + strings.Repeat("c", 55)
+
+	got := workflowChildRunName(workflowName, jobName, stepName)
+	if len(got) > childRunNameMaxLength {
+		t.Fatalf("child run name length = %d, want <= %d: %q", len(got), childRunNameMaxLength, got)
+	}
+	if errs := validation.IsDNS1123Label(got); len(errs) > 0 {
+		t.Fatalf("child run name %q is not a DNS label: %v", got, errs)
+	}
+	if again := workflowChildRunName(workflowName, jobName, stepName); again != got {
+		t.Fatalf("child run name is not stable: %q then %q", got, again)
+	}
+	if other := workflowChildRunName(workflowName, jobName, "step-"+strings.Repeat("d", 55)); other == got {
+		t.Fatalf("different step produced same child run name %q", got)
+	}
+}
+
+func TestWorkflowChildRunNameNormalizesInvalidDNSLabelCharacters(t *testing.T) {
+	got := workflowChildRunName("Release.WF", "Build_Job", "Compile.Step")
+	if len(got) > childRunNameMaxLength {
+		t.Fatalf("child run name length = %d, want <= %d: %q", len(got), childRunNameMaxLength, got)
+	}
+	if errs := validation.IsDNS1123Label(got); len(errs) > 0 {
+		t.Fatalf("child run name %q is not a DNS label: %v", got, errs)
+	}
+	if !strings.HasPrefix(got, "wf-release-wf-build-job-compile-step-") {
+		t.Fatalf("child run name = %q, want normalized prefix with hash suffix", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- generate Workflow child Run names through a DNS-label helper
- preserve existing short child Run names when they are already valid
- truncate long or normalized names and append a stable sha256 hash suffix
- mark the child Run name roadmap item complete

## Tests
- GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/controller -count=1
- GOCACHE=/tmp/go-build make test