### PR TITLE
docs: add target user interview template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Target user validation playbook
     url: https://github.com/kruntimes/kruntimes/blob/main/docs/user-validation.md
-    about: Review how design partner trials are evaluated
+    about: Review how interviews and design partner trials are evaluated
   - name: Security vulnerability
     url: https://github.com/kruntimes/kruntimes/security/advisories/new
     about: Report vulnerabilities privately

--- a/.github/ISSUE_TEMPLATE/target_user_interview.yml
+++ b/.github/ISSUE_TEMPLATE/target_user_interview.yml
@@ -1,0 +1,93 @@
+name: Target user interview
+description: Record public, non-sensitive feedback from a target-user conversation
+title: "[Interview]: "
+labels:
+  - validation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for public, non-sensitive interview notes. Do not include
+        credentials, private source code, customer data, confidential company
+        details, or security vulnerabilities. Report security issues privately
+        through GitHub Security Advisories.
+  - type: dropdown
+    id: segment
+    attributes:
+      label: Target segment
+      description: Pick the closest segment for this conversation.
+      options:
+        - AI agent infrastructure
+        - Platform engineering
+        - CI infrastructure
+        - Automation platform
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: workload
+    attributes:
+      label: Current workload
+      description: Describe the short-lived execution workload the user runs today.
+      placeholder: Trusted AI tool execution, short CI step, internal automation script, etc.
+    validations:
+      required: true
+  - type: dropdown
+    id: current_model
+    attributes:
+      label: Current execution model
+      options:
+        - One Kubernetes Pod per task
+        - Warm workers or queue consumers
+        - Existing workflow or CI system
+        - Internal platform
+        - Other
+    validations:
+      required: true
+  - type: checkboxes
+    id: pain
+    attributes:
+      label: Pain points observed
+      options:
+        - label: Pod startup latency affects users or pipelines.
+        - label: Burst queue drain time is a current problem.
+        - label: Runtime image, ServiceAccount, resource, or policy ownership is unclear or expensive.
+        - label: Logs, artifacts, cancellation, retry, or status semantics are hard to provide.
+        - label: The user does not experience these problems.
+  - type: textarea
+    id: value_signal
+    attributes:
+      label: Value signal
+      description: Record how the user explained kruntimes back in their own words.
+    validations:
+      required: true
+  - type: textarea
+    id: objections
+    attributes:
+      label: Objections or non-goals
+      description: Capture why kruntimes may not fit, including security, workflow UI, serving, or batch-policy needs.
+  - type: dropdown
+    id: trial_interest
+    attributes:
+      label: Trial interest
+      description: Would the user try kruntimes on a real or representative non-production workload?
+      options:
+        - Yes, with a clear candidate workload
+        - Maybe, after specific blockers are addressed
+        - No
+    validations:
+      required: true
+  - type: textarea
+    id: follow_up
+    attributes:
+      label: Follow-up
+      description: Link to a trial issue, notes, blocker issue, or next action.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I removed credentials, private source code, sensitive data, and confidential company details.
+          required: true
+        - label: This issue does not report a security vulnerability.
+          required: true

--- a/docs/community.md
+++ b/docs/community.md
@@ -45,6 +45,13 @@ Post-public target-user validation is tracked with
 how the project evaluates whether users understand the value, try real
 workloads, and validate or reject the first product wedge.
 
