### PR TITLE
chore(release): publish signed image SBOMs

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -1,0 +1,103 @@
+name: Release Images
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Optional image tag for manual publish runs"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+concurrency:
+  group: release-images-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: kruntimes-scheduler
+            dockerfile: Dockerfile.scheduler
+          - image: kruntimes-controller
+            dockerfile: Dockerfile.controller
+          - image: kruntimes-runtimed
+            dockerfile: Dockerfile.runtimed
+          - image: kruntimes-bash-runtime
+            dockerfile: Dockerfile.bash-runtime
+          - image: kruntimes-python-runtime
+            dockerfile: Dockerfile.python-runtime
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Resolve registry owner
+        id: registry
+        shell: bash
+        run: |
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "image=ghcr.io/${owner}/${{ matrix.image }}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.6.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.11.1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5.7.0
+        with:
+          images: ${{ steps.registry.outputs.image }}
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' }}
+            type=sha,format=long,enable=${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag == '' }}
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6.18.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          sbom: true
+          provenance: mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
+      - name: Sign image digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        shell: bash
+        run: |
+          while IFS= read -r tag; do
+            if [[ -n "${tag}" ]]; then
+              cosign sign --yes "${tag}@${DIGEST}"
+            fi
+          done <<< "${TAGS}"

--- a/README.md
+++ b/README.md
@@ -567,6 +567,25 @@ make test-integration      # integration tests (envtest)
 make docker-build          # build all Docker images
 ```
 
+## Release Images
+
+Pushing a SemVer tag such as `v0.1.0` runs the `Release Images` workflow. The
+workflow publishes the scheduler, controller, runtimed, Bash Runtime, and Python
+Runtime images to GitHub Container Registry under `ghcr.io/<owner>/`.
+
+Each published image is built for `linux/amd64` and `linux/arm64`, includes
+BuildKit SBOM and provenance attestations, and is signed with `cosign` keyless
+signing through GitHub OIDC. Tags include the original Git tag, the SemVer
+version without the leading `v`, and the major/minor version.
+
+Example verification:
+
+```bash
+cosign verify ghcr.io/<owner>/kruntimes-controller:0.1.0 \
+  --certificate-identity-regexp 'https://github.com/.*/.github/workflows/release-images.yml@refs/tags/v0.1.0' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
 ## Python Runtime
 
 ### Development Setup

--- a/docs/open-source-readiness.md
+++ b/docs/open-source-readiness.md
@@ -154,7 +154,7 @@ Artifact finalizer 最初由 Runtime Pod 内的 runtimed 执行，导致 Runtime
 - [x] Python 镜像通过 `uv.lock` 安装依赖，不直接安装未固定版本。
 - [x] 固定 Makefile 中 controller-gen、setup-envtest、golangci-lint、
   protoc plugins 和 uv 的版本。
-- [ ] 发布镜像生成 SBOM，并使用 cosign 或等价机制签名。
+- [x] 发布镜像生成 SBOM，并使用 cosign 或等价机制签名。
 
 验收标准：
 


### PR DESCRIPTION
## Summary
- add a release image workflow for scheduler, controller, runtimed, Bash Runtime, and Python Runtime images
- publish images to GHCR with BuildKit SBOM/provenance attestations and cosign keyless signatures
- document release image verification and mark the supply-chain readiness item done

## Validation
- yq eval '.' .github/workflows/release-images.yml
- make test-helm

Note: GitHub Actions may still fail to start until the repository billing issue is resolved.