### PR TITLE
ci: publish renamed image packages

### DIFF
--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -28,15 +28,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: kruntimes-scheduler
+          - image: scheduler
             dockerfile: Dockerfile.scheduler
-          - image: kruntimes-controller
+          - image: controller
             dockerfile: Dockerfile.controller
-          - image: kruntimes-runtimed
+          - image: runtimed
             dockerfile: Dockerfile.runtimed
-          - image: kruntimes-bash-runtime
+          - image: bash-runtime
             dockerfile: Dockerfile.bash-runtime
-          - image: kruntimes-python-runtime
+          - image: python-runtime
             dockerfile: Dockerfile.python-runtime
 
     steps:


### PR DESCRIPTION
## Summary
- update the Release Images workflow to publish the new GHCR package names without the redundant kruntimes- prefix
- publish images as scheduler, controller, runtimed, bash-runtime, and python-runtime under ghcr.io/kruntimes
- leave Helm chart defaults and user-facing docs unchanged until the new image packages are released and verified

## Follow-up after merge
- create/publish the next release so the new image packages exist
- after that release is verified, open a separate chart/docs PR to switch defaults and examples to the new package names
- only remove the old ghcr.io/kruntimes/kruntimes-* packages after the migration release and docs update are complete

## Validation
- git diff --check upstream/main..HEAD
- GOCACHE=/tmp/go-build make test
- GOCACHE=/tmp/go-build make test-integration