### PR TITLE
feat(metrics): add run lifecycle observability

### DIFF
--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -174,7 +174,7 @@
 - [x] 增加真实 readiness check，而不是固定返回成功。
 - [x] 为 CRD 增加 CEL 校验和字段大小限制。
 - [x] 为 Run/Workflow conditions 使用 Kubernetes list-map markers。
-- [ ] 补齐 queue time、dispatch latency、retry、failure 和 active Run metrics。
+- [x] 补齐 queue time、dispatch latency、retry、failure 和 active Run metrics。
 - [x] Chart 创建 metrics Service，并提供可选 ServiceMonitor。
 
 ## P2: Release and Contributor Experience

--- a/internal/runstatus/status.go
+++ b/internal/runstatus/status.go
@@ -8,6 +8,7 @@ import (
 )
 
 const (
+	ConditionScheduled = "Scheduled"
 	ConditionRunning   = "Running"
 	ConditionCompleted = "Completed"
 )

--- a/internal/runtimed/controller.go
+++ b/internal/runtimed/controller.go
@@ -66,6 +66,35 @@ var (
 		},
 		[]string{"runtime"},
 	)
+	dispatchDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "kruntimes_runtimed_dispatch_duration_seconds",
+			Help:    "Time from scheduler assignment until runtimed claims the Run.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"runtime"},
+	)
+	runRetries = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kruntimes_runtimed_run_retries_total",
+			Help: "Total number of Run retries scheduled by this runtimed.",
+		},
+		[]string{"runtime", "reason"},
+	)
+	runFailures = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "kruntimes_runtimed_run_failures_total",
+			Help: "Total number of terminal Run failures by this runtimed.",
+		},
+		[]string{"runtime", "phase", "reason"},
+	)
+	activeRuns = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kruntimes_runtimed_active_runs",
+			Help: "Number of Runs currently active in this runtimed.",
+		},
+		[]string{"runtime"},
+	)
 )
 
 type activeRun struct {
@@ -217,11 +246,20 @@ func (c *Controller) reconcileScheduled(ctx context.Context, run *v1alpha1.Run) 
 		return ctrl.Result{RequeueAfter: time.Second}, nil
 	}
 
+	startedAt := metav1.Now()
 	run.Status.Phase = v1alpha1.RunRunning
-	run.Status.StartTime = &metav1.Time{Time: time.Now()}
+	run.Status.StartTime = &startedAt
+	meta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{
+		Type:               runstatus.ConditionRunning,
+		Status:             metav1.ConditionTrue,
+		Reason:             "Claimed",
+		Message:            "claimed by runtimed",
+		LastTransitionTime: startedAt,
+	})
 	if err := c.Status().Update(ctx, run); err != nil {
 		return ctrl.Result{}, err
 	}
+	c.observeDispatchDuration(run, startedAt.Time)
 	klog.Infof("Claimed run %s", run.Name)
 
 	ar := &activeRun{
@@ -234,6 +272,7 @@ func (c *Controller) reconcileScheduled(ctx context.Context, run *v1alpha1.Run) 
 	}
 
 	c.activeRuns.Store(uid, ar)
