### PR TITLE
cli: add krt version command

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -60,8 +60,12 @@ jobs:
             fi
 
             mkdir -p "${workdir}"
+            ldflags="-s -w"
+            ldflags="${ldflags} -X github.com/kruntimes/kruntimes/internal/version.Version=${RELEASE_TAG#v}"
+            ldflags="${ldflags} -X github.com/kruntimes/kruntimes/internal/version.Commit=${GITHUB_SHA}"
+            ldflags="${ldflags} -X github.com/kruntimes/kruntimes/internal/version.Date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
             CGO_ENABLED=0 GOOS="${goos}" GOARCH="${goarch}" \
-              go build -trimpath -ldflags="-s -w" -o "${workdir}/${binary}" ./cmd/krt
+              go build -trimpath -ldflags="${ldflags}" -o "${workdir}/${binary}" ./cmd/krt
 
             tar -C "${workdir}" -czf "dist/${name}.tar.gz" "${binary}"
             rm -rf "${workdir}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ but each release note must call them out explicitly.
 
 ## Unreleased
 
+### Added
+
+- Added `krt version` to print the CLI version, commit, and build timestamp.
+
 ## 0.0.3 - 2026-07-01
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ build-controller: generate ## Build controller binary.
 
 .PHONY: build-cli
 build-cli: generate ## Build krt binary.
-	go build -o bin/krt ./cmd/krt
+	go build -ldflags="-X github.com/kruntimes/kruntimes/internal/version.Version=dev" -o bin/krt ./cmd/krt
 
 .PHONY: build-bash-runtime
 build-bash-runtime: proto ## Build bash-runtime binary.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -75,6 +75,7 @@ curl -L -o /tmp/krt.tar.gz \
   "https://github.com/kruntimes/kruntimes/releases/download/v${KRUNTIMES_VERSION}/krt_v${KRUNTIMES_VERSION}_${OS}_${ARCH}.tar.gz"
 tar -xzf /tmp/krt.tar.gz -C /tmp
 sudo install /tmp/krt /usr/local/bin/krt
+krt version
 krt --help
 ```
 

--- a/docs/installation.zh.md
+++ b/docs/installation.zh.md
@@ -73,6 +73,7 @@ curl -L -o /tmp/krt.tar.gz \
   "https://github.com/kruntimes/kruntimes/releases/download/v${KRUNTIMES_VERSION}/krt_v${KRUNTIMES_VERSION}_${OS}_${ARCH}.tar.gz"
 tar -xzf /tmp/krt.tar.gz -C /tmp
 sudo install /tmp/krt /usr/local/bin/krt
+krt version
 krt --help
 ```
 

--- a/internal/krt/root.go
+++ b/internal/krt/root.go
@@ -46,6 +46,7 @@ func NewRootCmd() *cobra.Command {
 	root.AddCommand(newArtifactCmd(configFlags, scheme))
 	root.AddCommand(runtimeCmd)
 	root.AddCommand(workflowCmd)
+	root.AddCommand(newVersionCmd())
 
 	return root
 }

--- a/internal/krt/version.go
+++ b/internal/krt/version.go
@@ -1,0 +1,22 @@
+package krt
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kruntimes/kruntimes/internal/version"
+)
+
+func newVersionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the krt version.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "krt %s\ncommit: %s\nbuilt: %s\n", version.Version, version.Commit, version.Date)
+			return err
+		},
+	}
+	return cmd
+}

--- a/internal/krt/version_test.go
+++ b/internal/krt/version_test.go
@@ -1,0 +1,25 @@
+package krt
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestVersionCommand(t *testing.T) {
+	cmd := NewRootCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetArgs([]string{"version"})
+
+	if err := cmd.ExecuteContext(t.Context()); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+
+	got := output.String()
+	for _, want := range []string{"krt dev", "commit: unknown", "built: unknown"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("version output = %q, want to contain %q", got, want)
+		}
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+var (
+	Version = "dev"
+	Commit  = "unknown"
+	Date    = "unknown"
+)


### PR DESCRIPTION
## Summary
- add krt version to print CLI version, commit, and build timestamp
- inject release metadata into krt release binaries
- document krt version as an install verification step

## Validation
- git diff --check
- GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/krt ./cmd/krt -count=1
- GOCACHE=/tmp/go-build make test
- GOCACHE=/tmp/go-build make test-integration
- GOBIN=/tmp/kruntimes-bin make site-build