### PR TITLE
release: prepare v0.0.3 image rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ but each release note must call them out explicitly.
 
 ## Unreleased
 
+## 0.0.3 - 2026-07-01
+
+### Changed
+
+- Renamed published container image packages to remove the redundant
+  `kruntimes-` prefix. New images are published as `scheduler`, `controller`,
+  `runtimed`, `bash-runtime`, and `python-runtime` under
+  `ghcr.io/kruntimes/`.
+- Updated Helm chart defaults to use the published `ghcr.io/kruntimes/*`
+  image repositories directly.
+
 ## 0.0.2 - 2026-06-30
 
 ### Added

--- a/charts/kruntimes-runtimes/Chart.yaml
+++ b/charts/kruntimes-runtimes/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kruntimes-runtimes
 description: Built-in runtimes for kruntimes
 type: application
-version: 0.0.2
-appVersion: "0.0.2"
+version: 0.0.3
+appVersion: "0.0.3"
 keywords:
   - kruntimes
   - runtime

--- a/charts/kruntimes-runtimes/values.yaml
+++ b/charts/kruntimes-runtimes/values.yaml
@@ -5,7 +5,7 @@ workspace:
   sizeLimit: 10Gi
 
 bash:
-  image: kruntimes-bash-runtime
+  image: ghcr.io/kruntimes/bash-runtime
   port: 9091
   replicas: 2
   capacity:
@@ -20,7 +20,7 @@ bash:
       memory: 2Gi
 
 python:
-  image: kruntimes-python-runtime
+  image: ghcr.io/kruntimes/python-runtime
   port: 9092
   replicas: 2
   capacity:

--- a/charts/kruntimes/Chart.yaml
+++ b/charts/kruntimes/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kruntimes
 description: Two-layer scheduling system for CI/CD run warm-up on Kubernetes
 type: application
-version: 0.0.2
-appVersion: "0.0.2"
+version: 0.0.3
+appVersion: "0.0.3"
 keywords:
   - cicd
   - scheduling

--- a/charts/kruntimes/values.yaml
+++ b/charts/kruntimes/values.yaml
@@ -1,7 +1,7 @@
 imagePullSecrets: []
 
 scheduler:
-  image: kruntimes-scheduler
+  image: ghcr.io/kruntimes/scheduler
   imagePullPolicy: IfNotPresent
   replicas: 2
   leaderElect: true
@@ -34,7 +34,7 @@ scheduler:
       memory: 256Mi
 
 controller:
-  image: kruntimes-controller
+  image: ghcr.io/kruntimes/controller
   imagePullPolicy: IfNotPresent
   replicas: 1
   leaderElect: true
@@ -67,7 +67,7 @@ controller:
       memory: 256Mi
 
 runtimed:
-  image: kruntimes-runtimed
+  image: ghcr.io/kruntimes/runtimed
 
 workspace:
   sizeLimit: 10Gi

--- a/hack/verify-helm-images.py
+++ b/hack/verify-helm-images.py
@@ -14,11 +14,11 @@ def main() -> int:
     runtimes_app_version = helm_chart_field("charts/kruntimes-runtimes", "appVersion")
 
     expected_defaults = [
-        f"image: kruntimes-controller:{platform_app_version}",
-        f"image: kruntimes-scheduler:{platform_app_version}",
-        f"--default-daemon-image=kruntimes-runtimed:{platform_app_version}",
-        f"image: kruntimes-bash-runtime:{runtimes_app_version}",
-        f"image: kruntimes-python-runtime:{runtimes_app_version}",
+        f"image: ghcr.io/kruntimes/controller:{platform_app_version}",
+        f"image: ghcr.io/kruntimes/scheduler:{platform_app_version}",
+        f"--default-daemon-image=ghcr.io/kruntimes/runtimed:{platform_app_version}",
+        f"image: ghcr.io/kruntimes/bash-runtime:{runtimes_app_version}",
+        f"image: ghcr.io/kruntimes/python-runtime:{runtimes_app_version}",
     ]
     for expected in expected_defaults:
         if expected not in platform and expected not in runtimes:


### PR DESCRIPTION
## Summary
- bump both Helm charts to 0.0.3 / appVersion 0.0.3
- switch chart defaults to the new ghcr.io/kruntimes/{scheduler,controller,runtimed,bash-runtime,python-runtime} image packages
- record the package rename in CHANGELOG.md
- update the Helm image verifier for the new defaults

## Release order
After this PR merges, create/publish v0.0.3. The release image workflow from #231 will publish the renamed image packages, and this chart release will point to those package names. User-facing docs stay on the old released examples until v0.0.3 is actually available.

## Validation
- git diff --check
- make test-helm
- GOCACHE=/tmp/go-build make test
- GOCACHE=/tmp/go-build make test-integration