### PR TITLE
fix(helm): default image tags to chart appVersion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,7 @@ test-helm: manifests ## Validate Helm charts and multi-release rendering.
 	$(HELM) template kruntimes ./charts/kruntimes --namespace kruntimes-system
 	$(HELM) template kruntimes-runtimes ./charts/kruntimes-runtimes --namespace default
 	./hack/verify-helm-multi-release.py
+	./hack/verify-helm-images.py
 
 ##@ Deployment
 

--- a/charts/kruntimes-runtimes/templates/_helpers.tpl
+++ b/charts/kruntimes-runtimes/templates/_helpers.tpl
@@ -4,3 +4,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+
+{{- define "kruntimes-runtimes.image" -}}
+{{- $root := index . 0 -}}
+{{- $image := index . 1 -}}
+{{- if or (contains "@" $image) (regexMatch "(^|/)[^/]+:[^/]+$" $image) -}}
+{{- $image -}}
+{{- else -}}
+{{- printf "%s:%s" $image $root.Chart.AppVersion -}}
+{{- end -}}
+{{- end }}

--- a/charts/kruntimes-runtimes/templates/bash-runtime.yaml
+++ b/charts/kruntimes-runtimes/templates/bash-runtime.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "kruntimes-runtimes.labels" . | nindent 4 }}
 spec:
-  image: {{ .Values.bash.image }}
+  image: {{ include "kruntimes-runtimes.image" (list . .Values.bash.image) }}
   port: {{ .Values.bash.port }}
   replicas: {{ .Values.bash.replicas }}
   capacity:

--- a/charts/kruntimes-runtimes/templates/python-runtime.yaml
+++ b/charts/kruntimes-runtimes/templates/python-runtime.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "kruntimes-runtimes.labels" . | nindent 4 }}
 spec:
-  image: {{ .Values.python.image }}
+  image: {{ include "kruntimes-runtimes.image" (list . .Values.python.image) }}
   port: {{ .Values.python.port }}
   replicas: {{ .Values.python.replicas }}
   capacity:

--- a/charts/kruntimes-runtimes/values.yaml
+++ b/charts/kruntimes-runtimes/values.yaml
@@ -5,7 +5,7 @@ workspace:
   sizeLimit: 10Gi
 
 bash:
-  image: kruntimes-bash-runtime:latest
+  image: kruntimes-bash-runtime
   port: 9091
   replicas: 2
   capacity:
@@ -20,7 +20,7 @@ bash:
       memory: 2Gi
 
 python:
-  image: kruntimes-python-runtime:latest
+  image: kruntimes-python-runtime
   port: 9092
   replicas: 2
   capacity:

--- a/charts/kruntimes/templates/_helpers.tpl
+++ b/charts/kruntimes/templates/_helpers.tpl
@@ -63,3 +63,13 @@ app: kruntimes-scheduler
 app.kubernetes.io/component: runtimed
 app: kruntimes-runtimed
 {{- end }}
+
+{{- define "kruntimes.image" -}}
+{{- $root := index . 0 -}}
+{{- $image := index . 1 -}}
+{{- if or (contains "@" $image) (regexMatch "(^|/)[^/]+:[^/]+$" $image) -}}
+{{- $image -}}
+{{- else -}}
+{{- printf "%s:%s" $image $root.Chart.AppVersion -}}
+{{- end -}}
+{{- end }}

