### PR TITLE
chore: pin Docker base image digests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      docker-base-images:
+        patterns:
+          - "*"

--- a/Dockerfile.bash-runtime
+++ b/Dockerfile.bash-runtime
@@ -1,11 +1,11 @@
-FROM golang:1.26 AS builder
+FROM golang:1.26.4@sha256:792443b89f65105abba56b9bd5e97f680a80074ac62fc844a584212f8c8102c3 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o bash-runtime ./runtimes/bash/cmd
 
-FROM ubuntu:latest
+FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
 COPY --from=builder /app/bash-runtime /bash-runtime
 USER 65532
 ENTRYPOINT ["/bash-runtime"]

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -1,4 +1,4 @@
-FROM golang:1.26 AS builder
+FROM golang:1.26.4@sha256:792443b89f65105abba56b9bd5e97f680a80074ac62fc844a584212f8c8102c3 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Dockerfile.python-runtime
+++ b/Dockerfile.python-runtime
@@ -1,6 +1,6 @@
-FROM ghcr.io/astral-sh/uv:0.11.16 AS uv
+FROM ghcr.io/astral-sh/uv:0.11.16@sha256:440fd6477af86a2f1b38080c539f1672cd22acb1b1a47e321dba5158ab08864d AS uv
 
-FROM python:3.14-slim AS dependencies
+FROM python:3.14.6-slim-trixie@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6500b1eff50061 AS dependencies
 
 COPY --from=uv /uv /bin/uv
 
@@ -14,7 +14,7 @@ ENV UV_COMPILE_BYTECODE=1 \
 
 RUN uv sync --locked --no-dev --no-install-project
 
-FROM python:3.14-slim
+FROM python:3.14.6-slim-trixie@sha256:44dd04494ee8f3b538294360e7c4b3acb87c8268e4d0a4828a6500b1eff50061
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git && \

--- a/Dockerfile.runtimed
+++ b/Dockerfile.runtimed
@@ -1,11 +1,11 @@
-FROM golang:1.26 AS builder
+FROM golang:1.26.4@sha256:792443b89f65105abba56b9bd5e97f680a80074ac62fc844a584212f8c8102c3 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o runtimed ./cmd/runtimed
 
-FROM ubuntu:latest
+FROM ubuntu:24.04@sha256:786a8b558f7be160c6c8c4a54f9a57274f3b4fb1491cf65146521ae77ff1dc54
 RUN useradd -u 65532 nonroot
 COPY --from=builder /app/runtimed /runtimed
 USER 65532

--- a/Dockerfile.scheduler
+++ b/Dockerfile.scheduler
@@ -1,4 +1,4 @@
-FROM golang:1.26 AS builder
+FROM golang:1.26.4@sha256:792443b89f65105abba56b9bd5e97f680a80074ac62fc844a584212f8c8102c3 AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -149,7 +149,7 @@
 改进项：
 
 - [ ] 升级 Go toolchain 和受影响依赖，并让 `govulncheck` 通过。
-- [ ] Docker 基础镜像固定到明确 patch version 和 digest。
+- [x] Docker 基础镜像固定到明确 patch version 和 digest。
 - [x] Python 镜像通过 `uv.lock` 安装依赖，不直接安装未固定版本。
 - [x] 固定 Makefile 中 controller-gen、setup-envtest、golangci-lint、
   protoc plugins 和 uv 的版本。


### PR DESCRIPTION
## Summary
- pin Go builder images to golang:1.26.4 with an immutable manifest digest
- replace ubuntu:latest with ubuntu:24.04 plus an immutable manifest digest
- pin Python runtime base images to python:3.14.6-slim-trixie and the uv image to immutable manifest digests
- mark the Docker base image supply-chain roadmap item done

## Tests
- docker buildx imagetools inspect golang:1.26.4
- docker buildx imagetools inspect ubuntu:24.04
- docker buildx imagetools inspect python:3.14.6-slim-trixie
- docker buildx imagetools inspect ghcr.io/astral-sh/uv:0.11.16
- GOCACHE=/tmp/go-build make docker-build