### PR TITLE
docs: add dashboard design

### DIFF
--- a/docs/design/_index.md
+++ b/docs/design/_index.md
@@ -10,3 +10,4 @@ implemented.
 - [Function Mode and Agent Sandboxes](function-mode/)
 - [Workflow Data Sharing](workflow-data-sharing/)
 - [Workflow Reuse](workflow-reuse/)
+- [Dashboard](dashboard/)

--- a/docs/design/_index.zh.md
+++ b/docs/design/_index.zh.md
@@ -8,3 +8,4 @@
 - [Function Mode 和 Agent Sandboxes](function-mode/)
 - [Workflow Data Sharing](workflow-data-sharing/)
 - [Workflow Reuse](workflow-reuse/)
+- [Dashboard](dashboard/)

--- a/docs/design/dashboard.md
+++ b/docs/design/dashboard.md
@@ -1,0 +1,183 @@
+# Dashboard
+
+This document describes a target v0.x design. It is not implemented yet.
+
+kruntimes should provide a small read-only dashboard for developers and
+operators who need to understand what is running, what is stuck, and where to
+find logs and artifacts without switching between multiple `kubectl` and `krt`
+commands.
+
+The dashboard is not intended to become the workflow engine or the primary
+control plane. It should visualize Kubernetes-native state that already exists
+in CRDs, pods, conditions, logs, and artifact references.
+
+## Goals
+
+- Browse Runs by namespace.
+- Inspect Run phase, conditions, runtime, assigned Runtime Pod, attempts,
+  timestamps, bounded outputs, and artifact references.
+- Stream or retrieve Run logs through the same security boundary used by
+  `krt logs`.
+- Preserve Kubernetes RBAC and namespace boundaries.
+- Provide an operator-friendly view for Pending, Scheduled, Running, Succeeded,
+  Failed, Cancelled, and TimedOut Runs.
+- Leave room for future WorkflowRun, Workflow, Action, and PersistentWorkspace
+  views after those APIs stabilize.
+
+## Non-Goals
+
+- No create, cancel, delete, retry, or edit operations in the first version.
+- No workflow editor or visual DAG builder in the first version.
+- No browser access directly to Runtime Pods, Runtime Servers, or runtimed
+  endpoints.
+- No custom identity system that bypasses Kubernetes authentication and
+  authorization.
+- No replacement for Prometheus, log collection, or long-term audit storage.
+- No stable public dashboard HTTP API in v0.x.
+
+## Users
+
+Developers use the dashboard to answer:
+
+- did my Run start;
+- which Runtime handled it;
+- why is it Pending or Failed;
+- what did the logs and bounded outputs say;
+- where are artifacts stored.
+
+Operators use the dashboard to answer:
+
+- which namespaces have stuck or failing Runs;
+- whether capacity, readiness, RBAC, or image/runtime problems are visible in
+  Run conditions;
+- which Runtime Pods are receiving work;
+- whether users are asking for logs or artifact access that require additional
+  RBAC.
+
+## Architecture
+
+The dashboard should have two components:
+
+| Component | Role |
+| --- | --- |
+| Dashboard backend | Talks to the Kubernetes API, enforces the selected auth/RBAC model, reads kruntimes CRDs, and proxies log/artifact access when allowed. |
+| Dashboard frontend | Read-only web UI that renders namespace, Run list, Run detail, logs, and artifact metadata. |
+
+The first version should read the following sources:
+
+- `Run` objects through the Kubernetes API;
+- Runtime Pod metadata referenced by `Run.status.assignedPod`;
+- Kubernetes Events related to Runs and Runtime Pods when available;
+- runtimed log/status endpoints through a backend-controlled path;
+- `Run.status.outputs` and `Run.status.artifactRefs`.
+
+Future versions can add:
+
+- `WorkflowRun`, `Workflow`, and `Action` list/detail pages;
+- PersistentWorkspace detail pages;
+- runtime pool capacity and health views;
+- metrics panels backed by Prometheus or another metrics backend.
+
+## Log Access
+
+The dashboard backend must not expose Runtime Pods directly to browsers.
+
+For v0.x, the expected path is:
+
+1. The user opens logs for a Run.
+2. The backend reads the Run and its assigned Runtime Pod.
+3. The backend verifies the request using the configured Kubernetes auth/RBAC
+   model.
+4. The backend reaches runtimed using the same conceptual boundary as `krt logs`
+   and streams or returns the requested log tail.
+
+The exact transport can evolve. It may use Kubernetes port-forwarding, an
+internal service, or a dedicated log proxy, but the boundary should stay the
+same: users need permission to read the Run and to access runtime logs.
+
+Structured runtimed logs should remain keyed by Run UID so the dashboard can
+show the correct logs even when Runtime Pods handle multiple Runs.
+
+## Security Model
+
+The dashboard must be read-only by default.
+
+The preferred production model is Kubernetes-native:
+
+- authentication comes from Kubernetes or the cluster's identity integration;
+- authorization uses Kubernetes RBAC;
+- namespace visibility follows the user's permissions;
+- log and artifact access require explicit permission, not just dashboard
+  access;
+- secrets, service account tokens, environment variables, and raw pod specs are
+  hidden unless a future privileged operator view explicitly exposes them.
+
+For local development, a kubeconfig-backed mode is acceptable, but it should be
+documented as a development mode rather than the production default.
+
+## Internal API Shape
+
+The dashboard frontend can use an internal, versioned-for-the-binary HTTP API.
+It should not be documented as a stable public API in v0.x.
+
+Initial endpoints can be:
+
+```text
+GET /api/namespaces
+GET /api/namespaces/{namespace}/runs
+GET /api/namespaces/{namespace}/runs/{name}
+GET /api/namespaces/{namespace}/runs/{name}/logs?tail=&follow=
+```
+
+The Run list endpoint should support server-side pagination and filter fields
+where practical:
+
+- phase;
+- runtime;
+- assigned pod;
+- label selector;
+- created-after or age window.
+
+## User Interface
+
+The first version should keep the UI narrow and operational:
+
+- namespace selector;
+- Run table with phase, runtime, assigned pod, age, attempts, and last
+  transition reason;
+- filters for phase and runtime;
+- Run detail page or drawer;
+- conditions timeline;
+- bounded outputs and artifact references;
+- logs panel with tail and follow controls;
+- links to related Runtime Pod metadata when the user has permission.
+
+It should not include mutation buttons until the read-only authorization model
+is proven.
+
+## Implementation Sequence
+
+1. Add this design document and keep the roadmap explicit.
+2. Add a dashboard backend package with read-only Kubernetes client wiring.
+3. Define the production and local-development auth modes.
+4. Implement Run list/detail APIs with unit tests.
+5. Implement log tail/follow through a backend-controlled path.
+6. Add the frontend Run list/detail/log views.
+7. Add an optional Helm chart value or separate dashboard chart.
+8. Add E2E smoke coverage that installs the dashboard, creates a Run, lists it,
+   opens detail, and fetches logs.
+9. Add WorkflowRun/Workflow/Action/PersistentWorkspace views after the
+   corresponding APIs stabilize.
+
+## Open Questions
+
+- Should the dashboard ship in the main kruntimes chart, a separate chart, or
+  both?
+- Which production auth mode should be first: service account with
+  impersonation, Kubernetes API proxy integration, or external auth in front of
+  the dashboard?
+- Should log access continue to use port-forward semantics or move to a
+  dedicated cluster-internal log proxy service?
+- How should artifact downloads be authorized and proxied when artifact stores
+  are outside the cluster?
+- What scale target should the first list/watch implementation support?

