### PR TITLE
ci: decouple chart and app versions

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -38,15 +38,16 @@ jobs:
           set -euo pipefail
 
           version="${RELEASE_TAG#v}"
+          semver_re='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
           for chart in charts/kruntimes charts/kruntimes-runtimes; do
             chart_version="$(helm show chart "${chart}" | awk '$1 == "version:" { print $2 }')"
             app_version="$(helm show chart "${chart}" | awk '$1 == "appVersion:" { gsub(/"/, "", $2); print $2 }')"
-            if [[ "${chart_version}" != "${version}" ]]; then
-              echo "${chart} version ${chart_version} does not match ${version}" >&2
+            if [[ ! "${chart_version}" =~ ${semver_re} ]]; then
+              echo "${chart} version ${chart_version} is not valid SemVer" >&2
               exit 1
             fi
             if [[ "${app_version}" != "${version}" ]]; then
-              echo "${chart} appVersion ${app_version} does not match ${version}" >&2
+              echo "${chart} appVersion ${app_version} does not match release ${version}" >&2
               exit 1
             fi
           done

--- a/charts/kruntimes-runtimes/Chart.yaml
+++ b/charts/kruntimes-runtimes/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kruntimes-runtimes
 description: Built-in runtimes for kruntimes
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.0.1
+appVersion: "0.0.1"
 keywords:
   - kruntimes
   - runtime

--- a/charts/kruntimes/Chart.yaml
+++ b/charts/kruntimes/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kruntimes
 description: Two-layer scheduling system for CI/CD run warm-up on Kubernetes
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.0.1
+appVersion: "0.0.1"
 keywords:
   - cicd
   - scheduling

--- a/docs/release.md
+++ b/docs/release.md
@@ -15,12 +15,17 @@ make those changes explicit.
   notes describe the impact and migration path.
 - Major releases are reserved for stable API compatibility commitments.
 
-Keep these versions aligned for a release:
+Keep these versions aligned for an application release:
 
 - Git tag: `vX.Y.Z`
-- `charts/kruntimes/Chart.yaml`: `version` and `appVersion`
-- `charts/kruntimes-runtimes/Chart.yaml`: `version` and `appVersion`
+- `charts/kruntimes/Chart.yaml`: `appVersion`
+- `charts/kruntimes-runtimes/Chart.yaml`: `appVersion`
 - README examples that name a concrete released version
+
+Chart `version` is the Helm package version and does not need to equal
+`appVersion`. Bump chart `version` whenever chart templates, values,
+dependencies, or chart metadata change. Bump `appVersion` when the default
+installed kruntimes application or runtime image version changes.
 
 Do not reuse or move published release tags. If a release artifact is bad after
 publication, cut a new patch release and mark the bad GitHub release as

--- a/docs/release.zh.md
+++ b/docs/release.zh.md
@@ -14,12 +14,16 @@ breaking API 或行为变更。发布说明必须明确指出这些变更。
   影响和迁移路径时，可能包含 breaking changes。
 - 主版本保留给稳定的 API 兼容性承诺。
 
-发布时保持以下版本一致：
+发布应用版本时保持以下版本一致：
 
 - Git tag：`vX.Y.Z`
-- `charts/kruntimes/Chart.yaml`：`version` 和 `appVersion`
-- `charts/kruntimes-runtimes/Chart.yaml`：`version` 和 `appVersion`
+- `charts/kruntimes/Chart.yaml`：`appVersion`
+- `charts/kruntimes-runtimes/Chart.yaml`：`appVersion`
 - 引用了具体发布版本的 README 示例
+
+Chart `version` 是 Helm package version，不需要等于 `appVersion`。当 chart
+templates、values、dependencies 或 chart metadata 变化时 bump chart `version`。
+当默认安装的 kruntimes application 或 runtime image 版本变化时 bump `appVersion`。
 
 不要复用或移动已发布的 release tags。如果发布产物在发布后有问题，请发布一个新的补丁
 版本，并将有问题的 GitHub release 标记为被取代。

--- a/hack/verify-helm-images.py
+++ b/hack/verify-helm-images.py
@@ -10,13 +10,15 @@ import sys
 def main() -> int:
     platform = helm_template("kruntimes", "charts/kruntimes")
     runtimes = helm_template("kruntimes-runtimes", "charts/kruntimes-runtimes")
+    platform_app_version = helm_chart_field("charts/kruntimes", "appVersion")
+    runtimes_app_version = helm_chart_field("charts/kruntimes-runtimes", "appVersion")
 
     expected_defaults = [
-        "image: kruntimes-controller:0.1.0",
-        "image: kruntimes-scheduler:0.1.0",
-        "--default-daemon-image=kruntimes-runtimed:0.1.0",
-        "image: kruntimes-bash-runtime:0.1.0",
-        "image: kruntimes-python-runtime:0.1.0",
+        f"image: kruntimes-controller:{platform_app_version}",
+        f"image: kruntimes-scheduler:{platform_app_version}",
+        f"--default-daemon-image=kruntimes-runtimed:{platform_app_version}",
+        f"image: kruntimes-bash-runtime:{runtimes_app_version}",
+        f"image: kruntimes-python-runtime:{runtimes_app_version}",
     ]
     for expected in expected_defaults:
         if expected not in platform and expected not in runtimes:
@@ -68,6 +70,15 @@ def helm_template(release: str, chart: str, *args: str) -> str:
         ["helm", "template", release, chart, "--namespace", "default", *args],
         text=True,
     )
+
+
+def helm_chart_field(chart: str, field: str) -> str:
+    chart_yaml = subprocess.check_output(["helm", "show", "chart", chart], text=True)
+    for line in chart_yaml.splitlines():
+        key, sep, value = line.partition(":")
+        if sep and key == field:
+            return value.strip().strip('"')
+    raise RuntimeError(f"{chart} is missing {field}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- stop requiring Helm chart version to equal the application release version
- keep release validation that chart appVersion matches the release tag
- validate chart version as SemVer and document chart version vs appVersion semantics

## Testing
- GOCACHE=/tmp/go-build make test
- GOCACHE=/tmp/go-build make test-integration
- GOBIN=/tmp/kruntimes-bin make site-build
- git diff --check