### PR TITLE
docs: define cluster-wide installation scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,17 @@ make deploy           # platform (CRDs, scheduler, controller, RBAC)
 make deploy-runtimes  # built-in runtimes (bash, python)
 ```
 
+kruntimes currently uses a cluster-wide installation model. Install the platform
+chart once per cluster; it installs CRDs plus cluster-scoped RBAC for the
+controller and scheduler. Install the runtimes chart into each namespace that
+should host Runtime pools and Runs.
+
+Runtime scheduling is namespace-local: a Run is assigned only to Runtime Pods in
+the same namespace. The cluster-wide control plane watches all namespaces, but
+application access should be granted with namespace-scoped RBAC. Use separate
+namespaces for tenants or trust boundaries that should not share Runtime Pods,
+workspace volumes, service accounts, or artifact credentials.
+
 Before granting user access, read
 [Security, Authorization, and Threat Model](docs/security.md). Creating a `Run`
 grants code-execution capability inside the selected Runtime Pod's trust

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -100,7 +100,7 @@
 
 ### 6. Installation Scope and Helm Correctness
 
-- [ ] 明确选择 cluster-wide 或 single-namespace 安装模型。
+- [x] 明确选择 cluster-wide 或 single-namespace 安装模型。
 - [x] Runtime Deployment 引用的 runtimed ServiceAccount 必须存在于 Runtime namespace。
 - [x] 为自定义 `Runtime.spec.runtimedServiceAccountName` 增加 namespace-scoped RBAC
   controller 或等价机制，确保对应 ServiceAccount 拥有 runtimed 所需最小权限。

--- a/docs/security.md
+++ b/docs/security.md
@@ -131,8 +131,9 @@ Namespaces should therefore group subjects and Runtime pools that share a trust
 level. Do not place mutually untrusted Run submitters in one namespace with a
 shared built-in Runtime pool.
 
-The platform Helm chart currently installs cluster-scoped controller roles.
-Those roles are for kruntimes components, not examples of end-user access.
+The platform Helm chart installs a cluster-wide control plane with
+cluster-scoped controller and scheduler roles. Those roles are for kruntimes
+components, not examples of end-user access.
 Application user access should be granted separately with namespaced RBAC.
 
 NetworkPolicy limits direct Pod ingress, but it does not isolate Runs executing

--- a/hack/verify-helm-multi-namespace.py
+++ b/hack/verify-helm-multi-namespace.py
@@ -31,7 +31,7 @@ def main() -> int:
     resources = [
         *parse_resources(
             "platform",
-            helm_template(PLATFORM_RELEASE, PLATFORM_CHART, PLATFORM_NAMESPACE),
+            helm_template(PLATFORM_RELEASE, PLATFORM_CHART, PLATFORM_NAMESPACE, include_crds=True),
         ),
         *parse_resources(
             "runtimes",
@@ -47,6 +47,7 @@ def main() -> int:
         return 1
 
     checks = [
+        require_platform_cluster_scoped_resources(resources),
         require_namespaced_resources("platform", PLATFORM_NAMESPACE, resources),
         require_namespaced_resources("runtimes", RUNTIMES_NAMESPACE, resources),
         require_rbac_subject_namespace(resources),
@@ -59,11 +60,11 @@ def main() -> int:
     return 0
 
 
-def helm_template(release: str, chart: Path, namespace: str) -> str:
-    return subprocess.check_output(
-        ["helm", "template", release, str(chart), "--namespace", namespace],
-        text=True,
-    )
+def helm_template(release: str, chart: Path, namespace: str, include_crds: bool = False) -> str:
+    command = ["helm", "template", release, str(chart), "--namespace", namespace]
+    if include_crds:
+        command.append("--include-crds")
+    return subprocess.check_output(command, text=True)
 
 
 def parse_resources(chart: str, rendered: str) -> list[Resource]:
@@ -122,6 +123,30 @@ def require_namespaced_resources(chart: str, namespace: str, resources: list[Res
             )
             ok = False
     return ok
+
+
+def require_platform_cluster_scoped_resources(resources: list[Resource]) -> bool:
+    expected = {
+        ("CustomResourceDefinition", "runs.kruntimes.io"),
+        ("CustomResourceDefinition", "runtimes.kruntimes.io"),
+        ("CustomResourceDefinition", "workflows.kruntimes.io"),
+        ("ClusterRole", "kruntimes-controller"),
+        ("ClusterRole", "kruntimes-scheduler"),
+        ("ClusterRoleBinding", "kruntimes-controller"),
+        ("ClusterRoleBinding", "kruntimes-scheduler"),
+    }
+    actual = {
+        (resource.kind, resource.name)
+        for resource in resources
+        if resource.chart == "platform" and resource.namespace == "_cluster"
+    }
+    missing = expected - actual
+    if missing:
+        print("platform chart missing expected cluster-scoped resources:", file=sys.stderr)
+        for kind, name in sorted(missing):
+            print(f"  {kind}/{name}", file=sys.stderr)
+        return False
+    return True
 
 
 def require_rbac_subject_namespace(resources: list[Resource]) -> bool:


### PR DESCRIPTION
## Summary
- document the current cluster-wide control-plane installation model
- clarify namespace-local Runtime/Run scheduling and RBAC trust boundaries
- extend the multi-namespace Helm verifier to include CRDs and expected cluster-scoped control-plane RBAC

## Tests
- GOCACHE=/tmp/go-build make test-helm
- GOCACHE=/tmp/go-build make test

Note: PR #182 is still pending and covers the separate runtimed ServiceAccount/RBAC controller work.