+	c.recordActiveRuns(run.Spec.Runtime)
 
 	workDir, err := prepareSource(run)
 	if err != nil {
@@ -583,6 +622,7 @@ func (c *Controller) scheduleRetry(ctx context.Context, ar *activeRun, curAttemp
 	}
 
 	c.rleg.RemoveRun(string(run.UID))
+	runRetries.WithLabelValues(run.Spec.Runtime, reason).Inc()
 	c.recordEvent(run, corev1.EventTypeWarning, "RunFailedRetrying",
 		"Run failed (attempt %d/%d), retrying in %s. Reason: %s: %s",
 		curAttempt, policy.MaxAttempts, backoff, reason, msg)
@@ -620,6 +660,9 @@ func (c *Controller) applyTerminalWithOutput(
 
 	c.emitExecutionOutput(run, output)
 	c.cleanup(ctx, ar, phase)
+	if phase == v1alpha1.RunFailed || phase == v1alpha1.RunTimeout {
+		runFailures.WithLabelValues(run.Spec.Runtime, string(phase), reason).Inc()
+	}
 	c.recordEvent(run, corev1.EventTypeWarning, "RunRetriesExhausted",
 		"Run failed after %d attempts: %s: %s", run.Status.Attempt, reason, msg)
 	return ctrl.Result{}, nil
@@ -634,6 +677,7 @@ func (c *Controller) cleanup(ctx context.Context, ar *activeRun, phase v1alpha1.
 		c.rleg.RemoveRun(string(ar.run.UID))
 	}
 	c.activeRuns.Delete(string(ar.run.UID))
+	c.recordActiveRuns(ar.run.Spec.Runtime)
 	c.releaseExecution(ctx, string(ar.run.UID))
 	if err := os.RemoveAll(workspaceForRun(ar.run)); err != nil {
 		c.Log.Error(err, "failed to remove Run workspace", "run", client.ObjectKeyFromObject(ar.run))
@@ -875,10 +919,39 @@ func (c *Controller) addRecoveredRun(run *v1alpha1.Run) *activeRun {
 	ar := c.buildActiveRun(run)
 	ar.started.Store(true)
 	c.activeRuns.Store(uid, ar)
+	c.recordActiveRuns(run.Spec.Runtime)
 	if c.rleg != nil {
 		c.rleg.AddRun(run)
 	}
 	return ar
+}
+
+func (c *Controller) observeDispatchDuration(run *v1alpha1.Run, claimedAt time.Time) {
+	if seconds, ok := dispatchDurationSeconds(run, claimedAt); ok {
+		dispatchDuration.WithLabelValues(run.Spec.Runtime).Observe(seconds)
+	}
+}
+
+func dispatchDurationSeconds(run *v1alpha1.Run, claimedAt time.Time) (float64, bool) {
+	if run == nil || claimedAt.IsZero() {
+		return 0, false
+	}
+	condition := meta.FindStatusCondition(run.Status.Conditions, runstatus.ConditionScheduled)
+	if condition == nil || condition.Status != metav1.ConditionTrue || condition.LastTransitionTime.IsZero() {
+		return 0, false
+	}
+	duration := claimedAt.Sub(condition.LastTransitionTime.Time)
+	if duration < 0 {
+		return 0, false
+	}
+	return duration.Seconds(), true
+}
+
+func (c *Controller) recordActiveRuns(runtimeName string) {
+	if runtimeName == "" {
+		runtimeName = c.RuntimeName
+	}
+	activeRuns.WithLabelValues(runtimeName).Set(float64(c.activeRunCount()))
 }
 
 func (c *Controller) buildActiveRun(run *v1alpha1.Run) *activeRun {

--- a/internal/runtimed/controller_test.go
+++ b/internal/runtimed/controller_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 	"github.com/kruntimes/kruntimes/internal/artifact"
 	runretry "github.com/kruntimes/kruntimes/internal/retry"
+	"github.com/kruntimes/kruntimes/internal/runstatus"
 	rlegpkg "github.com/kruntimes/kruntimes/internal/runtimed/rleg"
 )
 
@@ -45,6 +46,36 @@ func TestPrepareSource_NoSource(t *testing.T) {
 	}
 	if _, err := os.Stat(workDir); err != nil {
 		t.Errorf("workDir not created: %v", err)
+	}
+}
+
+func TestDispatchDurationSeconds(t *testing.T) {
+	claimedAt := time.Now()
+	run := &v1alpha1.Run{
+		Status: v1alpha1.RunStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               runstatus.ConditionScheduled,
+					Status:             metav1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(claimedAt.Add(-3 * time.Second)),
+				},
+			},
+		},
+	}
+
+	got, ok := dispatchDurationSeconds(run, claimedAt)
+	if !ok || got < 2.9 || got > 3.1 {
+		t.Fatalf("dispatchDurationSeconds() = %f, %v; want about 3s", got, ok)
+	}
+
+	run.Status.Conditions[0].LastTransitionTime = metav1.NewTime(claimedAt.Add(time.Second))
+	if _, ok := dispatchDurationSeconds(run, claimedAt); ok {
+		t.Fatal("dispatchDurationSeconds() ok = true for negative duration")
+	}
+
+	run.Status.Conditions = nil
+	if _, ok := dispatchDurationSeconds(run, claimedAt); ok {
+		t.Fatal("dispatchDurationSeconds() ok = true without Scheduled condition")
 	}
 }
 

--- a/internal/scheduler/reconciler.go
+++ b/internal/scheduler/reconciler.go
@@ -50,10 +50,18 @@ var (
 		},
 		[]string{"runtime"},
 	)
+	runQueueDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "kruntimes_scheduler_run_queue_duration_seconds",
+			Help:    "Time from Run creation until scheduler assignment.",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"runtime"},
+	)
 )
 
 func init() {
-	metrics.Registry.MustRegister(runsScheduled, syncDuration, noPodsTotal)
+	metrics.Registry.MustRegister(runsScheduled, syncDuration, noPodsTotal, runQueueDuration)
 }
 
 // RunReconciler watches Pending Tasks and assigns them to Runtime Pods.
@@ -158,6 +166,14 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	run.Status.AssignedPod = selected.Name
 	run.Status.Phase = v1alpha1.RunScheduled
