### PR TITLE
ci: treat issue templates as docs-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,12 @@ jobs:
               - "!README.md"
               - "!docs/**"
               - "!site/**"
+              - "!.github/ISSUE_TEMPLATE/**"
 
   unit:
     name: Go unit tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.non_docs == 'true'
     steps:
@@ -43,13 +45,14 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - run: make test
+      - run: timeout 15m make test
       - name: Verify tests did not modify tracked files
         run: git diff --exit-code
 
   integration:
     name: Go integration tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.non_docs == 'true'
     steps:
@@ -58,11 +61,12 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - run: make test-integration
+      - run: timeout 15m make test-integration
 
   race:
     name: Go race detector
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.non_docs == 'true'
     steps:
@@ -71,7 +75,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - run: make test-race
+      - run: timeout 15m make test-race
 
   python:
     name: Python Runtime tests

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,6 +34,7 @@ jobs:
               - "!README.md"
               - "!docs/**"
               - "!site/**"
+              - "!.github/ISSUE_TEMPLATE/**"
 
   secrets:
     name: Secret scanning


### PR DESCRIPTION
## Summary
- exclude .github/ISSUE_TEMPLATE/** from non-docs detection in CI and Security workflows
- prevent issue-template-only PRs from running full Go and secret scanning jobs unnecessarily

## Tests
- git diff --check