+Use the public issue templates for non-sensitive evidence:
+
+- [Target user interview](https://github.com/kruntimes/kruntimes/issues/new?template=target_user_interview.yml)
+  for conversation notes and value-comprehension signals.
+- [Design partner trial](https://github.com/kruntimes/kruntimes/issues/new?template=design_partner_trial.yml)
+  for real or representative workload trials.
+
 ## Security
 
 Do not report vulnerabilities through public issues. Use the private reporting

--- a/docs/community.zh.md
+++ b/docs/community.zh.md
@@ -41,6 +41,13 @@ kruntimes 基于 Apache License 2.0 发布。详见
 [目标用户验证 Playbook](user-validation.md) 跟踪。这些文档定义项目如何判断用户是否理解
 价值、是否试用真实 workload，以及第一个产品 wedge 是否被验证或应被否定。
 
+公开、非敏感的 evidence 可以使用以下 issue templates：
+
+- [Target user interview](https://github.com/kruntimes/kruntimes/issues/new?template=target_user_interview.yml)
+  用于记录访谈摘要和 value-comprehension signals。
+- [Design partner trial](https://github.com/kruntimes/kruntimes/issues/new?template=design_partner_trial.yml)
+  用于记录真实或有代表性的 workload trial。
+
 ## 安全
 
 请勿通过公开 issue 报告漏洞。使用

--- a/docs/user-validation.md
+++ b/docs/user-validation.md
@@ -48,6 +48,12 @@ I'm mainly trying to learn whether this solves a real problem, not to sell a
 finished platform.
 ```
 
+Public interview feedback can be recorded with the
+[Target user interview issue template](https://github.com/kruntimes/kruntimes/issues/new?template=target_user_interview.yml).
+Use the template for public, non-sensitive summaries only. Keep private company
+details, credentials, private source code, customer data, and security reports
+out of public issues.
+
 ## Interview Script
 
 Keep the first conversation focused on current behavior, not desired features.
@@ -99,7 +105,7 @@ of public docs unless the user explicitly approves attribution.
 
 | Date | User Label | Segment | Workload | Signal | Evidence | Follow-up |
 | --- | --- | --- | --- | --- | --- | --- |
-| YYYY-MM-DD | design-partner-a | AI infra / Platform / CI / Automation | Short description | Comprehension / Trial / Quick start / Rejection | Link to issue, Discussion, notes, or anonymized quote | Next action |
+| YYYY-MM-DD | target-user-a | AI infra / Platform / CI / Automation | Short description | Comprehension / Trial interest / Trial / Quick start / Rejection | Link to interview issue, trial issue, Discussion, notes, or anonymized quote | Next action |
 
 ## Wedge Decision Rules
 

--- a/docs/user-validation.zh.md
+++ b/docs/user-validation.zh.md
@@ -50,6 +50,10 @@ I'm mainly trying to learn whether this solves a real problem, not to sell a
 finished platform.
 ```
 
+公开的访谈反馈可以通过
+[Target user interview issue template](https://github.com/kruntimes/kruntimes/issues/new?template=target_user_interview.yml)
+记录。这个模板只用于公开、非敏感的摘要。不要在公开 issue 中包含真实公司机密、凭证、私有源代码、客户数据或安全漏洞报告。
+
 ## 访谈脚本
 
 第一次对话聚焦当前行为，而不是让用户描述想要的功能。
@@ -92,7 +96,7 @@ credentials、私有源代码或客户数据。
 
 | Date | User Label | Segment | Workload | Signal | Evidence | Follow-up |
 | --- | --- | --- | --- | --- | --- | --- |
-| YYYY-MM-DD | design-partner-a | AI infra / Platform / CI / Automation | Short description | Comprehension / Trial / Quick start / Rejection | Link to issue, Discussion, notes, or anonymized quote | Next action |
+| YYYY-MM-DD | target-user-a | AI infra / Platform / CI / Automation | Short description | Comprehension / Trial interest / Trial / Quick start / Rejection | Link to interview issue, trial issue, Discussion, notes, or anonymized quote | Next action |
 
 ## Wedge 判断规则
 


### PR DESCRIPTION
## Summary
- add a public target user interview issue template for non-sensitive validation evidence
- link interview and trial evidence paths from the validation and community docs
- keep English and Chinese docs aligned

## Validation
- git diff --check
- GOBIN=/tmp/kruntimes-bin make site-build

Docs-only change; Go tests were not run.