### PR TITLE
ci: fix docs-only path filter semantics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          predicate-quantifier: every
           filters: |
             non_docs:
               - "**"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          predicate-quantifier: every
           filters: |
             non_docs:
               - "**"


### PR DESCRIPTION
## Summary
- set dorny/paths-filter predicate-quantifier to every in CI and Security workflows
- make the non_docs filter treat docs/README/site-only pull requests as docs-only
- follow-up for #211 after #212 showed non_docs still matched docs files

## Testing
- git diff --check