--- a/docs/design/dashboard.zh.md
+++ b/docs/design/dashboard.zh.md
@@ -1,0 +1,163 @@
+# Dashboard
+
+本文描述 v0.x 的目标设计，当前尚未实现。
+
+kruntimes 应该提供一个小型只读 dashboard，帮助开发者和运维人员理解当前有哪些任务在运行、
+哪些任务卡住了，以及如何找到 logs 和 artifacts，而不需要在多个 `kubectl` 和 `krt`
+命令之间来回切换。
+
+dashboard 不应该成为 workflow engine，也不应该成为新的主控制面。它应该展示已经存在于
+CRD、Pod、conditions、logs 和 artifact references 中的 Kubernetes-native 状态。
+
+## 目标
+
+- 按 namespace 浏览 Runs。
+- 查看 Run phase、conditions、runtime、assigned Runtime Pod、attempts、时间戳、
+  有界 outputs 和 artifact references。
+- 通过与 `krt logs` 相同的安全边界 stream 或 retrieve Run logs。
+- 保持 Kubernetes RBAC 和 namespace 边界。
+- 为 Pending、Scheduled、Running、Succeeded、Failed、Cancelled 和 TimedOut Runs
+  提供面向运维的视图。
+- 为后续 WorkflowRun、Workflow、Action 和 PersistentWorkspace 视图预留空间。
+
+## 非目标
+
+- 第一版不提供 create、cancel、delete、retry 或 edit 操作。
+- 第一版不提供 workflow editor 或 visual DAG builder。
+- 不允许浏览器直接访问 Runtime Pods、Runtime Servers 或 runtimed endpoints。
+- 不引入绕过 Kubernetes authentication 和 authorization 的自定义身份系统。
+- 不替代 Prometheus、log collection 或长期 audit storage。
+- v0.x 不承诺稳定的公开 dashboard HTTP API。
+
+## 用户
+
+开发者通过 dashboard 回答：
+
+- 我的 Run 是否启动了；
+- 哪个 Runtime 处理了它；
+- 为什么它 Pending 或 Failed；
+- logs 和 bounded outputs 是什么；
+- artifacts 存储在哪里。
+
+运维人员通过 dashboard 回答：
+
+- 哪些 namespace 里有卡住或失败的 Runs；
+- capacity、readiness、RBAC 或 image/runtime 问题是否体现在 Run conditions 中；
+- 哪些 Runtime Pods 正在接收任务；
+- 用户是否需要额外 RBAC 才能读取 logs 或 artifacts。
+
+## 架构
+
+dashboard 应该包含两个组件：
+
+| 组件 | 作用 |
+| --- | --- |
+| Dashboard backend | 访问 Kubernetes API，执行所选 auth/RBAC 模型，读取 kruntimes CRDs，并在允许时代理 logs/artifacts 访问。 |
+| Dashboard frontend | 只读 Web UI，展示 namespace、Run list、Run detail、logs 和 artifact metadata。 |
+
+第一版应读取以下数据源：
+
+- 通过 Kubernetes API 读取 `Run` objects；
+- 读取 `Run.status.assignedPod` 引用的 Runtime Pod metadata；
+- 在可用时读取与 Runs 和 Runtime Pods 相关的 Kubernetes Events；
+- 通过 backend-controlled 路径访问 runtimed log/status endpoints；
+- 读取 `Run.status.outputs` 和 `Run.status.artifactRefs`。
+
+后续版本可以增加：
+
+- `WorkflowRun`、`Workflow` 和 `Action` list/detail pages；
+- PersistentWorkspace detail pages；
+- runtime pool capacity 和 health views；
+- 基于 Prometheus 或其他 metrics backend 的 metrics panels。
+
+## 日志访问
+
+Dashboard backend 不能把 Runtime Pods 直接暴露给浏览器。
+
+v0.x 预期路径是：
+
+1. 用户打开某个 Run 的 logs。
+2. Backend 读取该 Run 以及它 assigned 的 Runtime Pod。
+3. Backend 使用配置好的 Kubernetes auth/RBAC 模型校验请求。
+4. Backend 通过与 `krt logs` 概念上相同的边界访问 runtimed，并 stream 或返回请求的
+   log tail。
+
+具体 transport 可以演进。它可以使用 Kubernetes port-forwarding、internal service 或
+专用 log proxy，但边界应该保持不变：用户需要有读取 Run 以及访问 runtime logs 的权限。
+
+结构化 runtimed logs 应继续以 Run UID 作为 key，这样即使 Runtime Pods 同时处理多个 Runs，
+dashboard 也能展示正确的 logs。
+
+## 安全模型
+
+dashboard 默认必须是只读的。
+
+推荐的生产模型是 Kubernetes-native：
+
+- authentication 来自 Kubernetes 或集群身份集成；
+- authorization 使用 Kubernetes RBAC；
+- namespace 可见性遵循用户权限；
+- logs 和 artifacts 访问需要显式权限，而不仅仅是 dashboard 访问权限；
+- 默认隐藏 secrets、service account tokens、environment variables 和 raw pod specs，
+  除非未来明确增加 privileged operator view。
+
+本地开发可以支持 kubeconfig-backed 模式，但它应该被记录为开发模式，而不是生产默认模式。
+
+## 内部 API 形状
+
+dashboard frontend 可以使用随二进制版本演进的内部 HTTP API。v0.x 不应把它文档化为稳定的
+公开 API。
+
+初始 endpoints 可以是：
+
+```text
+GET /api/namespaces
+GET /api/namespaces/{namespace}/runs
+GET /api/namespaces/{namespace}/runs/{name}
+GET /api/namespaces/{namespace}/runs/{name}/logs?tail=&follow=
+```
+
+Run list endpoint 应尽量支持 server-side pagination 和过滤：
+
+- phase；
+- runtime；
+- assigned pod；
+- label selector；
+- created-after 或 age window。
+
+## 用户界面
+
+第一版 UI 应保持聚焦、面向运维：
+
+- namespace selector；
+- Run table，包含 phase、runtime、assigned pod、age、attempts 和 last transition reason；
+- phase 和 runtime filters；
+- Run detail page 或 drawer；
+- conditions timeline；
+- bounded outputs 和 artifact references；
+- logs panel，包含 tail 和 follow controls；
+- 当用户有权限时，链接到相关 Runtime Pod metadata。
+
+在只读授权模型被验证之前，不应加入 mutation buttons。
+
+## 实现顺序
+
+1. 增加本文档，并在 roadmap 中保持 TODO 明确。
+2. 增加 dashboard backend package，接入只读 Kubernetes client。
+3. 定义生产和本地开发 auth modes。
+4. 实现 Run list/detail APIs，并增加 unit tests。
+5. 通过 backend-controlled 路径实现 log tail/follow。
+6. 增加 frontend Run list/detail/log views。
+7. 增加可选 Helm chart value 或独立 dashboard chart。
+8. 增加 E2E smoke coverage：安装 dashboard、创建 Run、列出 Run、打开 detail、读取 logs。
+9. 在相关 APIs 稳定后增加 WorkflowRun/Workflow/Action/PersistentWorkspace views。
+
+## 待确认问题
+
+- dashboard 应该放在主 kruntimes chart、独立 chart，还是两者都支持？
+- 第一版生产 auth mode 应该是什么：service account with impersonation、Kubernetes API
+  proxy integration，还是 dashboard 前置 external auth？
+- log access 是否继续使用 port-forward 语义，还是迁移到专用的 cluster-internal log proxy
+  service？
+- 当 artifact stores 位于集群外部时，artifact downloads 应如何授权和代理？
+- 第一版 list/watch 实现应该支持怎样的规模目标？

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -207,6 +207,15 @@ wiring from accumulating avoidable conflicts.
 - [ ] Dashboard: design and build a read-only web dashboard, similar in spirit
   to Tekton Dashboard, that can browse Runs by namespace and inspect status and
   logs.
