### PR TITLE
feat(artifacts): centralize cleanup ownership

### DIFF
--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -3,9 +3,12 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -o controller ./cmd/controller
+RUN CGO_ENABLED=0 go build -o controller ./cmd/controller && \
+    CGO_ENABLED=0 go build -o artifact-cleaner ./cmd/artifact-cleaner
 
 FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /app/controller /controller
+COPY --from=builder /app/artifact-cleaner /artifact-cleaner
 USER 65532
 ENTRYPOINT ["/controller"]

--- a/README.md
+++ b/README.md
@@ -379,7 +379,21 @@ file, verify size and SHA-256, then atomically rename into place.
 
 Runs that publish artifacts carry an artifact cleanup finalizer. Manual
 deletion and `ttlSecondsAfterFinished` garbage collection remove all external
-objects for the Run before the Run is deleted.
+objects for the Run before the Run is deleted. Before the first upload,
+runtimed snapshots the non-secret store configuration in
+`Run.status.artifactStore`. The long-lived controller uses that snapshot to
+run an isolated cleanup Job, so cleanup does not depend on the Runtime or its
+Pods still existing.
+
+Cleanup is idempotent: an already-missing filesystem path or S3 object is
+treated as success. Missing PVCs, unavailable object stores, and missing or
+invalid credential Secrets keep the Run finalizer in place; the cleanup Job
+continues or is recreated after the dependency is restored. Secret contents
+are never copied into the Run. For Runs created before store snapshots were
+introduced, the controller copies the configuration from the Runtime while it
+still exists. If both the snapshot and Runtime are missing, recreate the
+Runtime with the original artifact store configuration so migration and
+cleanup can continue.
 
 ## Quick Start
 

