### PR TITLE
chore: pin govulncheck workflow tool

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.26.0"
+          go-version-file: go.mod
           cache: true
       - name: Install gitleaks
         run: go install github.com/zricethezav/gitleaks/v8@v8.30.1
@@ -43,7 +43,5 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run govulncheck
-        run: govulncheck ./...
+        run: make govulncheck

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ ENVTEST_K8S_VERSION = 1.32
 CONTROLLER_GEN_VERSION ?= v0.17.3
 SETUP_ENVTEST_VERSION ?= v0.24.1
 GOLANGCI_LINT_VERSION ?= v2.12.2
+GOVULNCHECK_VERSION ?= v1.4.0
 PROTOC_VERSION ?= 29.3
 PROTOC_ARCH ?= linux-x86_64
 PROTOC_GEN_GO_VERSION ?= v1.36.11
@@ -78,6 +79,10 @@ test-integration: generate manifests setup-envtest ## Run integration tests (req
 .PHONY: test-race
 test-race: generate manifests proto ## Run focused Go race-detector coverage for runtime and control-plane packages.
 	go test -race ./internal/controller ./internal/scheduler ./internal/runtimed ./runtimes/bash -count=1
+
+.PHONY: govulncheck
+govulncheck: govulncheck-tool ## Run govulncheck against all Go packages.
+	$(GOVULNCHECK) ./...
 
 .PHONY: test-s3-integration
 test-s3-integration: ## Run S3 ArtifactStore integration tests against MinIO.
@@ -271,6 +276,13 @@ GOLANGCI_LINT = $(GOBIN)/golangci-lint
 golangci-lint: ## Install golangci-lint if not present.
 	@if ! test -x $(GOLANGCI_LINT) || ! $(GOLANGCI_LINT) --version | grep -q "$(GOLANGCI_LINT_VERSION)"; then \
 		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); \
+	fi
+
+GOVULNCHECK = $(GOBIN)/govulncheck
+.PHONY: govulncheck-tool
+govulncheck-tool: ## Install govulncheck if not present.
+	@if ! test -x $(GOVULNCHECK) || ! $(GOVULNCHECK) -version | grep -q "$(GOVULNCHECK_VERSION)"; then \
+		go install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION); \
 	fi
 
 .PHONY: protoc

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -148,7 +148,7 @@
 
 改进项：
 
-- [ ] 升级 Go toolchain 和受影响依赖，并让 `govulncheck` 通过。
+- [x] 升级 Go toolchain 和受影响依赖，并让 `govulncheck` 通过。
 - [x] Docker 基础镜像固定到明确 patch version 和 digest。
 - [x] Python 镜像通过 `uv.lock` 安装依赖，不直接安装未固定版本。
 - [x] 固定 Makefile 中 controller-gen、setup-envtest、golangci-lint、
@@ -213,5 +213,5 @@ artifact store 的配置所有权。
 - Helm lint: 通过。
 - Python Runtime unit tests: 通过。
 - `go test -race`: 失败，复现 Bash Runtime 并发读写。
-- `govulncheck ./...`: 失败，检测到 5 个可达漏洞。
+- `make govulncheck`: 通过。
 - 完整 `make e2e`: 本次审查未执行。


### PR DESCRIPTION
## Summary
- add a pinned Makefile govulncheck target using golang.org/x/vuln v1.4.0
- update Security workflow to use go.mod for Go setup and run make govulncheck instead of @latest
- mark the Go/x/net vulnerability cleanup item done after verification

## Tests
- GOCACHE=/tmp/go-build make govulncheck
- GOCACHE=/tmp/go-build make test