### PR TITLE
docs: add design partner trial template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Target user validation playbook
+    url: https://github.com/kruntimes/kruntimes/blob/main/docs/user-validation.md
+    about: Review how design partner trials are evaluated
   - name: Security vulnerability
     url: https://github.com/kruntimes/kruntimes/security/advisories/new
     about: Report vulnerabilities privately

--- a/.github/ISSUE_TEMPLATE/design_partner_trial.yml
+++ b/.github/ISSUE_TEMPLATE/design_partner_trial.yml
@@ -1,0 +1,76 @@
+name: Design partner trial
+description: Share results from trying kruntimes on a real or representative workload
+title: "[Trial]: "
+labels:
+  - validation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for public, non-sensitive trial feedback. Do not include
+        credentials, private source code, customer data, or security vulnerabilities.
+        Report security issues privately through GitHub Security Advisories.
+  - type: dropdown
+    id: segment
+    attributes:
+      label: Target segment
+      description: Pick the closest segment for this workload.
+      options:
+        - AI agent infrastructure
+        - Platform engineering
+        - CI infrastructure
+        - Automation platform
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: workload
+    attributes:
+      label: Workload
+      description: Describe the real or representative workload you tried.
+      placeholder: Trusted AI tool execution, short CI step, internal automation script, etc.
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Kubernetes version, cluster type, kruntimes version, and install method.
+      placeholder: kind v1.32, kruntimes v0.0.2, Helm OCI chart
+    validations:
+      required: true
+  - type: checkboxes
+    id: activities
+    attributes:
+      label: Activities completed
+      options:
+        - label: I completed the Quick Start.
+        - label: I ran at least one end-to-end demo.
+        - label: I replaced the demo command with a real or representative workload.
+        - label: I inspected Run status, outputs, and logs.
+  - type: textarea
+    id: results
+    attributes:
+      label: Results
+      description: Summarize what worked, what failed, and whether the warm Runtime pool model helped.
+    validations:
+      required: true
+  - type: textarea
+    id: blockers
+    attributes:
+      label: Blockers or missing capabilities
+      description: List setup issues, permission gaps, confusing docs, missing features, or operational concerns.
+  - type: textarea
+    id: value
+    attributes:
+      label: Value signal
+      description: Explain kruntimes in your own words, and whether it solves a current problem for you.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I removed credentials, private source code, and sensitive data.
+          required: true
+        - label: This issue does not report a security vulnerability.
+          required: true

--- a/docs/user-validation.md
+++ b/docs/user-validation.md
@@ -86,6 +86,12 @@ Ask each qualified user to try one small workload:
 Do not count a trial as a design-partner success unless the user runs a real or
 representative workload, not only a maintainer-led demo.
 
+Public trial feedback can be recorded with the
+[Design partner trial issue template](https://github.com/kruntimes/kruntimes/issues/new?template=design_partner_trial.yml).
+Private interviews should use the same fields internally and avoid publishing
+company names, credentials, private source code, or customer data without
+explicit approval.
+
 ## Evidence Template
 
 Use one row per conversation or trial. Keep private company and person names out

--- a/docs/user-validation.zh.md
+++ b/docs/user-validation.zh.md
@@ -80,6 +80,11 @@ finished platform.
 只有用户运行了真实或有代表性的 workload，才把 trial 计为 design-partner success。只看
 maintainer 演示不算。
 
+公开 trial feedback 可以通过
+[Design partner trial issue template](https://github.com/kruntimes/kruntimes/issues/new?template=design_partner_trial.yml)
+记录。私下访谈应在内部使用同样字段，并且不要在未经明确同意的情况下公开公司名称、
+credentials、私有源代码或客户数据。
+
 ## 证据模板
 
 每次对话或 trial 记录一行。除非用户明确同意公开引用，不要在公开文档中写真实公司或个人


### PR DESCRIPTION
## Summary
- add a design partner trial issue template for real or representative workload feedback
- link the template from the target user validation playbook
- add the validation playbook to issue template contact links

## Tests
- GOBIN=/tmp/kruntimes-bin make site-build
- git diff --check