### PR TITLE
chore: prepare v0.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ but each release note must call them out explicitly.
 
 ## Unreleased
 
+## 0.0.2 - 2026-06-30
+
 ### Added
 
 - Initial release process documentation for SemVer tags, changelog entries, and
@@ -24,3 +26,11 @@ but each release note must call them out explicitly.
   Runtime CRD template ownership, capacity, and compatibility expectations.
 - GitHub Actions release workflow for publishing Helm OCI charts to GitHub
   Container Registry.
+- GitHub Pages custom domain configuration for `https://kruntimes.io/`.
+
+### Changed
+
+- Decoupled Helm chart package versions from kruntimes application versions
+  while keeping chart `appVersion` aligned with release tags.
+- Improved release image build performance with BuildKit cache reuse and native
+  cross-compilation for Go-based multi-architecture images.

--- a/charts/kruntimes-runtimes/Chart.yaml
+++ b/charts/kruntimes-runtimes/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kruntimes-runtimes
 description: Built-in runtimes for kruntimes
 type: application
-version: 0.0.1
-appVersion: "0.0.1"
+version: 0.0.2
+appVersion: "0.0.2"
 keywords:
   - kruntimes
   - runtime

--- a/charts/kruntimes/Chart.yaml
+++ b/charts/kruntimes/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kruntimes
 description: Two-layer scheduling system for CI/CD run warm-up on Kubernetes
 type: application
-version: 0.0.1
-appVersion: "0.0.1"
+version: 0.0.2
+appVersion: "0.0.2"
 keywords:
   - cicd
   - scheduling


### PR DESCRIPTION
## Summary
- move current unreleased release-related entries into a v0.0.2 changelog section
- bump platform and built-in runtime chart versions to 0.0.2
- set chart appVersion to 0.0.2 so the v0.0.2 tag publishes charts with matching default image tags

## Validation
- GOCACHE=/tmp/go-build make test
- GOCACHE=/tmp/go-build make test-integration
- GOCACHE=/tmp/go-build make test-helm
- git diff --check

## Release follow-up after merge
- run full release preflight, including make e2e
- create and push annotated tag v0.0.2
- verify Release Images, Release Charts, and Release CLI artifacts