+	scheduledAt := metav1.Now()
+	meta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{
+		Type:               runstatus.ConditionScheduled,
+		Status:             metav1.ConditionTrue,
+		Reason:             "Assigned",
+		Message:            fmt.Sprintf("assigned to runtime pod %s", selected.Name),
+		LastTransitionTime: scheduledAt,
+	})
 	if err := r.Status().Update(ctx, &run); err != nil {
 		if apierrors.IsConflict(err) {
 			return ctrl.Result{Requeue: true}, nil
@@ -167,7 +183,25 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	log.Info("Run scheduled", "pod", selected.Name)
 	runsScheduled.WithLabelValues(run.Spec.Runtime, "scheduled").Inc()
+	observeRunQueueDuration(&run, scheduledAt.Time)
 	return ctrl.Result{}, nil
+}
+
+func observeRunQueueDuration(run *v1alpha1.Run, scheduledAt time.Time) {
+	if seconds, ok := runQueueDurationSeconds(run, scheduledAt); ok {
+		runQueueDuration.WithLabelValues(run.Spec.Runtime).Observe(seconds)
+	}
+}
+
+func runQueueDurationSeconds(run *v1alpha1.Run, scheduledAt time.Time) (float64, bool) {
+	if run == nil || run.CreationTimestamp.IsZero() || scheduledAt.IsZero() {
+		return 0, false
+	}
+	duration := scheduledAt.Sub(run.CreationTimestamp.Time)
+	if duration < 0 {
+		return 0, false
+	}
+	return duration.Seconds(), true
 }
 
 func (r *RunReconciler) applyCancelled(ctx context.Context, run *v1alpha1.Run) (ctrl.Result, error) {

--- a/internal/scheduler/reconciler_test.go
+++ b/internal/scheduler/reconciler_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -15,6 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	"github.com/kruntimes/kruntimes/internal/runstatus"
 	"github.com/kruntimes/kruntimes/internal/runtimepod"
 )
 
@@ -128,6 +130,83 @@ func TestReconcileCancelsPendingRun(t *testing.T) {
 	}
 }
 
+func TestReconcileRecordsScheduledCondition(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add kruntimes scheme: %v", err)
+	}
+
+	createdAt := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	run := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "run-scheduled",
+			Namespace:         "default",
+			CreationTimestamp: createdAt,
+		},
+		Spec: v1alpha1.RunSpec{Runtime: "bash"},
+		Status: v1alpha1.RunStatus{
+			Phase: v1alpha1.RunPending,
+		},
+	}
+	podReady := metav1.Now()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "runtime-a",
+			Namespace: "default",
+			Labels: map[string]string{
+				"runtime": "bash",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				{
+					Type:          v1alpha1.RuntimePodRuntimedReadyCondition,
+					Status:        corev1.ConditionTrue,
+					LastProbeTime: podReady,
+				},
+			},
+		},
+	}
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.Run{}).
+		WithObjects(run, pod).
+		Build()
+
+	reconciler := &RunReconciler{
+		Client:   client,
+		Log:      logr.Discard(),
+		Strategy: &LeastLoaded{},
+	}
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: run.Name, Namespace: run.Namespace},
+	}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	var updated v1alpha1.Run
+	if err := client.Get(context.Background(), types.NamespacedName{Name: run.Name, Namespace: run.Namespace}, &updated); err != nil {
+		t.Fatalf("get updated run: %v", err)
+	}
+	if updated.Status.Phase != v1alpha1.RunScheduled {
+		t.Fatalf("phase = %s, want Scheduled", updated.Status.Phase)
+	}
+	if updated.Status.AssignedPod != pod.Name {
+		t.Fatalf("assignedPod = %q, want %q", updated.Status.AssignedPod, pod.Name)
+	}
+	condition := meta.FindStatusCondition(updated.Status.Conditions, runstatus.ConditionScheduled)
+	if condition == nil || condition.Status != metav1.ConditionTrue || condition.Reason != "Assigned" {
+		t.Fatalf("Scheduled condition = %#v, want true/Assigned", condition)
+	}
+}
+
 func TestIsPodSchedulableRequiresReadyRunningPod(t *testing.T) {
 	now := metav1.Now()
 	tests := []struct {
@@ -233,6 +312,24 @@ func TestPendingRetryDelay(t *testing.T) {
 	run.Status.Conditions[0].LastTransitionTime = metav1.NewTime(time.Now().Add(-2 * time.Minute))
 	if delay := pendingRetryDelay(run); delay > 0 {
 		t.Fatalf("pendingRetryDelay() = %s, want no delay after backoff expires", delay)
+	}
+}
+
+func TestRunQueueDurationSeconds(t *testing.T) {
+	scheduledAt := time.Now()
+	run := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{
+			CreationTimestamp: metav1.NewTime(scheduledAt.Add(-2 * time.Second)),
+		},
+	}
+	got, ok := runQueueDurationSeconds(run, scheduledAt)
+	if !ok || got < 1.9 || got > 2.1 {
+		t.Fatalf("runQueueDurationSeconds() = %f, %v; want about 2s", got, ok)
+	}
+
+	run.CreationTimestamp = metav1.NewTime(scheduledAt.Add(time.Second))
+	if _, ok := runQueueDurationSeconds(run, scheduledAt); ok {
+		t.Fatal("runQueueDurationSeconds() ok = true for negative duration")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add scheduler queue duration metrics and record a Scheduled condition when assigning Runs
- add runtimed dispatch duration, retry, terminal failure, and active Run metrics
- add focused tests for Scheduled condition and latency helpers
- mark the open-source readiness metrics item done

## Tests
- GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/scheduler ./internal/runtimed -count=1
- GOCACHE=/tmp/go-build make test