### PR TITLE
feat(helm): make control plane deployment settings configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,7 @@ test-helm: manifests ## Validate Helm charts and multi-release rendering.
 	./hack/verify-helm-images.py
 	./hack/verify-helm-multi-namespace.py
 	./hack/verify-helm-metrics.py
+	./hack/verify-helm-config-values.py
 
 ##@ Deployment
 

--- a/charts/kruntimes/templates/controller-deployment.yaml
+++ b/charts/kruntimes/templates/controller-deployment.yaml
@@ -6,53 +6,78 @@ metadata:
   labels:
     {{- include "kruntimes.controller.labels" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.controller.replicas }}
   selector:
     matchLabels:
       {{- include "kruntimes.controller.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.controller.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "kruntimes.controller.labels" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "kruntimes.controller.name" . }}
+      {{- with .Values.controller.podSecurityContext }}
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: controller
           image: {{ include "kruntimes.image" (list . .Values.controller.image) }}
           imagePullPolicy: {{ .Values.controller.imagePullPolicy }}
+          {{- with .Values.controller.securityContext }}
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
-            - --leader-elect=true
-            - --metrics-bind-address=:8082
-            - --health-probe-bind-address=:8083
+            - --leader-elect={{ .Values.controller.leaderElect }}
+            - --metrics-bind-address={{ .Values.controller.metricsBindAddress }}
+            - --health-probe-bind-address={{ .Values.controller.probeBindAddress }}
             - --default-daemon-image={{ include "kruntimes.image" (list . .Values.runtimed.image) }}
             - --runtimed-service-account-name={{ include "kruntimes.runtimed.name" . }}
           ports:
-            - containerPort: 8082
+            - containerPort: {{ .Values.controller.metricsPort }}
               name: metrics
               protocol: TCP
-            - containerPort: 8083
+            - containerPort: {{ .Values.controller.probePort }}
               name: probes
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8083
+              port: probes
             initialDelaySeconds: 5
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /readyz
-              port: 8083
+              port: probes
             initialDelaySeconds: 5
             periodSeconds: 10
           resources:

--- a/charts/kruntimes/templates/scheduler-deployment.yaml
+++ b/charts/kruntimes/templates/scheduler-deployment.yaml
@@ -12,45 +12,70 @@ spec:
       {{- include "kruntimes.scheduler.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.scheduler.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- include "kruntimes.scheduler.labels" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "kruntimes.scheduler.name" . }}
+      {{- with .Values.scheduler.podSecurityContext }}
       securityContext:
-        seccompProfile:
-          type: RuntimeDefault
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.scheduler.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: scheduler
           image: {{ include "kruntimes.image" (list . .Values.scheduler.image) }}
           imagePullPolicy: {{ .Values.scheduler.imagePullPolicy }}
+          {{- with .Values.scheduler.securityContext }}
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             - --leader-elect={{ .Values.scheduler.leaderElect }}
             - --metrics-bind-address={{ .Values.scheduler.metricsBindAddress }}
             - --health-probe-bind-address={{ .Values.scheduler.probeBindAddress }}
           ports:
-            - containerPort: 8080
+            - containerPort: {{ .Values.scheduler.metricsPort }}
               name: metrics
               protocol: TCP
-            - containerPort: 8081
+            - containerPort: {{ .Values.scheduler.probePort }}
               name: probes
               protocol: TCP
           livenessProbe:
             httpGet:
               path: /healthz
-              port: 8081
+              port: probes
             initialDelaySeconds: 5
             periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /readyz
-              port: 8081
+              port: probes
             initialDelaySeconds: 5
             periodSeconds: 10
           resources:

--- a/charts/kruntimes/values.yaml
+++ b/charts/kruntimes/values.yaml
@@ -1,4 +1,4 @@
-namespace: default
+imagePullSecrets: []
 
 scheduler:
   image: kruntimes-scheduler
@@ -7,6 +7,24 @@ scheduler:
   leaderElect: true
   metricsBindAddress: ":8080"
   probeBindAddress: ":8081"
+  metricsPort: 8080
+  probePort: 8081
+  podAnnotations: {}
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    capabilities:
+      drop:
+        - ALL
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+  priorityClassName: ""
   resources:
     requests:
       cpu: 100m
@@ -18,6 +36,28 @@ scheduler:
 controller:
   image: kruntimes-controller
   imagePullPolicy: IfNotPresent
+  replicas: 1
+  leaderElect: true
+  metricsBindAddress: ":8082"
+  probeBindAddress: ":8083"
+  metricsPort: 8082
+  probePort: 8083
+  podAnnotations: {}
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    capabilities:
+      drop:
+        - ALL
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+  priorityClassName: ""
   resources:
     requests:
       cpu: 100m
@@ -28,15 +68,6 @@ controller:
 
 runtimed:
   image: kruntimes-runtimed
-  imagePullPolicy: IfNotPresent
-  workers: 2
-  resources:
-    requests:
-      cpu: 500m
-      memory: 512Mi
-    limits:
-      cpu: "2"
-      memory: 2Gi
 
 workspace:
   sizeLimit: 10Gi

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -107,7 +107,7 @@
 - [ ] 明确 Runtime Pod customization API：评估是否用 `PodTemplateSpec` 风格的
   template 取代当前 Runtime spec 中逐步复制的 PodSpec-like 字段。
 - [x] 所有 Helm 资源名称使用 release fullname，支持多个 release 共存。
-- [ ] 移除未使用 values，并让 replicas、leader election、ports、imagePullSecrets、
+- [x] 移除未使用 values，并让 replicas、leader election、ports、imagePullSecrets、
   security context、scheduling constraints 等可配置。
 - [x] 避免默认使用 `latest`，镜像 tag 应跟随 chart appVersion。
 - [x] 增加多 namespace 模板/安装测试。

--- a/hack/verify-helm-config-values.py
+++ b/hack/verify-helm-config-values.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Verify kruntimes Helm chart deployment configuration values render."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+CHART = Path("charts/kruntimes")
+RELEASE = "kruntimes"
+NAMESPACE = "kruntimes-system"
+
+OVERRIDES = """
+imagePullSecrets:
+  - name: pull-secret
+scheduler:
+  replicas: 3
+  leaderElect: false
+  metricsBindAddress: ":18080"
+  probeBindAddress: ":18081"
+  metricsPort: 18080
+  probePort: 18081
+  podAnnotations:
+    checksum/config: scheduler
+  podSecurityContext:
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+    capabilities:
+      drop:
+        - ALL
+  nodeSelector:
+    workload: control-plane
+  tolerations:
+    - key: dedicated
+      operator: Equal
+      value: kruntimes
+      effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                  - linux
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: scheduler
+  priorityClassName: system-cluster-critical
+controller:
+  replicas: 2
+  leaderElect: false
+  metricsBindAddress: ":18082"
+  probeBindAddress: ":18083"
+  metricsPort: 18082
+  probePort: 18083
+  podAnnotations:
+    checksum/config: controller
+  podSecurityContext:
+    runAsUser: 1001
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+    capabilities:
+      drop:
+        - ALL
+  nodeSelector:
+    workload: control-plane
+  tolerations:
+    - key: dedicated
+      operator: Equal
+      value: kruntimes
+      effect: NoSchedule
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: controller
+  topologySpreadConstraints:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/component: controller
+  priorityClassName: system-cluster-critical
+"""
+
+
+@dataclass(frozen=True)
+class Resource:
+    kind: str
+    name: str
+    text: str
+
+
+def main() -> int:
+    rendered = helm_template_with_overrides()
+    resources = parse_resources(rendered)
+
+    checks = [
+        require_deployment(
+            resources,
+            "kruntimes-scheduler",
+            [
+                "replicas: 3",
+                "--leader-elect=false",
+                "--metrics-bind-address=:18080",
+                "--health-probe-bind-address=:18081",
+                "containerPort: 18080",
+                "containerPort: 18081",
+                "checksum/config: scheduler",
+                "name: pull-secret",
+                "runAsUser: 1000",
+                "readOnlyRootFilesystem: false",
+                "workload: control-plane",
+                "key: dedicated",
+                "nodeAffinity:",
+                "topologySpreadConstraints:",
+                "priorityClassName: system-cluster-critical",
+                "port: probes",
+            ],
+        ),
+        require_deployment(
+            resources,
+            "kruntimes-controller",
+            [
+                "replicas: 2",
+                "--leader-elect=false",
+                "--metrics-bind-address=:18082",
+                "--health-probe-bind-address=:18083",
+                "containerPort: 18082",
+                "containerPort: 18083",
+                "checksum/config: controller",
+                "name: pull-secret",
+                "runAsUser: 1001",
+                "readOnlyRootFilesystem: false",
+                "workload: control-plane",
+                "key: dedicated",
+                "podAntiAffinity:",
+                "topologySpreadConstraints:",
+                "priorityClassName: system-cluster-critical",
+                "port: probes",
+            ],
+        ),
+    ]
+    return 0 if all(checks) else 1
+
+
+def helm_template_with_overrides() -> str:
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml") as values:
+        values.write(OVERRIDES)
+        values.flush()
+        return subprocess.check_output(
+            [
+                "helm",
+                "template",
+                RELEASE,
+                str(CHART),
+                "--namespace",
+                NAMESPACE,
+                "-f",
+                values.name,
+            ],
+            text=True,
+        )
+
+
+def require_deployment(resources: list[Resource], name: str, expected: list[str]) -> bool:
+    deployment = find_resource(resources, "Deployment", name)
+    if deployment is None:
+        print(f"missing Deployment/{name}", file=sys.stderr)
+        return False
+    ok = True
+    for text in expected:
+        if text not in deployment.text:
+            print(f"Deployment/{name} missing {text!r}", file=sys.stderr)
+            ok = False
+    return ok
+
+
+def parse_resources(rendered: str) -> list[Resource]:
+    docs = re.split(r"^---\s*$", rendered, flags=re.MULTILINE)
+    resources: list[Resource] = []
+    for doc in docs:
+        if not doc.strip():
+            continue
+        kind = field_at_indent(doc, "kind", 0)
+        name = metadata_field(doc, "name")
+        if kind and name:
+            resources.append(Resource(kind=kind, name=name, text=doc))
+    return resources
+
+
+def find_resource(resources: list[Resource], kind: str, name: str) -> Resource | None:
+    for resource in resources:
+        if resource.kind == kind and resource.name == name:
+            return resource
+    return None
+
+
+def field_at_indent(doc: str, field: str, indent: int) -> str:
+    prefix = " " * indent + field + ":"
+    for line in doc.splitlines():
+        if line.startswith(prefix):
+            return line.split(":", 1)[1].strip().strip('"')
+    return ""
+
+
+def metadata_field(doc: str, field: str) -> str:
+    in_metadata = False
+    for line in doc.splitlines():
+        if line == "metadata:":
+            in_metadata = True
+            continue
+        if in_metadata and line and not line.startswith(" "):
+            return ""
+        if in_metadata and line.startswith(f"  {field}:"):
+            return line.split(":", 1)[1].strip().strip('"')
+    return ""
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- make scheduler and controller replicas, leader election, bind addresses, container ports, security contexts, imagePullSecrets, and scheduling constraints configurable
- remove unused platform chart values for namespace and unused runtimed worker/resource settings
- add Helm rendering coverage for these configuration values
- mark the Helm configurability readiness item done

## Tests
- GOCACHE=/tmp/go-build make test-helm