### PR TITLE
docs: add copy buttons to code blocks

### DIFF
--- a/site/layouts/_default/baseof.html
+++ b/site/layouts/_default/baseof.html
@@ -21,6 +21,7 @@
     <link rel="apple-touch-icon" href="{{ "img/icon.png" | relURL }}">
     <link rel="stylesheet" href="{{ "css/site.css" | relURL }}">
     <script src="{{ "js/search.js" | relURL }}" defer></script>
+    <script src="{{ "js/copy-code.js" | relURL }}" defer></script>
   </head>
   <body>
     <header class="site-header">

--- a/site/static/css/site.css
+++ b/site/static/css/site.css
@@ -459,11 +459,38 @@ a:hover {
 }
 
 .content pre {
+  position: relative;
   overflow-x: auto;
   padding: 16px;
   border-radius: 6px;
   background: #121722;
   color: #f5f7fb;
+}
+
+.content pre.has-copy-button {
+  padding-top: 44px;
+}
+
+.copy-code-button {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 1;
+  min-width: 64px;
+  height: 28px;
+  padding: 0 10px;
+  border: 1px solid rgba(245, 247, 251, 0.28);
+  border-radius: 6px;
+  background: rgba(245, 247, 251, 0.08);
+  color: #f5f7fb;
+  font: inherit;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.copy-code-button:hover,
+.copy-code-button:focus-visible {
+  background: rgba(245, 247, 251, 0.16);
 }
 
 .content pre code {

--- a/site/static/js/copy-code.js
+++ b/site/static/js/copy-code.js
@@ -1,0 +1,57 @@
+(function () {
+  function copyText(text) {
+    if (navigator.clipboard && window.isSecureContext) {
+      return navigator.clipboard.writeText(text);
+    }
+
+    var textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "absolute";
+    textarea.style.left = "-9999px";
+    document.body.appendChild(textarea);
+    textarea.select();
+
+    try {
+      document.execCommand("copy");
+      return Promise.resolve();
+    } catch (error) {
+      return Promise.reject(error);
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  }
+
+  function labelFor(button, copied) {
+    button.textContent = copied ? button.dataset.copiedLabel : button.dataset.copyLabel;
+    button.setAttribute("aria-label", button.textContent);
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll(".content pre").forEach(function (pre) {
+      var code = pre.querySelector("code");
+      if (!code || pre.querySelector(".copy-code-button")) {
+        return;
+      }
+
+      var button = document.createElement("button");
+      button.type = "button";
+      button.className = "copy-code-button";
+      button.dataset.copyLabel = document.documentElement.lang === "zh-cn" ? "复制" : "Copy";
+      button.dataset.copiedLabel = document.documentElement.lang === "zh-cn" ? "已复制" : "Copied";
+      labelFor(button, false);
+
+      button.addEventListener("click", function () {
+        copyText(code.innerText).then(function () {
+          labelFor(button, true);
+          window.setTimeout(function () {
+            labelFor(button, false);
+          }, 1600);
+        });
+      });
+
+      pre.classList.add("has-copy-button");
+      pre.appendChild(button);
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- add a copy button to documentation code blocks
- localize the button label for English and Chinese pages
- keep the behavior self-contained in the docs site static assets

## Validation
- git diff --check
- node --check site/static/js/copy-code.js
- GOBIN=/tmp/kruntimes-bin make site-build

Docs-only change; Go tests were not run.