### PR TITLE
docs: configure GitHub Pages custom domain

### DIFF
--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -1,4 +1,4 @@
-baseURL: "https://kruntimes.github.io/kruntimes/"
+baseURL: "https://kruntimes.io/"
 title: "kruntimes"
 defaultContentLanguage: en
 disableKinds:

--- a/site/static/CNAME
+++ b/site/static/CNAME
@@ -1,0 +1,1 @@
+kruntimes.io


### PR DESCRIPTION
## Summary
- set the Hugo site baseURL to https://kruntimes.io/
- add site/static/CNAME so the GitHub Pages artifact preserves the custom domain

## Validation
- GOBIN=/tmp/kruntimes-bin make site-build
- verified site/public/CNAME contains kruntimes.io
- verified generated pages reference https://kruntimes.io/ assets