### PR TITLE
feat(helm): expose control plane metrics services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,6 +217,7 @@ test-helm: manifests ## Validate Helm charts and multi-release rendering.
 	./hack/verify-helm-multi-release.py
 	./hack/verify-helm-images.py
 	./hack/verify-helm-multi-namespace.py
+	./hack/verify-helm-metrics.py
 
 ##@ Deployment
 

--- a/README.md
+++ b/README.md
@@ -410,6 +410,11 @@ grants code-execution capability inside the selected Runtime Pod's trust
 boundary. Creating or updating a `Runtime` grants control over the images and
 storage used by that Runtime pool.
 
+The platform chart always creates Kubernetes Services for controller and
+scheduler metrics. Optional `ServiceMonitor` rendering is disabled by default;
+enable `metrics.serviceMonitor.enabled` only when Prometheus Operator has
+installed the `monitoring.coreos.com/v1` `ServiceMonitor` CRD in the cluster.
+
 ### Create a Run
 
 ```bash

--- a/charts/kruntimes/templates/metrics-service.yaml
+++ b/charts/kruntimes/templates/metrics-service.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kruntimes.scheduler.name" . }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kruntimes.scheduler.labels" . | nindent 4 }}
+  {{- with .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.metrics.service.type }}
+  selector:
+    {{- include "kruntimes.scheduler.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.service.port }}
+      targetPort: metrics
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kruntimes.controller.name" . }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kruntimes.controller.labels" . | nindent 4 }}
+  {{- with .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.metrics.service.type }}
+  selector:
+    {{- include "kruntimes.controller.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: metrics
+      port: {{ .Values.metrics.service.port }}
+      targetPort: metrics
+      protocol: TCP

--- a/charts/kruntimes/templates/servicemonitor.yaml
+++ b/charts/kruntimes/templates/servicemonitor.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "kruntimes.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kruntimes.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchExpressions:
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+          - controller
+          - scheduler
+      - key: app.kubernetes.io/instance
+        operator: In
+        values:
+          - {{ .Release.Name }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/charts/kruntimes/values.yaml
+++ b/charts/kruntimes/values.yaml
@@ -40,3 +40,17 @@ runtimed:
 
 workspace:
   sizeLimit: 10Gi
+
+metrics:
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+  # Disabled by default because ServiceMonitor is provided by Prometheus Operator,
+  # not by Kubernetes itself. Enable only when the monitoring.coreos.com/v1
+  # ServiceMonitor CRD is installed in the cluster.
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    scrapeTimeout: 10s
+    labels: {}

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -175,7 +175,7 @@
 - [x] 为 CRD 增加 CEL 校验和字段大小限制。
 - [x] 为 Run/Workflow conditions 使用 Kubernetes list-map markers。
 - [ ] 补齐 queue time、dispatch latency、retry、failure 和 active Run metrics。
-- [ ] Chart 创建 metrics Service，并提供可选 ServiceMonitor。
+- [x] Chart 创建 metrics Service，并提供可选 ServiceMonitor。
 
 ## P2: Release and Contributor Experience
 

--- a/hack/verify-helm-metrics.py
+++ b/hack/verify-helm-metrics.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Verify kruntimes Helm chart metrics Service and ServiceMonitor rendering."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CHART = Path("charts/kruntimes")
+RELEASE = "kruntimes"
+NAMESPACE = "kruntimes-system"
+
+
+@dataclass(frozen=True)
+class Resource:
+    kind: str
+    name: str
+    namespace: str
+    text: str
+
+
+def main() -> int:
+    rendered = helm_template()
+    resources = parse_resources(rendered)
+
+    service_names = {r.name for r in resources if r.kind == "Service"}
+    expected_services = {"kruntimes-scheduler-metrics", "kruntimes-controller-metrics"}
+    if not expected_services.issubset(service_names):
+        print(f"missing metrics Services: {expected_services - service_names}", file=sys.stderr)
+        return 1
+
+    for service in [r for r in resources if r.kind == "Service" and r.name in expected_services]:
+        if service.namespace != NAMESPACE:
+            print(f"Service/{service.name} namespace = {service.namespace}, want {NAMESPACE}", file=sys.stderr)
+            return 1
+        if "targetPort: metrics" not in service.text:
+            print(f"Service/{service.name} must target the named metrics port", file=sys.stderr)
+            return 1
+        component = service.name.removeprefix("kruntimes-").removesuffix("-metrics")
+        if f"app.kubernetes.io/component: {component}" not in service.text:
+            print(f"Service/{service.name} selector must target {component}", file=sys.stderr)
+            return 1
+
+    if any(r.kind == "ServiceMonitor" for r in resources):
+        print("ServiceMonitor must be disabled by default", file=sys.stderr)
+        return 1
+
+    monitored = helm_template("--set", "metrics.serviceMonitor.enabled=true")
+    monitored_resources = parse_resources(monitored)
+    service_monitors = [r for r in monitored_resources if r.kind == "ServiceMonitor"]
+    if len(service_monitors) != 1:
+        print(f"ServiceMonitor count = {len(service_monitors)}, want 1", file=sys.stderr)
+        return 1
+    monitor = service_monitors[0]
+    for expected in [
+        "name: kruntimes-metrics",
+        "port: metrics",
+        "path: /metrics",
+        "app.kubernetes.io/component",
+        "controller",
+        "scheduler",
+    ]:
+        if expected not in monitor.text:
+            print(f"ServiceMonitor missing {expected!r}", file=sys.stderr)
+            return 1
+
+    return 0
+
+
+def helm_template(*args: str) -> str:
+    return subprocess.check_output(
+        ["helm", "template", RELEASE, str(CHART), "--namespace", NAMESPACE, *args],
+        text=True,
+    )
+
+
+def parse_resources(rendered: str) -> list[Resource]:
+    docs = re.split(r"^---\s*$", rendered, flags=re.MULTILINE)
+    resources: list[Resource] = []
+    for doc in docs:
+        if not doc.strip():
+            continue
+        kind = field_at_indent(doc, "kind", 0)
+        name = metadata_field(doc, "name")
+        if not kind or not name:
+            continue
+        namespace = metadata_field(doc, "namespace") or "_cluster"
+        resources.append(Resource(kind=kind, name=name, namespace=namespace, text=doc))
+    return resources
+
+
+def field_at_indent(doc: str, field: str, indent: int) -> str:
+    prefix = " " * indent + field + ":"
+    for line in doc.splitlines():
+        if line.startswith(prefix):
+            return line.split(":", 1)[1].strip().strip('"')
+    return ""
+
+
+def metadata_field(doc: str, field: str) -> str:
+    in_metadata = False
+    for line in doc.splitlines():
+        if line == "metadata:":
+            in_metadata = True
+            continue
+        if in_metadata and line and not line.startswith(" "):
+            return ""
+        if in_metadata and line.startswith(f"  {field}:"):
+            return line.split(":", 1)[1].strip().strip('"')
+    return ""
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add controller and scheduler metrics Services to the platform chart
- add optional ServiceMonitor rendering with labels and scrape settings
- document that ServiceMonitor requires Prometheus Operator's monitoring.coreos.com/v1 CRD and is disabled by default
- add Helm verifier coverage and mark the roadmap item done

## Tests
- GOCACHE=/tmp/go-build make test-helm