--- a/api/v1alpha1/run_types.go
+++ b/api/v1alpha1/run_types.go
@@ -264,6 +264,12 @@ type RunStatus struct {
 	// +kubebuilder:validation:MaxItems=32
 	ArtifactRefs []ArtifactRef `json:"artifactRefs,omitempty"`
 
+	// ArtifactStore is the immutable cleanup configuration captured before
+	// artifacts are uploaded. It allows cleanup to continue if the Runtime is
+	// later changed or deleted. Secret contents are never copied here.
+	// +optional
+	ArtifactStore *RuntimeArtifactStoreSpec `json:"artifactStore,omitempty"`
+
 	// Attempt is the current execution attempt number (1-based).
 	// +optional
 	Attempt int32 `json:"attempt,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -326,6 +326,11 @@ func (in *RunStatus) DeepCopyInto(out *RunStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ArtifactStore != nil {
+		in, out := &in.ArtifactStore, &out.ArtifactStore
+		*out = new(RuntimeArtifactStoreSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
 		*out = make([]metav1.Condition, len(*in))

--- a/charts/kruntimes/crds/kruntimes.io_runs.yaml
+++ b/charts/kruntimes/crds/kruntimes.io_runs.yaml
@@ -425,6 +425,86 @@ spec:
                       || (self.driver == 's3' && has(self.location.s3))
                 maxItems: 32
                 type: array
+              artifactStore:
+                description: |-
+                  ArtifactStore is the immutable cleanup configuration captured before
+                  artifacts are uploaded. It allows cleanup to continue if the Runtime is
+                  later changed or deleted. Secret contents are never copied here.
+                properties:
+                  driver:
+                    description: Driver identifies the configured artifact storage
+                      backend.
+                    enum:
+                    - filesystem
+                    - s3
+                    type: string
+                  filesystem:
+                    description: Filesystem configures a PVC-backed filesystem artifact
+                      store.
+                    properties:
+                      volumeClaimName:
+                        description: VolumeClaimName is the PVC mounted into runtimed
+                          for durable artifact storage.
+                        minLength: 1
+                        type: string
+                    required:
+                    - volumeClaimName
+                    type: object
+                  s3:
+                    description: S3 configures an S3-compatible object artifact store.
+                    properties:
+                      bucket:
+                        description: Bucket is the S3 bucket used to store artifacts.
+                        minLength: 1
+                        pattern: ^[^/]+$
+                        type: string
+                      credentialsSecretName:
+                        description: |-
+                          CredentialsSecretName names a Secret whose keys are exposed to runtimed
+                          as environment variables for the AWS SDK credential chain.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      endpoint:
+                        description: Endpoint configures a custom S3-compatible service
+                          endpoint.
+                        maxLength: 2048
+                        type: string
+                      forcePathStyle:
+                        description: ForcePathStyle enables path-style S3 addressing.
+                        type: boolean
+                      prefix:
+                        description: Prefix is prepended to generated artifact object
+                          keys.
+                        maxLength: 1024
+                        type: string
+                      region:
+                        description: Region overrides the AWS SDK region.
+                        maxLength: 128
+                        type: string
+                      uploadConcurrency:
+                        description: UploadConcurrency overrides the number of concurrent
+                          multipart upload workers.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      uploadPartSize:
+                        description: UploadPartSize overrides the multipart upload
+                          part size in bytes.
+                        format: int64
+                        minimum: 5242880
+                        type: integer
+                    required:
+                    - bucket
+                    type: object
+                required:
+                - driver
+                type: object
+                x-kubernetes-validations:
+                - message: exactly one artifact store configuration matching driver
+                    must be set
+                  rule: (self.driver == 'filesystem' && has(self.filesystem) && !has(self.s3))
+                    || (self.driver == 's3' && has(self.s3) && !has(self.filesystem))
               assignedPod:
                 description: AssignedPod is the name of the Runtime Pod assigned by
                   the scheduler.

--- a/charts/kruntimes/templates/controller-deployment.yaml
+++ b/charts/kruntimes/templates/controller-deployment.yaml
@@ -1,3 +1,7 @@
+{{- $artifactCleanerPullSecrets := list -}}
+{{- range .Values.imagePullSecrets -}}
+{{- $artifactCleanerPullSecrets = append $artifactCleanerPullSecrets .name -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -61,6 +65,10 @@ spec:
             - --health-probe-bind-address={{ .Values.controller.probeBindAddress }}
             - --default-daemon-image={{ include "kruntimes.image" (list . .Values.runtimed.image) }}
             - --runtimed-service-account-name={{ include "kruntimes.runtimed.name" . }}
+            - --artifact-cleaner-image={{ include "kruntimes.image" (list . .Values.controller.image) }}
+            {{- if $artifactCleanerPullSecrets }}
+            - --artifact-cleaner-image-pull-secrets={{ join "," $artifactCleanerPullSecrets }}
+            {{- end }}
           ports:
             - containerPort: {{ .Values.controller.metricsPort }}
               name: metrics

--- a/charts/kruntimes/templates/controller-rbac.yaml
+++ b/charts/kruntimes/templates/controller-rbac.yaml
@@ -70,6 +70,16 @@ rules:
       - patch
       - delete
   - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+  - apiGroups:
       - networking.k8s.io
     resources:
       - networkpolicies

--- a/cmd/artifact-cleaner/main.go
+++ b/cmd/artifact-cleaner/main.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	"github.com/kruntimes/kruntimes/internal/artifact"
+	artifactfs "github.com/kruntimes/kruntimes/internal/artifact/filesystem"
+	artifacts3 "github.com/kruntimes/kruntimes/internal/artifact/s3"
+)
+
+func main() {
+	var (
+		namespace      string
+		runUID         string
+		driver         string
+		filesystemRoot string
+		volumeClaim    string
+		s3Bucket       string
+		s3Prefix       string
+		s3Region       string
+		s3Endpoint     string
+		s3PathStyle    bool
+	)
+	flag.StringVar(&namespace, "run-namespace", "", "Namespace of the Run being cleaned.")
+	flag.StringVar(&runUID, "run-uid", "", "UID of the Run being cleaned.")
+	flag.StringVar(&driver, "driver", "", "Artifact store driver: filesystem or s3.")
+	flag.StringVar(&filesystemRoot, "filesystem-root", "/var/lib/kruntimes/artifacts", "Mounted filesystem artifact root.")
+	flag.StringVar(&volumeClaim, "filesystem-volume-claim", "", "PVC backing the filesystem artifact store.")
+	flag.StringVar(&s3Bucket, "s3-bucket", "", "S3 bucket backing the artifact store.")
+	flag.StringVar(&s3Prefix, "s3-prefix", "", "S3 object key prefix.")
+	flag.StringVar(&s3Region, "s3-region", "", "S3 region override.")
+	flag.StringVar(&s3Endpoint, "s3-endpoint", "", "S3-compatible endpoint override.")
+	flag.BoolVar(&s3PathStyle, "s3-force-path-style", false, "Use path-style S3 addressing.")
+	flag.Parse()
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+	if err := clean(ctx, cleanupConfig{
+		namespace: namespace, runUID: runUID, driver: v1alpha1.ArtifactDriver(driver),
+		filesystemRoot: filesystemRoot, volumeClaim: volumeClaim,
+		s3Bucket: s3Bucket, s3Prefix: s3Prefix, s3Region: s3Region,
+		s3Endpoint: s3Endpoint, s3PathStyle: s3PathStyle,
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "artifact cleanup failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+type cleanupConfig struct {
+	namespace      string
+	runUID         string
+	driver         v1alpha1.ArtifactDriver
+	filesystemRoot string
+	volumeClaim    string
+	s3Bucket       string
+	s3Prefix       string
+	s3Region       string
+	s3Endpoint     string
+	s3PathStyle    bool
+}
+
+func clean(ctx context.Context, cfg cleanupConfig) error {
+	if cfg.namespace == "" || cfg.runUID == "" {
+		return fmt.Errorf("run namespace and UID are required")
+	}
+
+	var store artifact.RunStore
+	var err error
+	switch cfg.driver {
+	case v1alpha1.ArtifactDriverFilesystem:
+		if cfg.volumeClaim == "" {
+			return fmt.Errorf("filesystem volume claim is required")
+		}
+		store, err = artifactfs.NewWithLimit(cfg.filesystemRoot, cfg.volumeClaim, artifact.DefaultMaxArtifactBytes)
+	case v1alpha1.ArtifactDriverS3:
+		store, err = artifacts3.New(ctx, artifacts3.Config{
+			Bucket: cfg.s3Bucket, Prefix: cfg.s3Prefix, Region: cfg.s3Region,
+			Endpoint: cfg.s3Endpoint, ForcePathStyle: cfg.s3PathStyle,
+		})
+	default:
+		return fmt.Errorf("unsupported artifact store driver %q", cfg.driver)
+	}
+	if err != nil {
+		return fmt.Errorf("configure artifact store: %w", err)
+	}
+
+	run := &v1alpha1.Run{ObjectMeta: metav1.ObjectMeta{
+		Namespace: cfg.namespace,
+		UID:       types.UID(cfg.runUID),
+	}}
+	if err := store.DeleteRun(ctx, run); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/artifact-cleaner/main_test.go
+++ b/cmd/artifact-cleaner/main_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+func TestCleanFilesystemRun(t *testing.T) {
+	root := t.TempDir()
+	runPath := filepath.Join(root, "namespaces", "workloads", "runs", "run-uid")
+	if err := os.MkdirAll(runPath, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(runPath, "artifact"), []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := clean(t.Context(), cleanupConfig{
+		namespace: "workloads", runUID: "run-uid",
+		driver:         v1alpha1.ArtifactDriverFilesystem,
+		filesystemRoot: root, volumeClaim: "artifacts-pvc",
+	})
+	if err != nil {
+		t.Fatalf("clean: %v", err)
+	}
+	if _, err := os.Stat(runPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Run artifact path still exists: %v", err)
+	}
+	if err := clean(t.Context(), cleanupConfig{
+		namespace: "workloads", runUID: "run-uid",
+		driver:         v1alpha1.ArtifactDriverFilesystem,
+		filesystemRoot: root, volumeClaim: "artifacts-pvc",
+	}); err != nil {
+		t.Fatalf("idempotent clean: %v", err)
+	}
+}
+
+func TestCleanRequiresRunIdentity(t *testing.T) {
+	if err := clean(t.Context(), cleanupConfig{driver: v1alpha1.ArtifactDriverFilesystem}); err == nil {
+		t.Fatal("clean accepted an empty Run identity")
+	}
+}

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -37,6 +39,8 @@ func main() {
 		staleThreshold             time.Duration
 		defaultDaemonImage         string
 		runtimedServiceAccountName string
+		artifactCleanerImage       string
+		artifactCleanerPullSecrets string
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8082", "The address the metric endpoint binds to.")
@@ -45,6 +49,8 @@ func main() {
 	flag.DurationVar(&staleThreshold, "stale-threshold", 30*time.Second, "Threshold for marking a Run as stale when its assigned pod is unhealthy.")
 	flag.StringVar(&defaultDaemonImage, "default-daemon-image", "", "Default runtimed daemon image injected into Runtime Pods.")
 	flag.StringVar(&runtimedServiceAccountName, "runtimed-service-account-name", "", "ServiceAccount name injected into Runtime Pods for the runtimed sidecar.")
+	flag.StringVar(&artifactCleanerImage, "artifact-cleaner-image", "", "Controller image containing the artifact-cleaner helper.")
+	flag.StringVar(&artifactCleanerPullSecrets, "artifact-cleaner-image-pull-secrets", "", "Comma-separated image pull Secret names for artifact cleanup Jobs.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
@@ -89,6 +95,18 @@ func main() {
 		os.Exit(1)
 	}
 
+	artifactCleanup := &controller.ArtifactCleanupReconciler{
+		Client:           mgr.GetClient(),
+		Log:              ctrl.Log.WithName("controllers").WithName("ArtifactCleanup"),
+		Recorder:         mgr.GetEventRecorderFor("artifact-cleanup"),
+		CleanerImage:     artifactCleanerImage,
+		ImagePullSecrets: localObjectReferences(artifactCleanerPullSecrets),
+	}
+	if err := artifactCleanup.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "ArtifactCleanup")
+		os.Exit(1)
+	}
+
 	wfReconciler := &controller.WorkflowReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("Workflow"),
@@ -124,4 +142,14 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+func localObjectReferences(csv string) []corev1.LocalObjectReference {
+	var refs []corev1.LocalObjectReference
+	for _, value := range strings.Split(csv, ",") {
+		if name := strings.TrimSpace(value); name != "" {
+			refs = append(refs, corev1.LocalObjectReference{Name: name})
+		}
+	}
+	return refs
 }

--- a/cmd/runtimed/main.go
+++ b/cmd/runtimed/main.go
@@ -58,6 +58,7 @@ func main() {
 		artifactS3Region    string
 		artifactS3Endpoint  string
 		artifactS3PathStyle bool
+		artifactS3Secret    string
 		artifactS3PartSize  int64
 		artifactS3Workers   int
 		maxArtifactBytes    int64
@@ -78,6 +79,7 @@ func main() {
 	flag.StringVar(&artifactS3Region, "artifact-s3-region", "", "S3 region override.")
 	flag.StringVar(&artifactS3Endpoint, "artifact-s3-endpoint", "", "S3-compatible endpoint override.")
 	flag.BoolVar(&artifactS3PathStyle, "artifact-s3-force-path-style", false, "Use path-style S3 addressing.")
+	flag.StringVar(&artifactS3Secret, "artifact-s3-credentials-secret-name", "", "Secret containing S3 credentials (recorded for centralized cleanup).")
 	flag.Int64Var(&artifactS3PartSize, "artifact-s3-upload-part-size", 0, "S3 multipart upload part size.")
 	flag.IntVar(&artifactS3Workers, "artifact-s3-upload-concurrency", 0, "S3 multipart upload concurrency.")
 	flag.Int64Var(&maxArtifactBytes, "max-artifact-bytes", artifact.DefaultMaxArtifactBytes, "Maximum bytes allowed for one artifact.")
@@ -144,10 +146,17 @@ func main() {
 	defer cancel()
 
 	var artifactStore artifact.Store
+	var artifactStoreSpec *v1alpha1.RuntimeArtifactStoreSpec
 	switch artifactStoreDriver {
 	case "", string(v1alpha1.ArtifactDriverFilesystem):
 		if artifactStoreRoot != "" || artifactVolumeClaim != "" {
 			artifactStore, err = artifactfs.NewWithLimit(artifactStoreRoot, artifactVolumeClaim, maxArtifactBytes)
+			artifactStoreSpec = &v1alpha1.RuntimeArtifactStoreSpec{
+				Driver: v1alpha1.ArtifactDriverFilesystem,
+				Filesystem: &v1alpha1.FilesystemArtifactStoreSpec{
+					VolumeClaimName: artifactVolumeClaim,
+				},
+			}
 		}
 	case string(v1alpha1.ArtifactDriverS3):
 		artifactStore, err = artifacts3.New(ctx, artifacts3.Config{
@@ -159,6 +168,19 @@ func main() {
 			UploadPartSize:    artifactS3PartSize,
 			UploadConcurrency: artifactS3Workers,
 		})
+		artifactStoreSpec = &v1alpha1.RuntimeArtifactStoreSpec{
+			Driver: v1alpha1.ArtifactDriverS3,
+			S3: &v1alpha1.S3ArtifactStoreSpec{
+				Bucket:                artifactS3Bucket,
+				Prefix:                artifactS3Prefix,
+				Region:                artifactS3Region,
+				Endpoint:              artifactS3Endpoint,
+				ForcePathStyle:        artifactS3PathStyle,
+				CredentialsSecretName: artifactS3Secret,
+				UploadPartSize:        artifactS3PartSize,
+				UploadConcurrency:     int32(artifactS3Workers),
+			},
+		}
 	default:
 		err = fmt.Errorf("unsupported artifact store driver %q", artifactStoreDriver)
 	}
@@ -197,6 +219,7 @@ func main() {
 		RuntimeEndpoint:   runtimeEndpoint,
 		Workers:           workers,
 		ArtifactStore:     artifactStore,
+		ArtifactStoreSpec: artifactStoreSpec,
 		MaxArtifactBytes:  maxArtifactBytes,
 		MaxArtifactsBytes: maxArtifactsBytes,
 		Recorder:          mgr.GetEventRecorderFor("runtimed"),

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -124,15 +124,16 @@
 
 ### 7. Artifact Cleanup Ownership
 
-目前 artifact finalizer 由 Runtime Pod 内的 runtimed 执行。Runtime 被删除、缩容到零或
-凭据不可用时，Run 可能永久停留在 `Terminating`。
+Artifact finalizer 最初由 Runtime Pod 内的 runtimed 执行，导致 Runtime 删除或缩容到零
+时无法清理。现在由长期运行的 controller 创建独立 cleanup Job，并从 Run status 中读取
+持久化的 store 配置快照。
 
-- [ ] 将 artifact finalizer 清理迁移到独立、长期存在的 controller，或提供等价的
+- [x] 将 artifact finalizer 清理迁移到独立、长期存在的 controller，或提供等价的
   central GC。
-- [ ] 定义 store 配置删除、凭据丢失和外部对象不存在时的恢复语义。
+- [x] 定义 store 配置删除、凭据丢失和外部对象不存在时的恢复语义。
 - [x] 对部分上传失败进行回滚，避免孤立对象。
 - [x] S3 上传前执行最终存储大小限制，避免先上传再拒绝。
-- [ ] 增加 finalizer 故障恢复和 Runtime 删除后的 E2E 测试。
+- [x] 增加 finalizer 故障恢复和 Runtime 删除后的 E2E 测试。
 
 验收标准：
 

--- a/internal/artifact/artifact.go
+++ b/internal/artifact/artifact.go
@@ -2,9 +2,13 @@ package artifact
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"io"
 	"time"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 )
@@ -28,9 +32,18 @@ const (
 	DefaultMaxArtifactsBytes int64 = 10 << 30
 
 	RunArtifactFinalizer = "kruntimes.io/artifact-cleanup"
+
+	CleanupRunAnnotation    = "kruntimes.io/artifact-cleanup-run"
+	CleanupRunUIDAnnotation = "kruntimes.io/artifact-cleanup-run-uid"
 )
 
 var ErrSizeLimitExceeded = errors.New("artifact size limit exceeded")
+
+// CleanupJobName returns the stable name of the cleanup Job for a Run UID.
+func CleanupJobName(uid types.UID) string {
+	sum := sha256.Sum256([]byte(uid))
+	return "artifact-cleanup-" + hex.EncodeToString(sum[:8])
+}
 
 // PutOptions describes metadata applied while storing an artifact.
 type PutOptions struct {

--- a/internal/artifact/artifact_test.go
+++ b/internal/artifact/artifact_test.go
@@ -1,0 +1,18 @@
+package artifact
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestCleanupJobName(t *testing.T) {
+	uid := types.UID("d6ecbc18-4411-4d54-9d8e-032687dc85e8")
+	first := CleanupJobName(uid)
+	if first != CleanupJobName(uid) {
+		t.Fatal("cleanup Job name is not deterministic")
+	}
+	if len(first) > 63 || first == CleanupJobName(types.UID("different")) {
+		t.Fatalf("invalid cleanup Job name %q", first)
+	}
+}

--- a/internal/controller/artifact_cleanup_controller.go
+++ b/internal/controller/artifact_cleanup_controller.go
@@ -1,0 +1,287 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	kptr "k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	"github.com/kruntimes/kruntimes/internal/artifact"
+)
+
+const (
+	artifactCleanerMountPath = "/var/lib/kruntimes/artifacts"
+	artifactCleanupRetry     = 30 * time.Second
+)
+
+// ArtifactCleanupReconciler owns artifact finalizer removal independently of Runtime Pods.
+type ArtifactCleanupReconciler struct {
+	client.Client
+	Log              logr.Logger
+	Recorder         record.EventRecorder
+	CleanerImage     string
+	ImagePullSecrets []corev1.LocalObjectReference
+}
+
+// +kubebuilder:rbac:groups=kruntimes.io,resources=runs,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=kruntimes.io,resources=runs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=kruntimes.io,resources=runtimes,verbs=get;list;watch
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;delete
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+
+// SetupWithManager registers Run and cleanup Job watches.
+func (r *ArtifactCleanupReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	jobEvents := predicate.Funcs{
+		CreateFunc:  func(event.CreateEvent) bool { return true },
+		UpdateFunc:  func(event.UpdateEvent) bool { return true },
+		DeleteFunc:  func(event.DeleteEvent) bool { return true },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.Run{}).
+		Watches(
+			&batchv1.Job{},
+			handler.EnqueueRequestsFromMapFunc(r.runForCleanupJob),
+			builder.WithPredicates(jobEvents),
+		).
+		Complete(r)
+}
+
+// Reconcile snapshots store configuration and drives cleanup Jobs for deleting Runs.
+func (r *ArtifactCleanupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var run v1alpha1.Run
+	if err := r.Get(ctx, req.NamespacedName, &run); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	if !controllerutil.ContainsFinalizer(&run, artifact.RunArtifactFinalizer) {
+		return ctrl.Result{}, nil
+	}
+	if run.Status.ArtifactStore == nil {
+		return r.snapshotArtifactStore(ctx, &run)
+	}
+	if run.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+	if r.CleanerImage == "" {
+		return ctrl.Result{}, fmt.Errorf("artifact cleaner image is not configured")
+	}
+
+	jobKey := client.ObjectKey{Namespace: run.Namespace, Name: artifact.CleanupJobName(run.UID)}
+	var job batchv1.Job
+	if err := r.Get(ctx, jobKey, &job); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		job, err = r.buildCleanupJob(&run)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if err := r.Create(ctx, &job); err != nil {
+			return ctrl.Result{}, fmt.Errorf("create artifact cleanup Job: %w", err)
+		}
+		r.record(&run, corev1.EventTypeNormal, "ArtifactCleanupStarted", "Created artifact cleanup Job %s", job.Name)
+		return ctrl.Result{}, nil
+	}
+	if job.Annotations[artifact.CleanupRunAnnotation] != run.Name ||
+		job.Annotations[artifact.CleanupRunUIDAnnotation] != string(run.UID) {
+		return ctrl.Result{}, fmt.Errorf("artifact cleanup Job %s does not belong to Run %s", jobKey, req.NamespacedName)
+	}
+
+	if jobComplete(&job) {
+		base := run.DeepCopy()
+		controllerutil.RemoveFinalizer(&run, artifact.RunArtifactFinalizer)
+		if err := r.Patch(ctx, &run, client.MergeFrom(base)); err != nil {
+			return ctrl.Result{}, fmt.Errorf("remove artifact cleanup finalizer: %w", err)
+		}
+		r.record(&run, corev1.EventTypeNormal, "ArtifactCleanupComplete", "Deleted external artifacts")
+		return ctrl.Result{}, nil
+	}
+	if jobFailed(&job) {
+		r.record(&run, corev1.EventTypeWarning, "ArtifactCleanupRetry", "Cleanup Job %s failed; retrying", job.Name)
+		if err := r.Delete(ctx, &job); err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("delete failed artifact cleanup Job: %w", err)
+		}
+		return ctrl.Result{RequeueAfter: artifactCleanupRetry}, nil
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ArtifactCleanupReconciler) snapshotArtifactStore(ctx context.Context, run *v1alpha1.Run) (ctrl.Result, error) {
+	var runtimeResource v1alpha1.Runtime
+	key := client.ObjectKey{Namespace: run.Namespace, Name: run.Spec.Runtime}
+	if err := r.Get(ctx, key, &runtimeResource); err != nil {
+		return ctrl.Result{}, fmt.Errorf("resolve artifact store from Runtime %s: %w", key, err)
+	}
+	if runtimeResource.Spec.ArtifactStore == nil {
+		return ctrl.Result{}, fmt.Errorf("Runtime %s has no artifact store configuration", key)
+	}
+	base := run.DeepCopy()
+	run.Status.ArtifactStore = runtimeResource.Spec.ArtifactStore.DeepCopy()
+	if err := r.Status().Patch(ctx, run, client.MergeFrom(base)); err != nil {
+		return ctrl.Result{}, fmt.Errorf("snapshot artifact store configuration: %w", err)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *ArtifactCleanupReconciler) buildCleanupJob(run *v1alpha1.Run) (batchv1.Job, error) {
+	store := run.Status.ArtifactStore
+	if store == nil {
+		return batchv1.Job{}, fmt.Errorf("Run has no artifact store cleanup configuration")
+	}
+	args := []string{
+		"--run-namespace=" + run.Namespace,
+		"--run-uid=" + string(run.UID),
+		"--driver=" + string(store.Driver),
+	}
+	podSpec := corev1.PodSpec{
+		RestartPolicy:                corev1.RestartPolicyNever,
+		AutomountServiceAccountToken: kptr.To(false),
+		ImagePullSecrets:             append([]corev1.LocalObjectReference(nil), r.ImagePullSecrets...),
+		SecurityContext: &corev1.PodSecurityContext{
+			SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+		},
+	}
+	container := corev1.Container{
+		Name:    "cleaner",
+		Image:   r.CleanerImage,
+		Command: []string{"/artifact-cleaner"},
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: kptr.To(false),
+			ReadOnlyRootFilesystem:   kptr.To(true),
+			RunAsNonRoot:             kptr.To(true),
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("25m"), corev1.ResourceMemory: resource.MustParse("32Mi")},
+			Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m"), corev1.ResourceMemory: resource.MustParse("128Mi")},
+		},
+	}
+
+	switch store.Driver {
+	case v1alpha1.ArtifactDriverFilesystem:
+		if store.Filesystem == nil || store.Filesystem.VolumeClaimName == "" {
+			return batchv1.Job{}, fmt.Errorf("filesystem artifact store configuration is incomplete")
+		}
+		args = append(args,
+			"--filesystem-root="+artifactCleanerMountPath,
+			"--filesystem-volume-claim="+store.Filesystem.VolumeClaimName,
+		)
+		container.VolumeMounts = []corev1.VolumeMount{{Name: "artifact-store", MountPath: artifactCleanerMountPath}}
+		podSpec.Volumes = []corev1.Volume{{
+			Name: "artifact-store",
+			VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: store.Filesystem.VolumeClaimName,
+			}},
+		}}
+		podSpec.SecurityContext.FSGroup = kptr.To[int64](65532)
+		podSpec.SecurityContext.FSGroupChangePolicy = kptr.To(corev1.FSGroupChangeOnRootMismatch)
+	case v1alpha1.ArtifactDriverS3:
+		if store.S3 == nil || store.S3.Bucket == "" {
+			return batchv1.Job{}, fmt.Errorf("S3 artifact store configuration is incomplete")
+		}
+		args = append(args, "--s3-bucket="+store.S3.Bucket)
+		if store.S3.Prefix != "" {
+			args = append(args, "--s3-prefix="+store.S3.Prefix)
+		}
+		if store.S3.Region != "" {
+			args = append(args, "--s3-region="+store.S3.Region)
+		}
+		if store.S3.Endpoint != "" {
+			args = append(args, "--s3-endpoint="+store.S3.Endpoint)
+		}
+		if store.S3.ForcePathStyle {
+			args = append(args, "--s3-force-path-style=true")
+		}
+		if store.S3.CredentialsSecretName != "" {
+			container.EnvFrom = []corev1.EnvFromSource{{SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: store.S3.CredentialsSecretName},
+			}}}
+		}
+	default:
+		return batchv1.Job{}, fmt.Errorf("unsupported artifact store driver %q", store.Driver)
+	}
+	container.Args = args
+	podSpec.Containers = []corev1.Container{container}
+
+	job := batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      artifact.CleanupJobName(run.UID),
+			Namespace: run.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      "kruntimes",
+				"app.kubernetes.io/component": "artifact-cleaner",
+				"kruntimes.io/run-uid-hash":   strings.TrimPrefix(artifact.CleanupJobName(run.UID), "artifact-cleanup-"),
+			},
+			Annotations: map[string]string{
+				artifact.CleanupRunAnnotation:    run.Name,
+				artifact.CleanupRunUIDAnnotation: string(run.UID),
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit:            kptr.To[int32](3),
+			ActiveDeadlineSeconds:   kptr.To[int64](600),
+			TTLSecondsAfterFinished: kptr.To[int32](300),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+					"app.kubernetes.io/name":      "kruntimes",
+					"app.kubernetes.io/component": "artifact-cleaner",
+				}},
+				Spec: podSpec,
+			},
+		},
+	}
+	return job, nil
+}
+
+func (r *ArtifactCleanupReconciler) runForCleanupJob(_ context.Context, object client.Object) []ctrl.Request {
+	job, ok := object.(*batchv1.Job)
+	if !ok || job.Labels["app.kubernetes.io/component"] != "artifact-cleaner" {
+		return nil
+	}
+	runName := job.Annotations[artifact.CleanupRunAnnotation]
+	if runName == "" {
+		return nil
+	}
+	return []ctrl.Request{{NamespacedName: types.NamespacedName{Namespace: job.Namespace, Name: runName}}}
+}
+
+func jobComplete(job *batchv1.Job) bool {
+	return jobConditionTrue(job, batchv1.JobComplete)
+}
+
+func jobFailed(job *batchv1.Job) bool {
+	return jobConditionTrue(job, batchv1.JobFailed)
+}
+
+func jobConditionTrue(job *batchv1.Job, conditionType batchv1.JobConditionType) bool {
+	for _, condition := range job.Status.Conditions {
+		if condition.Type == conditionType && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *ArtifactCleanupReconciler) record(run *v1alpha1.Run, eventType, reason, message string, args ...any) {
+	if r.Recorder != nil {
+		r.Recorder.Eventf(run, eventType, reason, message, args...)
+	}
+}

--- a/internal/controller/artifact_cleanup_controller_test.go
+++ b/internal/controller/artifact_cleanup_controller_test.go
@@ -1,0 +1,188 @@
+package controller
+
+import (
+	"slices"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	"github.com/kruntimes/kruntimes/internal/artifact"
+)
+
+func TestArtifactCleanupSnapshotsRuntimeStore(t *testing.T) {
+	scheme := artifactCleanupScheme(t)
+	run := artifactCleanupRun(false, nil)
+	runtimeResource := &v1alpha1.Runtime{
+		ObjectMeta: metav1.ObjectMeta{Name: run.Spec.Runtime, Namespace: run.Namespace},
+		Spec:       v1alpha1.RuntimeSpec{ArtifactStore: filesystemStoreSpec()},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.Run{}).WithObjects(run, runtimeResource).Build()
+	r := &ArtifactCleanupReconciler{Client: k8sClient, CleanerImage: "controller:test"}
+
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	var current v1alpha1.Run
+	if err := k8sClient.Get(t.Context(), client.ObjectKeyFromObject(run), &current); err != nil {
+		t.Fatal(err)
+	}
+	if current.Status.ArtifactStore == nil || current.Status.ArtifactStore.Filesystem == nil ||
+		current.Status.ArtifactStore.Filesystem.VolumeClaimName != "artifacts-pvc" {
+		t.Fatalf("artifact store snapshot = %#v", current.Status.ArtifactStore)
+	}
+}
+
+func TestArtifactCleanupCreatesFilesystemJobWithoutRuntime(t *testing.T) {
+	scheme := artifactCleanupScheme(t)
+	run := artifactCleanupRun(true, filesystemStoreSpec())
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(run).Build()
+	r := &ArtifactCleanupReconciler{
+		Client: k8sClient, CleanerImage: "controller:test",
+		ImagePullSecrets: []corev1.LocalObjectReference{{Name: "registry"}},
+	}
+
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	var job batchv1.Job
+	if err := k8sClient.Get(t.Context(), types.NamespacedName{
+		Namespace: run.Namespace, Name: artifact.CleanupJobName(run.UID),
+	}, &job); err != nil {
+		t.Fatal(err)
+	}
+	container := job.Spec.Template.Spec.Containers[0]
+	if container.Image != "controller:test" || container.Command[0] != "/artifact-cleaner" {
+		t.Fatalf("cleaner container = %#v", container)
+	}
+	if !slices.Contains(container.Args, "--filesystem-volume-claim=artifacts-pvc") {
+		t.Fatalf("cleaner args = %v", container.Args)
+	}
+	if len(job.Spec.Template.Spec.Volumes) != 1 ||
+		job.Spec.Template.Spec.Volumes[0].PersistentVolumeClaim.ClaimName != "artifacts-pvc" {
+		t.Fatalf("cleanup volumes = %#v", job.Spec.Template.Spec.Volumes)
+	}
+	if len(job.Spec.Template.Spec.ImagePullSecrets) != 1 || job.Spec.Template.Spec.ImagePullSecrets[0].Name != "registry" {
+		t.Fatalf("imagePullSecrets = %#v", job.Spec.Template.Spec.ImagePullSecrets)
+	}
+}
+
+func TestBuildS3ArtifactCleanupJobUsesSecretReference(t *testing.T) {
+	store := &v1alpha1.RuntimeArtifactStoreSpec{
+		Driver: v1alpha1.ArtifactDriverS3,
+		S3: &v1alpha1.S3ArtifactStoreSpec{
+			Bucket: "artifacts", Prefix: "prod", Endpoint: "http://minio:9000",
+			ForcePathStyle: true, CredentialsSecretName: "s3-credentials",
+		},
+	}
+	run := artifactCleanupRun(true, store)
+	r := &ArtifactCleanupReconciler{CleanerImage: "controller:test"}
+
+	job, err := r.buildCleanupJob(run)
+	if err != nil {
+		t.Fatalf("buildCleanupJob: %v", err)
+	}
+	container := job.Spec.Template.Spec.Containers[0]
+	for _, want := range []string{
+		"--s3-bucket=artifacts", "--s3-prefix=prod", "--s3-endpoint=http://minio:9000", "--s3-force-path-style=true",
+	} {
+		if !slices.Contains(container.Args, want) {
+			t.Fatalf("cleaner args = %v, missing %s", container.Args, want)
+		}
+	}
+	if len(container.EnvFrom) != 1 || container.EnvFrom[0].SecretRef.Name != "s3-credentials" {
+		t.Fatalf("cleaner envFrom = %#v", container.EnvFrom)
+	}
+}
+
+func TestArtifactCleanupCompletedJobRemovesFinalizer(t *testing.T) {
+	scheme := artifactCleanupScheme(t)
+	run := artifactCleanupRun(true, filesystemStoreSpec())
+	r := &ArtifactCleanupReconciler{CleanerImage: "controller:test"}
+	job, err := r.buildCleanupJob(run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	job.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(run, &job).Build()
+	r.Client = k8sClient
+
+	if _, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	var current v1alpha1.Run
+	err = k8sClient.Get(t.Context(), client.ObjectKeyFromObject(run), &current)
+	if err == nil && slices.Contains(current.Finalizers, artifact.RunArtifactFinalizer) {
+		t.Fatalf("finalizer was not removed: %v", current.Finalizers)
+	}
+}
+
+func TestArtifactCleanupFailedJobIsDeletedForRetry(t *testing.T) {
+	scheme := artifactCleanupScheme(t)
+	run := artifactCleanupRun(true, filesystemStoreSpec())
+	r := &ArtifactCleanupReconciler{CleanerImage: "controller:test"}
+	job, err := r.buildCleanupJob(run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	job.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobFailed, Status: corev1.ConditionTrue}}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(run, &job).Build()
+	r.Client = k8sClient
+
+	result, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if result.RequeueAfter != artifactCleanupRetry {
+		t.Fatalf("RequeueAfter = %s, want %s", result.RequeueAfter, artifactCleanupRetry)
+	}
+	var currentJob batchv1.Job
+	if err := k8sClient.Get(t.Context(), client.ObjectKeyFromObject(&job), &currentJob); err == nil {
+		t.Fatal("failed cleanup Job was not deleted")
+	}
+}
+
+func artifactCleanupScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return scheme
+}
+
+func artifactCleanupRun(deleting bool, store *v1alpha1.RuntimeArtifactStoreSpec) *v1alpha1.Run {
+	run := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "artifact-run", Namespace: "workloads", UID: "artifact-run-uid",
+			Finalizers: []string{artifact.RunArtifactFinalizer},
+		},
+		Spec:   v1alpha1.RunSpec{Runtime: "bash"},
+		Status: v1alpha1.RunStatus{ArtifactStore: store},
+	}
+	if deleting {
+		now := metav1.Now()
+		run.DeletionTimestamp = &now
+	}
+	return run
+}
+
+func filesystemStoreSpec() *v1alpha1.RuntimeArtifactStoreSpec {
+	return &v1alpha1.RuntimeArtifactStoreSpec{
+		Driver: v1alpha1.ArtifactDriverFilesystem,
+		Filesystem: &v1alpha1.FilesystemArtifactStoreSpec{
+			VolumeClaimName: "artifacts-pvc",
+		},
+	}
+}

--- a/internal/controller/runtime_controller.go
+++ b/internal/controller/runtime_controller.go
@@ -580,6 +580,7 @@ func configureS3ArtifactStore(store *v1alpha1.S3ArtifactStoreSpec, daemon *corev
 		daemon.Args = append(daemon.Args, fmt.Sprintf("--artifact-s3-upload-concurrency=%d", store.UploadConcurrency))
 	}
 	if store.CredentialsSecretName != "" {
+		daemon.Args = append(daemon.Args, fmt.Sprintf("--artifact-s3-credentials-secret-name=%s", store.CredentialsSecretName))
 		daemon.EnvFrom = append(daemon.EnvFrom, corev1.EnvFromSource{
 			SecretRef: &corev1.SecretEnvSource{
 				LocalObjectReference: corev1.LocalObjectReference{Name: store.CredentialsSecretName},

--- a/internal/controller/runtime_controller_test.go
+++ b/internal/controller/runtime_controller_test.go
@@ -536,6 +536,7 @@ func TestBuildDeploymentConfiguresS3ArtifactStoreOnlyInRuntimed(t *testing.T) {
 		"--artifact-s3-force-path-style=true",
 		"--artifact-s3-upload-part-size=8388608",
 		"--artifact-s3-upload-concurrency=4",
+		"--artifact-s3-credentials-secret-name=artifact-credentials",
 	}
 	for _, arg := range wantArgs {
 		if !slices.Contains(daemon.Args, arg) {

--- a/internal/runtimed/artifacts.go
+++ b/internal/runtimed/artifacts.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"sort"
 
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
@@ -102,6 +101,15 @@ func (c *Controller) collectArtifacts(ctx context.Context, run *v1alpha1.Run) (r
 }
 
 func (c *Controller) ensureArtifactFinalizer(ctx context.Context, run *v1alpha1.Run) error {
+	if run.Status.ArtifactStore == nil && c.Client != nil {
+		if c.ArtifactStoreSpec == nil {
+			return fmt.Errorf("artifact store cleanup configuration is not available")
+		}
+		run.Status.ArtifactStore = c.ArtifactStoreSpec.DeepCopy()
+		if err := c.Status().Update(ctx, run); err != nil {
+			return fmt.Errorf("record artifact store cleanup configuration: %w", err)
+		}
+	}
 	if controllerutil.ContainsFinalizer(run, artifact.RunArtifactFinalizer) {
 		return nil
 	}
@@ -113,20 +121,6 @@ func (c *Controller) ensureArtifactFinalizer(ctx context.Context, run *v1alpha1.
 		return fmt.Errorf("add artifact cleanup finalizer: %w", err)
 	}
 	return nil
-}
-
-func (c *Controller) reconcileArtifactDeletion(ctx context.Context, run *v1alpha1.Run) (ctrl.Result, error) {
-	if !controllerutil.ContainsFinalizer(run, artifact.RunArtifactFinalizer) {
-		return ctrl.Result{}, nil
-	}
-	if err := c.deleteRunArtifacts(ctx, run); err != nil {
-		return ctrl.Result{}, err
-	}
-	controllerutil.RemoveFinalizer(run, artifact.RunArtifactFinalizer)
-	if err := c.Update(ctx, run); err != nil {
-		return ctrl.Result{}, fmt.Errorf("remove artifact cleanup finalizer: %w", err)
-	}
-	return ctrl.Result{}, nil
 }
 
 func (c *Controller) deleteRunArtifacts(ctx context.Context, run *v1alpha1.Run) error {

--- a/internal/runtimed/artifacts_test.go
+++ b/internal/runtimed/artifacts_test.go
@@ -109,7 +109,7 @@ func TestApplySuccessWritesArtifactRefsOnlyAfterAllUploadsSucceed(t *testing.T) 
 		WithObjects(run).
 		Build()
 	store := &fakeArtifactStore{failAt: 2}
-	c := &Controller{Client: k8sClient, ArtifactStore: store}
+	c := &Controller{Client: k8sClient, ArtifactStore: store, ArtifactStoreSpec: artifactTestStoreSpec()}
 	ar := &activeRun{run: run, workDir: filepath.Join(workspacePath, string(run.UID))}
 
 	result, err := c.applySuccess(t.Context(), ar, &pb.StatusResponse{Stdout: "stdout"})
@@ -298,8 +298,9 @@ func TestApplySuccessTransientStoreFailureRequeuesWithoutChangingRun(t *testing.
 		WithObjects(run).
 		Build()
 	c := &Controller{
-		Client:        k8sClient,
-		ArtifactStore: &fakeArtifactStore{failAt: 1},
+		Client:            k8sClient,
+		ArtifactStore:     &fakeArtifactStore{failAt: 1},
+		ArtifactStoreSpec: artifactTestStoreSpec(),
 	}
 	ar := &activeRun{run: run, workDir: filepath.Join(workspacePath, string(run.UID))}
 
@@ -347,7 +348,7 @@ func TestApplySuccessInvalidArtifactTerminatesWithoutRetry(t *testing.T) {
 		WithObjects(run).
 		Build()
 	store := &fakeArtifactStore{}
-	c := &Controller{Client: k8sClient, ArtifactStore: store}
+	c := &Controller{Client: k8sClient, ArtifactStore: store, ArtifactStoreSpec: artifactTestStoreSpec()}
 	ar := &activeRun{run: run, workDir: filepath.Join(workspacePath, string(run.UID))}
 
 	if _, err := c.applySuccess(t.Context(), ar, &pb.StatusResponse{Stdout: "stdout"}); err != nil {
@@ -369,7 +370,7 @@ func TestApplySuccessInvalidArtifactTerminatesWithoutRetry(t *testing.T) {
 	}
 }
 
-func TestReconcileArtifactDeletionDeletesRunObjectsAndRemovesFinalizer(t *testing.T) {
+func TestReconcileArtifactDeletionLeavesCleanupToCentralController(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := v1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
@@ -392,13 +393,16 @@ func TestReconcileArtifactDeletionDeletesRunObjectsAndRemovesFinalizer(t *testin
 	if _, err := c.Reconcile(t.Context(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}); err != nil {
 		t.Fatalf("Reconcile deletion: %v", err)
 	}
-	if store.deleteRuns != 1 {
-		t.Fatalf("DeleteRun calls = %d, want 1", store.deleteRuns)
+	if store.deleteRuns != 0 {
+		t.Fatalf("DeleteRun calls = %d, want 0", store.deleteRuns)
 	}
 	var current v1alpha1.Run
 	err := k8sClient.Get(t.Context(), client.ObjectKeyFromObject(run), &current)
-	if err == nil && slices.Contains(current.Finalizers, artifact.RunArtifactFinalizer) {
-		t.Fatalf("finalizer was not removed: %v", current.Finalizers)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(current.Finalizers, artifact.RunArtifactFinalizer) {
+		t.Fatalf("central cleanup finalizer was removed: %v", current.Finalizers)
 	}
 }
 
@@ -463,6 +467,15 @@ func artifactTestRun() *v1alpha1.Run {
 			UID:       "artifact-run-uid",
 		},
 		Spec: v1alpha1.RunSpec{Runtime: "bash"},
+	}
+}
+
+func artifactTestStoreSpec() *v1alpha1.RuntimeArtifactStoreSpec {
+	return &v1alpha1.RuntimeArtifactStoreSpec{
+		Driver: v1alpha1.ArtifactDriverFilesystem,
+		Filesystem: &v1alpha1.FilesystemArtifactStoreSpec{
+			VolumeClaimName: "artifacts-pvc",
+		},
 	}
 }
 

--- a/internal/runtimed/controller.go
+++ b/internal/runtimed/controller.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -117,6 +116,7 @@ type Controller struct {
 	RuntimeEndpoint   string
 	Workers           int
 	ArtifactStore     artifact.Store
+	ArtifactStoreSpec *v1alpha1.RuntimeArtifactStoreSpec
 	MaxArtifactBytes  int64
 	MaxArtifactsBytes int64
 
@@ -195,8 +195,7 @@ func (c *Controller) runFilter() predicate.Predicate {
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			run, ok := e.ObjectNew.(*v1alpha1.Run)
-			return ok && c.matchesRuntimeNamespace(run) &&
-				(run.Status.AssignedPod == c.Hostname || c.shouldCleanupArtifacts(run))
+			return ok && c.matchesRuntimeNamespace(run) && run.Status.AssignedPod == c.Hostname
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool { return false },
 		GenericFunc: func(e event.GenericEvent) bool {
@@ -218,7 +217,7 @@ func (c *Controller) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	if !run.DeletionTimestamp.IsZero() {
-		return c.reconcileArtifactDeletion(ctx, &run)
+		return ctrl.Result{}, nil
 	}
 
 	switch run.Status.Phase {
@@ -556,17 +555,6 @@ func (c *Controller) applySuccess(ctx context.Context, ar *activeRun, resp *pb.S
 			"Run succeeded after %d attempts", run.Status.Attempt)
 	}
 	return ctrl.Result{}, nil
-}
-
-func (c *Controller) shouldCleanupArtifacts(run *v1alpha1.Run) bool {
-	if run == nil || run.DeletionTimestamp.IsZero() ||
-		!controllerutil.ContainsFinalizer(run, artifact.RunArtifactFinalizer) {
-		return false
-	}
-	if c.RuntimeName != "" {
-		return run.Spec.Runtime == c.RuntimeName
-	}
-	return run.Status.AssignedPod == c.Hostname
 }
 
 // ===========================================================================

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -29,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	"github.com/kruntimes/kruntimes/internal/artifact"
 	"github.com/kruntimes/kruntimes/internal/krt"
 	"github.com/kruntimes/kruntimes/internal/runtimepod"
 )
@@ -63,6 +65,7 @@ func runtimedImage() string {
 func TestMain(m *testing.M) {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(batchv1.AddToScheme(scheme))
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 
 	restConfig = config.GetConfigOrDie()
@@ -620,6 +623,10 @@ func TestFilesystemArtifacts(t *testing.T) {
 	if len(run.Status.ArtifactRefs) != 2 {
 		t.Fatalf("artifact refs = %#v, want 2", run.Status.ArtifactRefs)
 	}
+	if run.Status.ArtifactStore == nil || run.Status.ArtifactStore.Filesystem == nil ||
+		run.Status.ArtifactStore.Filesystem.VolumeClaimName != claimName {
+		t.Fatalf("artifact store cleanup snapshot = %#v", run.Status.ArtifactStore)
+	}
 	var report, bundle *v1alpha1.ArtifactRef
 	for i := range run.Status.ArtifactRefs {
 		ref := &run.Status.ArtifactRefs[i]
@@ -663,7 +670,9 @@ func TestFilesystemArtifacts(t *testing.T) {
 	}
 	assertTarGzFile(t, bundlePath, "data.txt", "nested")
 
-	artifactPath := "/var/lib/kruntimes/artifacts/" + report.Location.Filesystem.Path
+	deleteRuntimeAndWait(t, runtimeName, 30*time.Second)
+	injectFailedArtifactCleanupJob(t, run)
+
 	ttlSeconds := int32(1)
 	for i := 0; i < 10; i++ {
 		if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(run), run); err != nil {
@@ -679,9 +688,123 @@ func TestFilesystemArtifacts(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 	}
 	waitForRunDeleted(t, run, 30*time.Second)
+	assertFilesystemArtifactMissing(t, claimName, report.Location.Filesystem.Path)
+}
 
-	if _, stderr, err := execInPod(context.Background(), run.Status.AssignedPod, "runtimed", []string{"test", "!", "-e", artifactPath}); err != nil {
-		t.Fatalf("artifact remained after Run deletion: %v: %s", err, stderr)
+func injectFailedArtifactCleanupJob(t *testing.T, run *v1alpha1.Run) {
+	t.Helper()
+	backoffLimit := int32(0)
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      artifact.CleanupJobName(run.UID),
+			Namespace: run.Namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      "kruntimes",
+				"app.kubernetes.io/component": "artifact-cleaner",
+			},
+			Annotations: map[string]string{
+				artifact.CleanupRunAnnotation:    run.Name,
+				artifact.CleanupRunUIDAnnotation: string(run.UID),
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: &backoffLimit,
+			Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+				RestartPolicy: corev1.RestartPolicyNever,
+				Containers: []corev1.Container{{
+					Name: "cleaner", Image: bashRuntimeImage(),
+					Command: []string{"/bin/sh", "-c"}, Args: []string{"exit 1"},
+				}},
+			}},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), job); err != nil {
+		t.Fatalf("create failed cleanup Job: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	for {
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(job), job); err != nil {
+			t.Fatalf("get failed cleanup Job: %v", err)
+		}
+		for _, condition := range job.Status.Conditions {
+			if condition.Type == batchv1.JobFailed && condition.Status == corev1.ConditionTrue {
+				return
+			}
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for injected cleanup Job to fail")
+		case <-time.After(250 * time.Millisecond):
+		}
+	}
+}
+
+func deleteRuntimeAndWait(t *testing.T, name string, timeout time.Duration) {
+	t.Helper()
+	runtimeResource := &v1alpha1.Runtime{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace}}
+	if err := k8sClient.Delete(context.Background(), runtimeResource); err != nil && !apierrors.IsNotFound(err) {
+		t.Fatalf("delete Runtime %s: %v", name, err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	for {
+		var pods corev1.PodList
+		if err := k8sClient.List(ctx, &pods, client.InNamespace(testNamespace), client.MatchingLabels{"runtime": name}); err != nil {
+			t.Fatalf("list Runtime pods: %v", err)
+		}
+		if len(pods.Items) == 0 {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for Runtime %s pods to be deleted", name)
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+func assertFilesystemArtifactMissing(t *testing.T, claimName, relativePath string) {
+	t.Helper()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "artifact-inspector-", Namespace: testNamespace},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{{
+				Name: "inspector", Image: bashRuntimeImage(),
+				Command:      []string{"test"},
+				Args:         []string{"!", "-e", "/artifacts/" + relativePath},
+				VolumeMounts: []corev1.VolumeMount{{Name: "artifacts", MountPath: "/artifacts"}},
+			}},
+			Volumes: []corev1.Volume{{
+				Name: "artifacts",
+				VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: claimName,
+				}},
+			}},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), pod); err != nil {
+		t.Fatalf("create artifact inspector Pod: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(context.Background(), pod) })
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	for {
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
+			t.Fatalf("get artifact inspector Pod: %v", err)
+		}
+		switch pod.Status.Phase {
+		case corev1.PodSucceeded:
+			return
+		case corev1.PodFailed:
+			t.Fatalf("artifact inspector found path %s", relativePath)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for artifact inspector Pod, phase=%s", pod.Status.Phase)
+		case <-time.After(500 * time.Millisecond):
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- persist the non-secret artifact store cleanup configuration in Run status before uploads
- move artifact finalizer ownership from runtimed Pods to a long-lived controller reconciler
- run filesystem and S3 cleanup in isolated Jobs using an artifact-cleaner helper embedded in the controller image
- retain finalizers across missing PVCs, credentials, and transient cleanup failures; retry failed Jobs idempotently
- carry controller image pull secrets and minimum Job security defaults into cleanup workloads
- document recovery semantics and mark the Artifact Cleanup Ownership P0 section complete

## Coverage
- unit coverage for snapshot migration, filesystem/S3 Job construction, failed Job retry, finalizer removal, and cleaner idempotency
- E2E deletes the Runtime before Run cleanup, injects a failed cleanup Job, verifies recovery, then mounts the PVC to prove artifacts were removed

## Testing
- GOCACHE=/tmp/go-build make test
- GOCACHE=/tmp/go-build make test-integration
- GOCACHE=/tmp/go-build make test-helm
- GOCACHE=/tmp/go-build make e2e (clean kind cluster)