### PR TITLE
fix: clarify benchmark latency semantics

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,60 @@
+name: Benchmark
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: benchmark-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: make benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          working-directory: runtimes/python
+          python-version: "3.12"
+          enable-cache: true
+      - uses: azure/setup-helm@v5.0.1
+      - uses: helm/kind-action@v1.14.0
+        with:
+          cluster_name: kruntimes-benchmark
+      - name: Set image tag
+        run: echo "E2E_IMAGE_TAG=benchmark-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_ENV"
+      - name: Set up benchmark environment
+        run: make e2e-setup KIND_CLUSTER_NAME=kruntimes-benchmark
+      - name: Run hot-path benchmark
+        run: make benchmark-run KIND_CLUSTER_NAME=kruntimes-benchmark | tee benchmark-hot.json
+      - name: Publish benchmark summary
+        run: |
+          {
+            echo "## Benchmark result"
+            echo
+            echo "### Hot-path benchmark"
+            echo
+            echo '```json'
+            cat benchmark-hot.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Dump Kubernetes diagnostics
+        if: failure()
+        run: |
+          set +e
+          kubectl get nodes -o wide
+          kubectl get pods,deployments,replicasets,runtimes,runs -A -o wide
+          kubectl describe pods -A
+          kubectl describe runtimes -A
+          kubectl describe runs -A
+          kubectl get events -A --sort-by=.lastTimestamp
+          kubectl logs deploy/kruntimes-controller --all-containers --tail=300 || true
+          kubectl logs -l app=kruntimes-scheduler --all-containers --tail=300 || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ but each release note must call them out explicitly.
 ### Added
 
 - Added `krt version` to print the CLI version, commit, and build timestamp.
+- Added a GitHub Benchmark workflow that runs the default hot-path benchmark in
+  the same kind-based environment as E2E.
+
+### Changed
+
+- Improved benchmark correctness by separating execution latency from
+  end-to-end backlog latency and preventing capacity probe Runs from
+  contaminating measured samples.
+- Changed default benchmark parameters to a no-sleep hot-path case with enough
+  Runtime capacity for all Runs.
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,11 @@ e2e-cleanup: ## Delete the kind cluster.
 	kind delete cluster --name $(KIND_CLUSTER_NAME)
 
 .PHONY: benchmark
-benchmark: e2e-setup ## Run the performance benchmark against the current Kubernetes context.
+benchmark: E2E_IMAGE_TAG := $(E2E_RUN_IMAGE_TAG)
+benchmark: e2e-setup benchmark-run ## Run the default no-sleep hot-path benchmark against a fresh E2E environment.
+
+.PHONY: benchmark-run
+benchmark-run: ## Run the benchmark against the current Kubernetes context. Pass benchmark parameters through KRUNTIMES_BENCHMARK_* env vars.
 	KRUNTIMES_BASH_RUNTIME_IMAGE=$(E2E_IMG_BASH_RUNTIME) \
 	KRUNTIMES_RUNTIMED_IMAGE=$(E2E_IMG_RUNTIMED) \
 	go run ./hack/benchmark

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -4,47 +4,87 @@ kruntimes includes an opt-in benchmark harness for measuring scheduler latency,
 completion throughput, Runtime capacity behavior, and control-plane request
 latency against a real Kubernetes cluster.
 
-The benchmark is not part of default CI because results depend on cluster size,
-node pressure, storage, image locality, and API server configuration. Run it
-with the same environment setup used by E2E tests:
+Benchmark numbers depend on cluster size, node pressure, storage, image
+locality, API server configuration, and the benchmark parameters. Always record
+the command, cluster type, Kubernetes version, kruntimes image tags or digests,
+Runtime replica/capacity settings, and the full JSON output when using numbers
+in release notes or comparisons.
+
+## How to Run Benchmarks
+
+### Environment
+
+The benchmark runs on Kubernetes. You can run it against:
+
+- a local kind cluster created by the project E2E setup, or
+- a GitHub Actions runner through the `Benchmark` workflow.
+
+For local runs, use the same setup path as E2E tests:
 
 ```bash
 make benchmark
 ```
 
-`make benchmark` creates a temporary Bash `Runtime`, submits all benchmark
-`Run` objects up front, waits for all terminal phases, and prints a JSON report.
-The default run uses 2 Runtime Pods, 4 concurrent Run slots per pod, 50 total
-Runs, and 10 concurrent create requests. This intentionally creates more Runs
-than the default Runtime capacity so the benchmark covers backlog drain after
-earlier Runs finish.
+`make benchmark` runs `make e2e-setup` first. That builds fresh local images,
+loads them into the configured kind cluster, upgrades the platform chart, and
+then runs the benchmark with the exact images loaded into kind.
 
-`make benchmark` depends on `make e2e-setup`, so it builds images with the
-fresh E2E tag, loads them into the configured kind cluster, upgrades the
-platform chart, and then passes the exact `E2E_IMG_BASH_RUNTIME` and
-`E2E_IMG_RUNTIMED` tags to the benchmark harness. The benchmark Runtime also
-sets the runtime container image pull policy to `IfNotPresent`, so kind uses the
-loaded images instead of trying to pull them from a registry.
-
-Useful overrides:
+If the environment already exists, run only the harness:
 
 ```bash
-KRUNTIMES_BENCHMARK_RUNS=200 \
-KRUNTIMES_BENCHMARK_CONCURRENCY=25 \
-KRUNTIMES_BENCHMARK_REPLICAS=4 \
-KRUNTIMES_BENCHMARK_CAPACITY=8 \
+make benchmark-run
+```
+
+The GitHub `Benchmark` workflow runs the same `e2e-setup` environment in kind
+and records the default hot-path benchmark in the workflow summary.
+
+### Default Parameters
+
+The default benchmark is the no-sleep hot-path case:
+
+| Parameter | Default |
+| --- | ---: |
+| `KRUNTIMES_BENCHMARK_RUNS` | `50` |
+| `KRUNTIMES_BENCHMARK_CONCURRENCY` | `25` |
+| `KRUNTIMES_BENCHMARK_REPLICAS` | `2` |
+| `KRUNTIMES_BENCHMARK_CAPACITY` | `64` |
+| `KRUNTIMES_BENCHMARK_SLEEP` | `0s` |
+| `KRUNTIMES_BENCHMARK_POLL_INTERVAL` | `50ms` |
+| `KRUNTIMES_BENCHMARK_CAPACITY_PROBE` | `false` |
+
+Total Runtime capacity is intentionally higher than the number of Runs, so the
+default result is not dominated by capacity queueing.
+
+### Parameterized Example
+
+To run a backlog/drain case with workload sleep and constrained capacity, pass
+parameters from the outside:
+
+```bash
+KRUNTIMES_BENCHMARK_RUNS=50 \
+KRUNTIMES_BENCHMARK_CONCURRENCY=10 \
+KRUNTIMES_BENCHMARK_REPLICAS=2 \
+KRUNTIMES_BENCHMARK_CAPACITY=4 \
 KRUNTIMES_BENCHMARK_SLEEP=500ms \
-make benchmark
+KRUNTIMES_BENCHMARK_CAPACITY_PROBE=true \
+make benchmark-run
 ```
 
-The output contains:
+This intentionally creates more Runs than Runtime capacity so the benchmark
+covers backlog drain after earlier Runs finish.
 
-- `latency.schedule`: time from local create request start until the scheduler
-  assigns a Runtime Pod.
-- `latency.dispatch`: time from local create request start until runtimed marks
-  the Run started.
-- `latency.complete`: time from local create request start until terminal Run
-  status.
+### Output Fields
+
+- `latency.schedule`: benchmark-observed time from local create request start
+  until the scheduler assigns a Runtime Pod.
+- `latency.dispatch`: benchmark-observed time from local create request start
+  until runtimed marks the Run started.
+- `latency.execution`: benchmark-observed time from Run start to terminal Run
+  status. This excludes benchmark backlog queueing before runtimed starts the
+  Run, but it is still bounded by the benchmark poll interval.
+- `latency.complete`: benchmark-observed time from local create request start
+  until terminal Run status. This is end-to-end latency and includes time
+  waiting for Runtime capacity when the benchmark is capacity constrained.
 - `throughput.runsPerSecond`: successful terminal Runs divided by benchmark wall
   time.
 - `capacity.maxObservedRunningRuns`: maximum concurrent Running Runs observed
@@ -56,130 +96,62 @@ The output contains:
 - `controlPlane.pods`: scheduler/controller readiness and restart counts in the
   configured control-plane namespace.
 
-For release notes, record the benchmark command, cluster type, Kubernetes
-version, kruntimes image tags or digests, Runtime replica/capacity settings, and
-the full JSON output. Do not compare numbers across different clusters without
-calling out the environment difference.
+## Local Results
 
-## Current Local Result
+### Default Hot-Path Result
 
-This result was captured on 2026-06-27 with `make benchmark` against a local
-kind cluster created by `make e2e-setup`. It uses the default benchmark settings:
-2 Runtime Pods, 4 Run slots per pod, 50 total Runs, 10 concurrent create
-requests, and 500 ms workload sleep.
+Command:
 
-```json
-{
-  "benchmarkID": "bench-1782529296",
-  "startedAt": "2026-06-27T11:01:36.424462547+08:00",
-  "completedAt": "2026-06-27T11:01:46.315089871+08:00",
-  "options": {
-    "namespace": "default",
-    "controlPlaneNamespace": "default",
-    "runtimeName": "benchmark-bash",
-    "runs": 50,
-    "concurrency": 10,
-    "replicas": 2,
-    "capacityPerPod": 4,
-    "sleepSeconds": 0.5,
-    "timeoutSeconds": 300
-  },
-  "latency": {
-    "schedule": {
-      "count": 50,
-      "minMs": 33.222,
-      "p50Ms": 4419.55,
-      "p95Ms": 5830.094,
-      "maxMs": 6226.511
-    },
-    "dispatch": {
-      "count": 50,
-      "minMs": 3034.152,
-      "p50Ms": 4615.892,
-      "p95Ms": 6224.137,
-      "maxMs": 6226.511
-    },
-    "complete": {
-      "count": 50,
-      "minMs": 3436.66,
-      "p50Ms": 5112.102,
-      "p95Ms": 6625.569,
-      "maxMs": 7026.797
-    }
-  },
-  "throughput": {
-    "successfulRuns": 50,
-    "failedRuns": 0,
-    "wallSeconds": 9.890627325,
-    "runsPerSecond": 5.055291070730945
-  },
-  "capacity": {
-    "readyRuntimePods": 2,
-    "configuredTotalRunSlots": 8,
-    "maxObservedRunningRuns": 8,
-    "maxObservedRunningByPod": {
-      "runtime-benchmark-bash-785b988db8-7gp57": 4,
-      "runtime-benchmark-bash-785b988db8-qkxfk": 4
-    },
-    "observedPendingAtCapacity": true,
-    "assignedRunsByPod": {
-      "runtime-benchmark-bash-785b988db8-7gp57": 24,
-      "runtime-benchmark-bash-785b988db8-qkxfk": 26
-    },
-    "runtimePodNames": [
-      "runtime-benchmark-bash-785b988db8-7gp57",
-      "runtime-benchmark-bash-785b988db8-qkxfk"
-    ],
-    "runtimePodRestarts": {
-      "runtime-benchmark-bash-785b988db8-7gp57": 0,
-      "runtime-benchmark-bash-785b988db8-qkxfk": 0
-    }
-  },
-  "controlPlane": {
-    "apiCreate": {
-      "count": 50,
-      "minMs": 2.546,
-      "p50Ms": 4.694,
-      "p95Ms": 9.901,
-      "maxMs": 10.801
-    },
-    "apiList": {
-      "count": 36,
-      "minMs": 3.812,
-      "p50Ms": 5.173,
-      "p95Ms": 6.5,
-      "maxMs": 9.064
-    },
-    "apiGet": {
-      "count": 50,
-      "minMs": 1.182,
-      "p50Ms": 1.442,
-      "p95Ms": 1.886,
-      "maxMs": 2.288
-    },
-    "pods": [
-      {
-        "name": "kruntimes-controller-cb4df56ff-lfq8x",
-        "ready": true,
-        "restarts": 0,
-        "component": "controller"
-      },
-      {
-        "name": "kruntimes-scheduler-7476d58d74-585gj",
-        "ready": true,
-        "restarts": 0,
-        "component": "scheduler"
-      },
-      {
-        "name": "kruntimes-scheduler-7476d58d74-q88bv",
-        "ready": true,
-        "restarts": 0,
-        "component": "scheduler"
-      }
-    ]
-  },
-  "terminalPhase": {
-    "Succeeded": 50
-  }
-}
+```bash
+make benchmark-run
 ```
+
+Parameters: 50 Runs, 2 Runtime Pods, 64 Run slots per Pod, 25 concurrent create
+requests, no workload sleep, 50 ms polling, and capacity probe disabled.
+
+| Metric | p50 | p95 | Notes |
+| --- | ---: | ---: | --- |
+| `latency.schedule` | 207.361 ms | 302.429 ms | local create start to assigned Pod observed by benchmark |
+| `latency.dispatch` | 207.456 ms | 322.593 ms | local create start to Running observed by benchmark |
+| `latency.execution` | 372.785 ms | 449.617 ms | Running to terminal observed by benchmark |
+| `latency.complete` | 580.422 ms | 627.611 ms | local create start to terminal observed by benchmark |
+
+Additional observations:
+
+- successful Runs: 50
+- throughput: 11.30 Runs/s
+- configured Runtime capacity: 128 Run slots
+- max observed Running Runs: 50
+- pending at capacity: false
+
+### Backlog/Drain Result with Parameters
+
+Command:
+
+```bash
+KRUNTIMES_BENCHMARK_RUNS=50 \
+KRUNTIMES_BENCHMARK_CONCURRENCY=10 \
+KRUNTIMES_BENCHMARK_REPLICAS=2 \
+KRUNTIMES_BENCHMARK_CAPACITY=4 \
+KRUNTIMES_BENCHMARK_SLEEP=500ms \
+KRUNTIMES_BENCHMARK_CAPACITY_PROBE=true \
+make benchmark-run
+```
+
+Parameters: 50 Runs, 2 Runtime Pods, 4 Run slots per Pod, 10 concurrent create
+requests, 500 ms workload sleep, and capacity probe enabled.
+
+| Metric | p50 | p95 | Notes |
+| --- | ---: | ---: | --- |
+| `latency.schedule` | 4419.550 ms | 5830.094 ms | includes backlog queueing |
+| `latency.dispatch` | 4615.892 ms | 6224.137 ms | includes backlog queueing |
+| `latency.execution` | N/A | N/A | not collected by the older result |
+| `latency.complete` | 5112.102 ms | 6625.569 ms | end-to-end backlog/drain latency |
+
+Additional observations:
+
+- successful Runs: 50
+- throughput: 5.05 Runs/s
+- configured Runtime capacity: 8 Run slots
+- max observed Running Runs: 8
+- pending at capacity: true

--- a/docs/benchmarks.zh.md
+++ b/docs/benchmarks.zh.md
@@ -2,171 +2,151 @@
 title: "性能基准测试"
 ---
 
-kruntimes 包含一个可选的 benchmark harness，用于在真实 Kubernetes 集群上测量调度延迟、
-完成吞吐量、Runtime 容量行为以及控制平面请求延迟。
+kruntimes 包含一个可选的 benchmark harness，用于在真实 Kubernetes 集群上测量 scheduler
+latency、完成吞吐量、Runtime capacity 行为和 control-plane request latency。
 
-基准测试不属于默认 CI，因为结果取决于集群规模、节点压力、存储、镜像本地性和 API server
-配置。使用与 E2E 测试相同的环境设置运行它：
+benchmark 数字会受到集群规模、节点压力、存储、镜像本地性、API server 配置以及 benchmark
+参数影响。如果要在 release notes 或对比中使用这些数字，请同时记录命令、集群类型、
+Kubernetes 版本、kruntimes image tags 或 digests、Runtime replica/capacity 设置，以及完整
+JSON 输出。
+
+## 如何运行 Benchmark
+
+### 环境
+
+benchmark 运行在 Kubernetes 上。可以使用：
+
+- 项目 E2E setup 创建的本地 kind 集群，或
+- GitHub Actions 中的 `Benchmark` workflow。
+
+本地运行可以使用与 E2E 测试相同的 setup path：
 
 ```bash
 make benchmark
 ```
 
-`make benchmark` 创建一个临时 Bash `Runtime`，一次性提交所有 benchmark `Run` 对象，
-等待所有终止阶段完成，并打印 JSON 报告。默认运行使用 2 个 Runtime Pods、每个 Pod 4 个
-并发 Run 槽位、50 个总 Run 数和 10 个并发创建请求。这有意创建的 Run 数量超过默认
-Runtime 容量，以便基准测试覆盖早期 Runs 完成后的积压消化过程。
+`make benchmark` 会先运行 `make e2e-setup`。它会 build 最新本地镜像、加载到配置的 kind
+集群、升级 platform chart，然后使用加载到 kind 中的精确镜像运行 benchmark。
 
-`make benchmark` 依赖 `make e2e-setup`，因此它会使用最新的 E2E tag 构建镜像，
-将其加载到配置的 kind 集群中，升级 platform chart，然后将精确的 `E2E_IMG_BASH_RUNTIME`
-和 `E2E_IMG_RUNTIMED` tags 传递给 benchmark harness。benchmark Runtime 还将 runtime
-容器镜像拉取策略设置为 `IfNotPresent`，使 kind 使用已加载的镜像而不是尝试从 registry 拉取。
-
-常用覆盖参数：
+如果环境已经存在，只运行 harness：
 
 ```bash
-KRUNTIMES_BENCHMARK_RUNS=200 \
-KRUNTIMES_BENCHMARK_CONCURRENCY=25 \
-KRUNTIMES_BENCHMARK_REPLICAS=4 \
-KRUNTIMES_BENCHMARK_CAPACITY=8 \
+make benchmark-run
+```
+
+GitHub `Benchmark` workflow 会在 kind 中运行同样的 `e2e-setup` 环境，并在 workflow
+summary 中记录默认 hot-path benchmark。
+
+### 默认参数
+
+默认 benchmark 是 no-sleep hot-path case：
+
+| Parameter | Default |
+| --- | ---: |
+| `KRUNTIMES_BENCHMARK_RUNS` | `50` |
+| `KRUNTIMES_BENCHMARK_CONCURRENCY` | `25` |
+| `KRUNTIMES_BENCHMARK_REPLICAS` | `2` |
+| `KRUNTIMES_BENCHMARK_CAPACITY` | `64` |
+| `KRUNTIMES_BENCHMARK_SLEEP` | `0s` |
+| `KRUNTIMES_BENCHMARK_POLL_INTERVAL` | `50ms` |
+| `KRUNTIMES_BENCHMARK_CAPACITY_PROBE` | `false` |
+
+总 Runtime capacity 有意高于 Run 数量，因此默认结果不会主要被 capacity queueing 主导。
+
+### 带参数示例
+
+如果要运行带 workload sleep 且限制 capacity 的 backlog/drain case，可以从外部传入参数：
+
+```bash
+KRUNTIMES_BENCHMARK_RUNS=50 \
+KRUNTIMES_BENCHMARK_CONCURRENCY=10 \
+KRUNTIMES_BENCHMARK_REPLICAS=2 \
+KRUNTIMES_BENCHMARK_CAPACITY=4 \
 KRUNTIMES_BENCHMARK_SLEEP=500ms \
-make benchmark
+KRUNTIMES_BENCHMARK_CAPACITY_PROBE=true \
+make benchmark-run
 ```
 
-输出包含：
+这个 case 会有意创建超过 Runtime capacity 的 Runs，以覆盖早期 Runs 完成后的 backlog
+drain。
 
-- `latency.schedule`：从本地创建请求开始到调度器分配 Runtime Pod 的时间。
-- `latency.dispatch`：从本地创建请求开始到 runtimed 将 Run 标记为已启动的时间。
-- `latency.complete`：从本地创建请求开始到 Run 进入终止状态的时间。
-- `throughput.runsPerSecond`：成功的终止 Runs 除以基准测试墙钟时间。
-- `capacity.maxObservedRunningRuns`：轮询期间观察到的最大并发 Running Runs 数。
-- `capacity.observedPendingAtCapacity`：在所有配置的 Runtime 槽位都被占用时是否观察到待处理 work。
-- `controlPlane.apiCreate`、`controlPlane.apiList` 和 `controlPlane.apiGet`：
-  基准测试期间的客户端 Kubernetes API 请求延迟。
-- `controlPlane.pods`：配置的控制平面 namespace 中 scheduler/controller 的就绪状态和重启计数。
+### 输出字段
 
-对于发布说明，记录 benchmark 命令、集群类型、Kubernetes 版本、kruntimes 镜像 tag 或
-digest、Runtime 副本/容量设置以及完整的 JSON 输出。不要在不同集群之间比较数据而不说明
-环境差异。
+- `latency.schedule`：benchmark observer 从本地 create request start 到 scheduler 分配
+  Runtime Pod 的观测时间。
+- `latency.dispatch`：benchmark observer 从本地 create request start 到 runtimed 将 Run
+  标记为 started 的观测时间。
+- `latency.execution`：benchmark observer 从 Run start 到 Run 进入 terminal status 的观测
+  时间。它不包含 runtimed 启动 Run 前的 benchmark backlog queueing，但仍受 benchmark
+  poll interval 影响。
+- `latency.complete`：benchmark observer 从本地 create request start 到 terminal Run status
+  的观测时间。这是端到端 latency；当 benchmark 受 capacity 限制时，它会包含等待 Runtime
+  capacity 的时间。
+- `throughput.runsPerSecond`：成功 terminal Runs 除以 benchmark wall time。
+- `capacity.maxObservedRunningRuns`：polling 期间观察到的最大并发 Running Runs 数。
+- `capacity.observedPendingAtCapacity`：当所有配置的 Runtime slots 被占用时，是否观察到
+  pending work。
+- `controlPlane.apiCreate`、`controlPlane.apiList` 和 `controlPlane.apiGet`：benchmark
+  期间客户端 Kubernetes API request latency。
+- `controlPlane.pods`：配置的 control-plane namespace 中 scheduler/controller readiness
+  和 restart counts。
 
-## 本地当前结果
+## 本地结果
 
-此结果于 2026-06-27 使用 `make benchmark` 在 `make e2e-setup` 创建的本地 kind 集群上
-捕获。使用默认 benchmark 设置：2 个 Runtime Pods，每个 Pod 4 个 Run 槽位，50 个总
-Run 数，10 个并发创建请求，500 ms workload sleep。
+### 默认 Hot-Path 结果
 
-```json
-{
-  "benchmarkID": "bench-1782529296",
-  "startedAt": "2026-06-27T11:01:36.424462547+08:00",
-  "completedAt": "2026-06-27T11:01:46.315089871+08:00",
-  "options": {
-    "namespace": "default",
-    "controlPlaneNamespace": "default",
-    "runtimeName": "benchmark-bash",
-    "runs": 50,
-    "concurrency": 10,
-    "replicas": 2,
-    "capacityPerPod": 4,
-    "sleepSeconds": 0.5,
-    "timeoutSeconds": 300
-  },
-  "latency": {
-    "schedule": {
-      "count": 50,
-      "minMs": 33.222,
-      "p50Ms": 4419.55,
-      "p95Ms": 5830.094,
-      "maxMs": 6226.511
-    },
-    "dispatch": {
-      "count": 50,
-      "minMs": 3034.152,
-      "p50Ms": 4615.892,
-      "p95Ms": 6224.137,
-      "maxMs": 6226.511
-    },
-    "complete": {
-      "count": 50,
-      "minMs": 3436.66,
-      "p50Ms": 5112.102,
-      "p95Ms": 6625.569,
-      "maxMs": 7026.797
-    }
-  },
-  "throughput": {
-    "successfulRuns": 50,
-    "failedRuns": 0,
-    "wallSeconds": 9.890627325,
-    "runsPerSecond": 5.055291070730945
-  },
-  "capacity": {
-    "readyRuntimePods": 2,
-    "configuredTotalRunSlots": 8,
-    "maxObservedRunningRuns": 8,
-    "maxObservedRunningByPod": {
-      "runtime-benchmark-bash-785b988db8-7gp57": 4,
-      "runtime-benchmark-bash-785b988db8-qkxfk": 4
-    },
-    "observedPendingAtCapacity": true,
-    "assignedRunsByPod": {
-      "runtime-benchmark-bash-785b988db8-7gp57": 24,
-      "runtime-benchmark-bash-785b988db8-qkxfk": 26
-    },
-    "runtimePodNames": [
-      "runtime-benchmark-bash-785b988db8-7gp57",
-      "runtime-benchmark-bash-785b988db8-qkxfk"
-    ],
-    "runtimePodRestarts": {
-      "runtime-benchmark-bash-785b988db8-7gp57": 0,
-      "runtime-benchmark-bash-785b988db8-qkxfk": 0
-    }
-  },
-  "controlPlane": {
-    "apiCreate": {
-      "count": 50,
-      "minMs": 2.546,
-      "p50Ms": 4.694,
-      "p95Ms": 9.901,
-      "maxMs": 10.801
-    },
-    "apiList": {
-      "count": 36,
-      "minMs": 3.812,
-      "p50Ms": 5.173,
-      "p95Ms": 6.5,
-      "maxMs": 9.064
-    },
-    "apiGet": {
-      "count": 50,
-      "minMs": 1.182,
-      "p50Ms": 1.442,
-      "p95Ms": 1.886,
-      "maxMs": 2.288
-    },
-    "pods": [
-      {
-        "name": "kruntimes-controller-cb4df56ff-lfq8x",
-        "ready": true,
-        "restarts": 0,
-        "component": "controller"
-      },
-      {
-        "name": "kruntimes-scheduler-7476d58d74-585gj",
-        "ready": true,
-        "restarts": 0,
-        "component": "scheduler"
-      },
-      {
-        "name": "kruntimes-scheduler-7476d58d74-q88bv",
-        "ready": true,
-        "restarts": 0,
-        "component": "scheduler"
-      }
-    ]
-  },
-  "terminalPhase": {
-    "Succeeded": 50
-  }
-}
+命令：
+
+```bash
+make benchmark-run
 ```
+
+参数：50 个 Runs、2 个 Runtime Pods、每个 Pod 64 个 Run slots、25 个并发创建请求、无
+workload sleep、50 ms polling，并关闭 capacity probe。
+
+| Metric | p50 | p95 | Notes |
+| --- | ---: | ---: | --- |
+| `latency.schedule` | 207.361 ms | 302.429 ms | benchmark 观测的本地创建开始到分配 Pod |
+| `latency.dispatch` | 207.456 ms | 322.593 ms | benchmark 观测的本地创建开始到 Running |
+| `latency.execution` | 372.785 ms | 449.617 ms | benchmark 观测的 Running 到 terminal |
+| `latency.complete` | 580.422 ms | 627.611 ms | benchmark 观测的本地创建开始到 terminal |
+
+其它观察结果：
+
+- successful Runs：50
+- throughput：11.30 Runs/s
+- configured Runtime capacity：128 Run slots
+- max observed Running Runs：50
+- pending at capacity：false
+
+### 带参数的 Backlog/Drain 结果
+
+命令：
+
+```bash
+KRUNTIMES_BENCHMARK_RUNS=50 \
+KRUNTIMES_BENCHMARK_CONCURRENCY=10 \
+KRUNTIMES_BENCHMARK_REPLICAS=2 \
+KRUNTIMES_BENCHMARK_CAPACITY=4 \
+KRUNTIMES_BENCHMARK_SLEEP=500ms \
+KRUNTIMES_BENCHMARK_CAPACITY_PROBE=true \
+make benchmark-run
+```
+
+参数：50 个 Runs、2 个 Runtime Pods、每个 Pod 4 个 Run slots、10 个并发创建请求、500 ms
+workload sleep，并启用 capacity probe。
+
+| Metric | p50 | p95 | Notes |
+| --- | ---: | ---: | --- |
+| `latency.schedule` | 4419.550 ms | 5830.094 ms | 包含 backlog queueing |
+| `latency.dispatch` | 4615.892 ms | 6224.137 ms | 包含 backlog queueing |
+| `latency.execution` | N/A | N/A | 旧结果未采集该字段 |
+| `latency.complete` | 5112.102 ms | 6625.569 ms | 端到端 backlog/drain latency |
+
+其它观察结果：
+
+- successful Runs：50
+- throughput：5.05 Runs/s
+- configured Runtime capacity：8 Run slots
+- max observed Running Runs：8
+- pending at capacity：true

--- a/hack/benchmark/main.go
+++ b/hack/benchmark/main.go
@@ -44,7 +44,9 @@ type options struct {
 	Capacity              int32
 	Sleep                 time.Duration
 	Timeout               time.Duration
+	PollInterval          time.Duration
 	Cleanup               bool
+	CapacityProbe         bool
 }
 
 type report struct {
@@ -69,12 +71,15 @@ type reportOptions struct {
 	CapacityPerPod        int32   `json:"capacityPerPod"`
 	SleepSeconds          float64 `json:"sleepSeconds"`
 	TimeoutSeconds        float64 `json:"timeoutSeconds"`
+	PollIntervalSeconds   float64 `json:"pollIntervalSeconds"`
+	CapacityProbe         bool    `json:"capacityProbe"`
 }
 
 type latencyReport struct {
-	Schedule latencyStats `json:"schedule"`
-	Dispatch latencyStats `json:"dispatch"`
-	Complete latencyStats `json:"complete"`
+	Schedule  latencyStats `json:"schedule"`
+	Dispatch  latencyStats `json:"dispatch"`
+	Execution latencyStats `json:"execution"`
+	Complete  latencyStats `json:"complete"`
 }
 
 type latencyStats struct {
@@ -137,7 +142,7 @@ func main() {
 func parseOptions() options {
 	opts := options{}
 	replicas := envIntOrDefault("KRUNTIMES_BENCHMARK_REPLICAS", 2)
-	capacity := envIntOrDefault("KRUNTIMES_BENCHMARK_CAPACITY", 4)
+	capacity := envIntOrDefault("KRUNTIMES_BENCHMARK_CAPACITY", 64)
 
 	flag.StringVar(&opts.Namespace, "namespace", envOrDefault("NAMESPACE", "default"), "Namespace for benchmark Runtime and Runs.")
 	flag.StringVar(&opts.ControlPlaneNamespace, "control-plane-namespace", envOrDefault("KRUNTIMES_CONTROL_PLANE_NAMESPACE", envOrDefault("NAMESPACE", "default")), "Namespace where scheduler/controller pods run.")
@@ -145,12 +150,14 @@ func parseOptions() options {
 	flag.StringVar(&opts.BashImage, "bash-image", envOrDefault("KRUNTIMES_BASH_RUNTIME_IMAGE", "kruntimes-bash-runtime:latest"), "Bash Runtime image.")
 	flag.StringVar(&opts.RuntimedImage, "runtimed-image", envOrDefault("KRUNTIMES_RUNTIMED_IMAGE", "kruntimes-runtimed:latest"), "Runtimed image injected into the benchmark Runtime.")
 	flag.IntVar(&opts.Runs, "runs", envIntOrDefault("KRUNTIMES_BENCHMARK_RUNS", 50), "Number of Runs to create.")
-	flag.IntVar(&opts.Concurrency, "concurrency", envIntOrDefault("KRUNTIMES_BENCHMARK_CONCURRENCY", 10), "Maximum concurrent Run create requests.")
+	flag.IntVar(&opts.Concurrency, "concurrency", envIntOrDefault("KRUNTIMES_BENCHMARK_CONCURRENCY", 25), "Maximum concurrent Run create requests.")
 	flag.IntVar(&replicas, "replicas", replicas, "Benchmark Runtime replica count.")
 	flag.IntVar(&capacity, "capacity", capacity, "Per-pod runs capacity for the benchmark Runtime.")
-	flag.DurationVar(&opts.Sleep, "sleep", envDurationOrDefault("KRUNTIMES_BENCHMARK_SLEEP", 500*time.Millisecond), "Sleep duration executed by each Run.")
+	flag.DurationVar(&opts.Sleep, "sleep", envDurationOrDefault("KRUNTIMES_BENCHMARK_SLEEP", 0), "Sleep duration executed by each Run.")
 	flag.DurationVar(&opts.Timeout, "timeout", envDurationOrDefault("KRUNTIMES_BENCHMARK_TIMEOUT", 5*time.Minute), "Overall benchmark timeout.")
+	flag.DurationVar(&opts.PollInterval, "poll-interval", envDurationOrDefault("KRUNTIMES_BENCHMARK_POLL_INTERVAL", 50*time.Millisecond), "Interval for polling Run status.")
 	flag.BoolVar(&opts.Cleanup, "cleanup", envBoolOrDefault("KRUNTIMES_BENCHMARK_CLEANUP", true), "Delete benchmark Runs and Runtime after completion.")
+	flag.BoolVar(&opts.CapacityProbe, "capacity-probe", envBoolOrDefault("KRUNTIMES_BENCHMARK_CAPACITY_PROBE", false), "Run a pre-benchmark capacity saturation probe.")
 	flag.Parse()
 
 	opts.Replicas = int32(replicas)
@@ -171,6 +178,9 @@ func validateOptions(opts options) {
 	}
 	if opts.Capacity <= 0 {
 		fail("capacity must be > 0")
+	}
+	if opts.PollInterval <= 0 {
+		fail("poll-interval must be > 0")
 	}
 }
 
@@ -216,9 +226,13 @@ func run(parent context.Context, opts options) error {
 		}()
 	}
 
-	capProbe, err := observeCapacitySaturation(ctx, k8sClient, opts, benchID, runtimePods)
-	if err != nil {
-		return err
+	capProbe := capacityReport{}
+	if opts.CapacityProbe {
+		var err error
+		capProbe, err = observeCapacitySaturation(ctx, k8sClient, opts, benchID, runtimePods)
+		if err != nil {
+			return err
+		}
 	}
 	observations, createLatencies, listLatencies, getLatencies, capReport, err := executeRuns(ctx, k8sClient, opts, benchID, runtimePods)
 	if err != nil {
@@ -436,7 +450,7 @@ func observeCapacitySaturation(ctx context.Context, k8sClient client.Client, opt
 	}
 	defer deleteRuns(context.Background(), k8sClient, opts.Namespace, names)
 
-	err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, opts.PollInterval, 30*time.Second, true, func(ctx context.Context) (bool, error) {
 		list := &v1alpha1.RunList{}
 		if err := k8sClient.List(ctx, list, client.InNamespace(opts.Namespace), client.MatchingLabels{benchmarkIDLabel: benchID + "-capacity"}); err != nil {
 			return false, fmt.Errorf("list capacity probe Runs: %w", err)
@@ -471,11 +485,34 @@ func observeCapacitySaturation(ctx context.Context, k8sClient client.Client, opt
 	if err != nil {
 		return out, nil
 	}
+	if err := waitForProbeTerminal(ctx, k8sClient, opts, benchID+"-capacity", len(names)); err != nil {
+		return out, err
+	}
 	return out, nil
 }
 
+func waitForProbeTerminal(ctx context.Context, k8sClient client.Client, opts options, benchID string, want int) error {
+	err := wait.PollUntilContextTimeout(ctx, opts.PollInterval, 30*time.Second, true, func(ctx context.Context) (bool, error) {
+		list := &v1alpha1.RunList{}
+		if err := k8sClient.List(ctx, list, client.InNamespace(opts.Namespace), client.MatchingLabels{benchmarkIDLabel: benchID}); err != nil {
+			return false, fmt.Errorf("list capacity probe Runs: %w", err)
+		}
+		terminal := 0
+		for i := range list.Items {
+			if isTerminal(list.Items[i].Status.Phase) {
+				terminal++
+			}
+		}
+		return terminal >= want, nil
+	})
+	if err != nil {
+		return fmt.Errorf("wait for capacity probe Runs to finish: %w", err)
+	}
+	return nil
+}
+
 func waitForAllTerminal(ctx context.Context, k8sClient client.Client, opts options, benchID string, observations map[string]*runObservation, listLatencies *[]time.Duration, capReport *capacityReport, assignedSeen map[string]struct{}) error {
-	err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, opts.Timeout, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, opts.PollInterval, opts.Timeout, true, func(ctx context.Context) (bool, error) {
 		list := &v1alpha1.RunList{}
 		start := time.Now()
 		if err := k8sClient.List(ctx, list, client.InNamespace(opts.Namespace), client.MatchingLabels{benchmarkIDLabel: benchID}); err != nil {
@@ -557,6 +594,7 @@ func benchmarkRun(opts options, benchID string, index int, sleep time.Duration) 
 func buildReport(opts options, benchID string, startedAt, completedAt time.Time, observations map[string]*runObservation, createLatencies, listLatencies, getLatencies []time.Duration, capReport capacityReport, controlPlanePods []componentPodInfo) report {
 	schedule := []time.Duration{}
 	dispatch := []time.Duration{}
+	execution := []time.Duration{}
 	complete := []time.Duration{}
 	phases := map[string]int{}
 	successful := 0
@@ -578,6 +616,9 @@ func buildReport(opts options, benchID string, startedAt, completedAt time.Time,
 		}
 		if !obs.StartedAt.IsZero() {
 			dispatch = append(dispatch, obs.StartedAt.Sub(obs.CreatedAt))
+		}
+		if !obs.StartedAt.IsZero() && !obs.FinishedAt.IsZero() && !obs.FinishedAt.Before(obs.StartedAt) {
+			execution = append(execution, obs.FinishedAt.Sub(obs.StartedAt))
 		}
 		if !obs.FinishedAt.IsZero() {
 			complete = append(complete, obs.FinishedAt.Sub(obs.CreatedAt))
@@ -603,11 +644,14 @@ func buildReport(opts options, benchID string, startedAt, completedAt time.Time,
 			CapacityPerPod:        opts.Capacity,
 			SleepSeconds:          opts.Sleep.Seconds(),
 			TimeoutSeconds:        opts.Timeout.Seconds(),
+			PollIntervalSeconds:   opts.PollInterval.Seconds(),
+			CapacityProbe:         opts.CapacityProbe,
 		},
 		Latency: latencyReport{
-			Schedule: summarize(schedule),
-			Dispatch: summarize(dispatch),
-			Complete: summarize(complete),
+			Schedule:  summarize(schedule),
+			Dispatch:  summarize(dispatch),
+			Execution: summarize(execution),
+			Complete:  summarize(complete),
 		},
 		Throughput: throughputReport{
 			SuccessfulRuns: successful,

--- a/hack/benchmark/main_test.go
+++ b/hack/benchmark/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"testing"
 	"time"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
 )
 
 func TestSummarize(t *testing.T) {
@@ -36,5 +38,40 @@ func TestPercentileInterpolates(t *testing.T) {
 	want := 29 * time.Millisecond
 	if got != want {
 		t.Fatalf("percentile = %v, want %v", got, want)
+	}
+}
+
+func TestBuildReportSeparatesExecutionFromEndToEndLatency(t *testing.T) {
+	createdAt := time.Unix(100, 0)
+	startedAt := createdAt.Add(2 * time.Second)
+	finishedAt := startedAt.Add(500 * time.Millisecond)
+	observations := map[string]*runObservation{
+		"run-1": {
+			CreatedAt:   createdAt,
+			ScheduledAt: createdAt.Add(time.Second),
+			StartedAt:   startedAt,
+			FinishedAt:  finishedAt,
+			Phase:       v1alpha1.RunSucceeded,
+		},
+	}
+
+	report := buildReport(
+		options{Runs: 1, RuntimeName: "benchmark-bash"},
+		"bench-test",
+		createdAt,
+		finishedAt,
+		observations,
+		nil,
+		nil,
+		nil,
+		capacityReport{},
+		nil,
+	)
+
+	if report.Latency.Execution.Count != 1 || report.Latency.Execution.P50MS != 500 {
+		t.Fatalf("execution latency = %#v, want one 500ms sample", report.Latency.Execution)
+	}
+	if report.Latency.Complete.Count != 1 || report.Latency.Complete.P50MS != 2500 {
+		t.Fatalf("complete latency = %#v, want one 2500ms sample", report.Latency.Complete)
 	}
 }


### PR DESCRIPTION
## Summary
- make the no-sleep, capacity-sufficient hot-path benchmark the default `make benchmark` / `make benchmark-run` case
- keep only one Make target for running benchmarks: `benchmark-run`; pass variants through `KRUNTIMES_BENCHMARK_*` environment variables
- remove the backlog benchmark job from the GitHub Benchmark workflow; the workflow now records the default hot-path case only
- wait for capacity probe Runs to finish before collecting measured samples when capacity probing is explicitly enabled
- add `latency.execution` for Run start-to-terminal observer timing
- document benchmark latency semantics, how to run benchmarks locally or through GitHub Actions, and local results for both default and parameterized cases

## Local hot-path result
Command:

```bash
E2E_IMAGE_TAG=e2e-20260701223453 make benchmark-run
```

Equivalent to the new default benchmark case. Environment: local kind cluster created by `make e2e-setup`, 50 Runs, 2 Runtime Pods, 64 Run slots per Pod, 25 concurrent create requests, `sleep=0s`, `pollInterval=50ms`, capacity probe disabled.

Key results:
- `latency.schedule`: p50 207.361 ms, p95 302.429 ms
- `latency.dispatch`: p50 207.456 ms, p95 322.593 ms
- `latency.execution`: p50 372.785 ms, p95 449.617 ms
- `latency.complete`: p50 580.422 ms, p95 627.611 ms
- throughput: 11.30 Runs/s
- max observed Running Runs: 50 / 128 configured slots
- pending at capacity: false

## Validation
- `make -n benchmark-run`
- `GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./hack/benchmark -count=1`
- `GOBIN=/tmp/kruntimes-bin make site-build`
- `GOCACHE=/tmp/go-build make test`
- `GOCACHE=/tmp/go-build make test-integration`
- `E2E_IMAGE_TAG=e2e-20260701223453 make benchmark-run`

Note: GitHub cannot manually dispatch a newly added workflow until the workflow file exists on the default branch. The Benchmark workflow can be triggered after this PR is merged.