+  Initial implementation TODO:
+  - [x] add a read-only [Dashboard design document](design/dashboard/) covering
+    scope, architecture, RBAC, log access, and implementation sequence;
+  - add a dashboard backend with read-only Kubernetes API access;
+  - implement Run list/detail APIs with namespace-aware RBAC;
+  - proxy Run log tail/follow through a backend-controlled path;
+  - add read-only frontend views for namespace selection, Run lists, Run
+    details, conditions, outputs, artifact references, and logs;
+  - add optional Helm installation support and E2E smoke coverage.
 - [ ] Continue supply-chain, security, compatibility, and operational
   hardening as the installation surface stabilizes.
 

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -176,6 +176,15 @@ controller wiring 累积不必要的冲突。
     validation failures 和 output propagation。
 - [ ] Dashboard：设计并实现只读 web dashboard，类似 Tekton Dashboard，可以按
   namespace 查看 Runs，并检查状态和日志。
+  初始实现 TODO：
+  - [x] 增加只读 [Dashboard 设计文档](design/dashboard/)，覆盖 scope、architecture、
+    RBAC、log access 和 implementation sequence；
+  - 增加 dashboard backend，提供只读 Kubernetes API access；
+  - 实现 Run list/detail APIs，并遵守 namespace-aware RBAC；
+  - 通过 backend-controlled 路径代理 Run log tail/follow；
+  - 增加只读 frontend views，覆盖 namespace selection、Run lists、Run details、
+    conditions、outputs、artifact references 和 logs；
+  - 增加可选 Helm installation support 和 E2E smoke coverage。
 - [ ] 随着安装面逐步稳定，继续推进供应链、安全、兼容性和运维加固。
 
 ### 迈向 v1.0


### PR DESCRIPTION
## Summary
- add English and Chinese design docs for the v0.x read-only dashboard
- clarify dashboard scope, non-goals, architecture, log access, RBAC/security, internal API shape, UI scope, and implementation sequence
- link the design doc from the design index and roadmap

## Validation
- GOBIN=/tmp/kruntimes-bin make site-build
- git diff --check

Docs-only change; Go tests not run.