--- a/charts/kruntimes/templates/controller-deployment.yaml
+++ b/charts/kruntimes/templates/controller-deployment.yaml
@@ -21,7 +21,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: controller
-          image: {{ .Values.controller.image }}
+          image: {{ include "kruntimes.image" (list . .Values.controller.image) }}
           imagePullPolicy: {{ .Values.controller.imagePullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -34,7 +34,7 @@ spec:
             - --leader-elect=true
             - --metrics-bind-address=:8082
             - --health-probe-bind-address=:8083
-            - --default-daemon-image={{ .Values.runtimed.image }}
+            - --default-daemon-image={{ include "kruntimes.image" (list . .Values.runtimed.image) }}
             - --runtimed-service-account-name={{ include "kruntimes.runtimed.name" . }}
           ports:
             - containerPort: 8082

--- a/charts/kruntimes/templates/scheduler-deployment.yaml
+++ b/charts/kruntimes/templates/scheduler-deployment.yaml
@@ -21,7 +21,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: scheduler
-          image: {{ .Values.scheduler.image }}
+          image: {{ include "kruntimes.image" (list . .Values.scheduler.image) }}
           imagePullPolicy: {{ .Values.scheduler.imagePullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/kruntimes/values.yaml
+++ b/charts/kruntimes/values.yaml
@@ -1,7 +1,7 @@
 namespace: default
 
 scheduler:
-  image: kruntimes-scheduler:latest
+  image: kruntimes-scheduler
   imagePullPolicy: IfNotPresent
   replicas: 2
   leaderElect: true
@@ -16,7 +16,7 @@ scheduler:
       memory: 256Mi
 
 controller:
-  image: kruntimes-controller:latest
+  image: kruntimes-controller
   imagePullPolicy: IfNotPresent
   resources:
     requests:
@@ -27,7 +27,7 @@ controller:
       memory: 256Mi
 
 runtimed:
-  image: kruntimes-runtimed:latest
+  image: kruntimes-runtimed
   imagePullPolicy: IfNotPresent
   workers: 2
   resources:

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -109,7 +109,7 @@
 - [x] 所有 Helm 资源名称使用 release fullname，支持多个 release 共存。
 - [ ] 移除未使用 values，并让 replicas、leader election、ports、imagePullSecrets、
   security context、scheduling constraints 等可配置。
-- [ ] 避免默认使用 `latest`，镜像 tag 应跟随 chart appVersion。
+- [x] 避免默认使用 `latest`，镜像 tag 应跟随 chart appVersion。
 - [ ] 增加多 namespace 模板/安装测试。
 - [x] 增加第二个 Helm release 的模板测试。
 

--- a/hack/verify-helm-images.py
+++ b/hack/verify-helm-images.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Verify Helm image defaults and explicit image overrides."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def main() -> int:
+    platform = helm_template("kruntimes", "charts/kruntimes")
+    runtimes = helm_template("kruntimes-runtimes", "charts/kruntimes-runtimes")
+
+    expected_defaults = [
+        "image: kruntimes-controller:0.1.0",
+        "image: kruntimes-scheduler:0.1.0",
+        "--default-daemon-image=kruntimes-runtimed:0.1.0",
+        "image: kruntimes-bash-runtime:0.1.0",
+        "image: kruntimes-python-runtime:0.1.0",
+    ]
+    for expected in expected_defaults:
+        if expected not in platform and expected not in runtimes:
+            print(f"missing default appVersion image: {expected}", file=sys.stderr)
+            return 1
+
+    platform_overrides = helm_template(
+        "kruntimes",
+        "charts/kruntimes",
+        "--set",
+        "scheduler.image=example.com:5000/ns/scheduler:dev",
+        "--set",
+        "controller.image=repo/controller@sha256:abc",
+        "--set",
+        "runtimed.image=repo/runtimed:dev",
+    )
+    expected_platform_overrides = [
+        "image: example.com:5000/ns/scheduler:dev",
+        "image: repo/controller@sha256:abc",
+        "--default-daemon-image=repo/runtimed:dev",
+    ]
+    for expected in expected_platform_overrides:
+        if expected not in platform_overrides:
+            print(f"missing explicit platform image override: {expected}", file=sys.stderr)
+            return 1
+
+    runtime_overrides = helm_template(
+        "kruntimes-runtimes",
+        "charts/kruntimes-runtimes",
+        "--set",
+        "bash.image=localhost:5000/bash:dev",
+        "--set",
+        "python.image=repo/python@sha256:def",
+    )
+    expected_runtime_overrides = [
+        "image: localhost:5000/bash:dev",
+        "image: repo/python@sha256:def",
+    ]
+    for expected in expected_runtime_overrides:
+        if expected not in runtime_overrides:
+            print(f"missing explicit runtime image override: {expected}", file=sys.stderr)
+            return 1
+
+    return 0
+
+
+def helm_template(release: str, chart: str, *args: str) -> str:
+    return subprocess.check_output(
+        ["helm", "template", release, chart, "--namespace", "default", *args],
+        text=True,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- remove latest from default platform and built-in runtime chart image values
- append .Chart.AppVersion when chart image values do not include an explicit tag or digest
- preserve explicit tag and digest overrides, including registry hosts with ports
- add Helm image rendering verification to make test-helm
- mark the Helm image tag roadmap item done

## Tests
- GOCACHE=/tmp/go-build make test-helm