### PR TITLE
ci: skip heavy checks for docs-only pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect non-docs changes
+    runs-on: ubuntu-latest
+    outputs:
+      non_docs: ${{ steps.filter.outputs.non_docs }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            non_docs:
+              - "**"
+              - "!README.md"
+              - "!docs/**"
+              - "!site/**"
+
   unit:
     name: Go unit tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.non_docs == 'true'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
@@ -30,6 +49,8 @@ jobs:
   integration:
     name: Go integration tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.non_docs == 'true'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
@@ -41,6 +62,8 @@ jobs:
   race:
     name: Go race detector
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.non_docs == 'true'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6
@@ -52,6 +75,8 @@ jobs:
   python:
     name: Python Runtime tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.non_docs == 'true'
     defaults:
       run:
         working-directory: runtimes/python
@@ -68,6 +93,8 @@ jobs:
   helm:
     name: Helm charts
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.non_docs == 'true'
     steps:
       - uses: actions/checkout@v7
       - uses: azure/setup-helm@v5.0.1
@@ -80,6 +107,8 @@ jobs:
   generated:
     name: Generated files
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.non_docs == 'true'
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,9 +17,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect non-docs changes
+    runs-on: ubuntu-latest
+    outputs:
+      non_docs: ${{ steps.filter.outputs.non_docs }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            non_docs:
+              - "**"
+              - "!README.md"
+              - "!docs/**"
+              - "!site/**"
+
   secrets:
     name: Secret scanning
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.non_docs == 'true'
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Summary
- detect README/docs/site-only changes in CI and Security workflows
- skip heavy required CI jobs for docs-only pull requests while keeping checks successful
- keep secret scanning active for push, scheduled, and manual Security runs

## Testing
- git diff --check