### PR TITLE
docs: refine workflow execution design

### DIFF
--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -224,6 +224,33 @@ For v0.x, validation should prefer a narrow model:
 - missing required inputs fail validation or reconcile early;
 - unknown input names fail validation or reconcile early.
 
+The WorkflowRun controller should bind inputs before expanding child jobs or
+steps:
+
+1. Start from the callee's declared `inputs`.
+2. Apply each input `default`.
+3. Overlay caller-provided `with` values.
+4. Reject missing required inputs.
+5. Reject unknown `with` keys.
+6. Store a resolved execution snapshot in `WorkflowRun.status` or an internal
+   child object annotation before creating Runs.
+
+Do not let an already-started WorkflowRun observe mutable changes to a
+referenced `Workflow` or `Action`. Reusable definitions may change over time,
+but each WorkflowRun execution must be deterministic once accepted. Later work
+can add explicit revisioning; the first version should capture enough resolved
+data to make retries and controller restarts stable.
+
+Step outputs come from child Run results. A step writes small key-value outputs
+to `KRUNTIME_OUTPUTS`; runtimed persists them to the child Run status. The
+WorkflowRun controller reads those child Run outputs and promotes them into
+`WorkflowRun.status.jobs.<job>.steps.<step>.outputs`.
+
+Job outputs are evaluated after all steps in the job succeed. Workflow outputs
+are evaluated after all jobs in the reusable Workflow succeed. Output
+evaluation must fail the WorkflowRun when an expression references a missing
+job, step, or output key.
+
 ## Reference Resolution
 
 The first version should keep references namespace-local:
@@ -238,6 +265,78 @@ URLs, Git refs, or OCI refs until there is a concrete need.
 
 This keeps the API small and avoids creating a reference format that must be
 supported long-term before the execution model is stable.
+
+Reference resolution should happen in this order:
+
+1. Resolve a top-level `WorkflowRun.spec.uses` to a `Workflow` in the same
+   namespace.
+2. Expand the referenced Workflow jobs into the WorkflowRun execution graph.
+3. Resolve each job-level `uses` to a same-namespace reusable `Workflow`.
+4. Expand reusable Workflow calls as nested job groups with their own
+   job/workspace/artifact boundary.
+5. Resolve each step-level `uses` to a same-namespace `Action`.
+6. Expand Action steps inline inside the caller job context.
+7. Detect cycles before creating any child Runs.
+
+Cycles must be rejected across Workflow calls. An Action must not call another
+Action in the first version because nested Action expansion is not needed yet
+and makes cycle detection harder. A reusable Workflow may call another
+Workflow only when the controller can prove the call graph is acyclic.
+
+Resolution failures should set the WorkflowRun to `Failed` before creating any
+child Runs. Examples include missing references, wrong namespace assumptions,
+unsupported nested Action calls, input binding failures, and cycles.
+
+## Execution Graph
+
+The WorkflowRun controller owns graph expansion and execution state. It should
+not rely on scheduler or runtimed to understand Workflow concepts.
+
+The first implementation should use a simple deterministic graph model:
+
+- every job has a stable execution path, such as `jobs.build` or
+  `jobs.release.jobs.build` for a job expanded from a reusable Workflow call;
+- every step has a stable execution path, such as `jobs.build.steps.package`;
+- each child Run is labeled with the WorkflowRun name, job path, and step path;
+- child Run names are generated deterministically enough for idempotent
+  reconciliation, or are discovered through labels before creating new Runs;
+- the controller creates Runs only when all dependency jobs have succeeded;
+- failed, cancelled, or timed-out child Runs fail the owning WorkflowRun unless
+  a future retry/continue-on-error API explicitly changes that behavior.
+
+The first version should support one execution strategy:
+
+1. Accept the WorkflowRun and set `status.phase=Pending`.
+2. Resolve references and bind inputs.
+3. Persist the resolved graph snapshot.
+4. Start ready jobs by creating the first step Run for each job.
+5. When a step Run succeeds, collect outputs and create the next step Run.
+6. When all steps in a job succeed, evaluate job outputs and mark the job
+   succeeded.
+7. When all jobs succeed, evaluate WorkflowRun outputs and mark the WorkflowRun
+   succeeded.
+
+This deliberately avoids adding a separate WorkflowRunInvocation API. Child
+Runs remain the durable execution records, and scheduler/runtimed continue to
+operate only on Runs.
+
+## Expression Context
+
+For v0.x, expressions should stay intentionally small. They should support only
+string interpolation from known contexts:
+
+| Context | Available from |
+| --- | --- |
+| `inputs.<name>` | resolved inputs for the current Workflow, Action, or WorkflowRun |
+| `steps.<step>.outputs.<name>` | previous steps in the same job |
+| `jobs.<job>.outputs.<name>` | completed dependency jobs in the same graph boundary |
+
+Expressions should not access Kubernetes objects, environment variables,
+secrets, files, arbitrary functions, or network resources. Secret handling
+needs a separate design before it is exposed to Workflow expressions.
+
+Evaluation must be deterministic and side-effect free. Unsupported syntax or
+missing values should fail the WorkflowRun with a clear condition and message.
 
 ## Status Model
 
@@ -290,13 +389,18 @@ the implementation lands.
 4. Add `Action` API types, CRD validation, status, and controller skeleton.
    Namespace-local resolution, input binding, output propagation, and
    WorkflowRun execution are separate follow-up implementation steps.
-5. Implement namespace-local reference resolution for top-level, job, and step
-   `uses`.
-6. Implement input binding, expression context, and output propagation.
-7. Update CLI verbs and docs to use `WorkflowRun` for execution.
-8. Add E2E coverage for inline `WorkflowRun`, reusable Workflow calls, Action
-   calls, validation failures, and output propagation.
-9. Update the final v0.x demos after the reusable model is implemented.
+5. Implement the resolved graph snapshot and namespace-local top-level
+   `WorkflowRun.spec.uses` resolution.
+6. Implement input binding for top-level reusable Workflow calls.
+7. Implement inline WorkflowRun execution for `jobs` and `steps.run`.
+8. Implement job-level reusable Workflow calls.
+9. Implement step-level Action expansion.
+10. Implement expression evaluation and output propagation.
+11. Update CLI verbs and docs to use `WorkflowRun` for execution.
+12. Add E2E coverage for inline `WorkflowRun`, reusable Workflow calls, Action
+    calls, validation failures, output propagation, and controller restart
+    recovery from the resolved graph snapshot.
+13. Update the final v0.x demos after the reusable model is implemented.
 
 Current implementation status:
 

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -218,6 +218,30 @@ outputs:
 - 缺少 required inputs 时 validation 或 reconcile 早期失败；
 - 未知 input names 时 validation 或 reconcile 早期失败。
 
+WorkflowRun controller 应在展开 child jobs 或 steps 之前完成 input binding：
+
+1. 从 callee 声明的 `inputs` 开始。
+2. 应用每个 input 的 `default`。
+3. 覆盖 caller 通过 `with` 传入的 values。
+4. 拒绝缺少 required inputs 的调用。
+5. 拒绝未知的 `with` keys。
+6. 在创建 Runs 之前，将 resolved execution snapshot 存入 `WorkflowRun.status`
+   或内部 child object annotation。
+
+已经启动的 WorkflowRun 不应观察到被引用 `Workflow` 或 `Action` 的后续变更。Reusable
+definitions 可以随时间变化，但每个 WorkflowRun 一旦 accepted，它的执行必须是确定的。后续
+可以增加显式 revisioning；第一版应捕获足够的 resolved data，让 retries 和 controller
+restart 后的恢复保持稳定。
+
+Step outputs 来自 child Run 结果。step 将小型 key-value outputs 写入
+`KRUNTIME_OUTPUTS`；runtimed 将其持久化到 child Run status。WorkflowRun controller
+读取这些 child Run outputs，并提升到
+`WorkflowRun.status.jobs.<job>.steps.<step>.outputs`。
+
+Job outputs 在 job 内所有 steps 成功后计算。Workflow outputs 在 reusable Workflow 内所有
+jobs 成功后计算。当 expression 引用了不存在的 job、step 或 output key 时，output
+evaluation 必须让 WorkflowRun 失败。
+
 ## Reference Resolution
 
 第一版 references 保持 namespace-local：
@@ -232,6 +256,72 @@ URLs、Git refs 或 OCI refs。
 
 这样可以保持 API 小，并避免在 execution model 稳定前过早创建必须长期支持的 reference
 format。
+
+Reference resolution 应按以下顺序发生：
+
+1. 将 top-level `WorkflowRun.spec.uses` 解析到同 namespace 下的 `Workflow`。
+2. 将被引用 Workflow 的 jobs 展开到 WorkflowRun execution graph。
+3. 将每个 job-level `uses` 解析到同 namespace 下的 reusable `Workflow`。
+4. 将 reusable Workflow calls 展开为 nested job groups，并保持它们自己的
+   job/workspace/artifact boundary。
+5. 将每个 step-level `uses` 解析到同 namespace 下的 `Action`。
+6. 将 Action steps inline 展开到 caller job context。
+7. 在创建任何 child Runs 之前检测 cycles。
+
+Workflow calls 之间的 cycles 必须被拒绝。第一版中 Action 不应再调用另一个 Action，因为
+nested Action expansion 目前不需要，而且会增加 cycle detection 的复杂度。Reusable
+Workflow 只有在 controller 能证明 call graph 无环时，才可以调用另一个 Workflow。
+
+Resolution failures 应在创建任何 child Runs 前将 WorkflowRun 置为 `Failed`。典型情况包括
+missing references、namespace 假设不匹配、unsupported nested Action calls、input binding
+失败以及 cycles。
+
+## Execution Graph
+
+WorkflowRun controller 拥有 graph expansion 和 execution state。它不应依赖 scheduler 或
+runtimed 理解 Workflow 概念。
+
+第一版应使用简单、确定性的 graph 模型：
+
+- 每个 job 都有稳定的 execution path，例如 `jobs.build`，或从 reusable Workflow call
+  展开的 `jobs.release.jobs.build`；
+- 每个 step 都有稳定的 execution path，例如 `jobs.build.steps.package`；
+- 每个 child Run 都带有 WorkflowRun name、job path 和 step path labels；
+- child Run names 要么足够确定以支持 idempotent reconciliation，要么在创建新 Runs 前
+  通过 labels 发现已有 Runs；
+- controller 只在所有 dependency jobs 成功后创建 Runs；
+- failed、cancelled 或 timed-out child Runs 会让 owning WorkflowRun 失败，除非未来
+  retry/continue-on-error API 显式改变这个行为。
+
+第一版应支持一种执行策略：
+
+1. Accept WorkflowRun，并设置 `status.phase=Pending`。
+2. Resolve references 并 bind inputs。
+3. 持久化 resolved graph snapshot。
+4. 通过为每个 ready job 创建第一个 step Run 来启动 ready jobs。
+5. 当 step Run 成功时，收集 outputs，并创建下一个 step Run。
+6. 当 job 内所有 steps 成功时，计算 job outputs，并将 job 标记为 succeeded。
+7. 当所有 jobs 成功时，计算 WorkflowRun outputs，并将 WorkflowRun 标记为 succeeded。
+
+这有意避免增加单独的 WorkflowRunInvocation API。Child Runs 仍然是持久 execution records，
+scheduler/runtimed 仍然只操作 Runs。
+
+## Expression Context
+
+对于 v0.x，expressions 应保持足够小，只支持来自已知 context 的 string interpolation：
+
+| Context | 来源 |
+| --- | --- |
+| `inputs.<name>` | 当前 Workflow、Action 或 WorkflowRun 的 resolved inputs |
+| `steps.<step>.outputs.<name>` | 同一 job 内已经完成的前序 steps |
+| `jobs.<job>.outputs.<name>` | 同一 graph boundary 内已经完成的 dependency jobs |
+
+Expressions 不应访问 Kubernetes objects、environment variables、secrets、files、
+arbitrary functions 或 network resources。Secret handling 在暴露给 Workflow expressions
+之前需要单独设计。
+
+Evaluation 必须是确定且无副作用的。Unsupported syntax 或 missing values 应让
+WorkflowRun 失败，并提供清晰 condition 和 message。
 
 ## Status Model
 
@@ -281,12 +371,18 @@ status:
 4. 增加 `Action` API types、CRD validation、status 和 controller skeleton。
    Namespace-local resolution、input binding、output propagation 和 WorkflowRun
    execution 是后续独立实现步骤。
-5. 实现 top-level、job 和 step `uses` 的 namespace-local reference resolution。
-6. 实现 input binding、expression context 和 output propagation。
-7. 更新 CLI verbs 和 docs，使 execution 使用 `WorkflowRun`。
-8. 增加 E2E 覆盖 inline `WorkflowRun`、reusable Workflow calls、Action calls、
-   validation failures 和 output propagation。
-9. reusable model 实现后，更新最终 v0.x demos。
+5. 实现 resolved graph snapshot 和 top-level `WorkflowRun.spec.uses` 的
+   namespace-local resolution。
+6. 实现 top-level reusable Workflow calls 的 input binding。
+7. 实现 inline WorkflowRun execution，覆盖 `jobs` 和 `steps.run`。
+8. 实现 job-level reusable Workflow calls。
+9. 实现 step-level Action expansion。
+10. 实现 expression evaluation 和 output propagation。
+11. 更新 CLI verbs 和 docs，使 execution 使用 `WorkflowRun`。
+12. 增加 E2E 覆盖 inline `WorkflowRun`、reusable Workflow calls、Action calls、
+    validation failures、output propagation，以及从 resolved graph snapshot 进行
+    controller restart recovery。
+13. reusable model 实现后，更新最终 v0.x demos。
 
 当前实现状态：
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -198,14 +198,20 @@ wiring from accumulating avoidable conflicts.
   - [x] change `Workflow` API types to reusable definitions;
   - [x] add `Action` API types, CRD validation, status, and controller
     skeleton;
-  - implement namespace-local `uses` resolution for top-level, job, and step
-    calls;
-  - implement input binding, expression context, and output propagation;
   - [x] add workflow-oriented `krt wf` verbs for reusable Workflow definitions
     and WorkflowRun skeletons;
   - [x] update CLI verbs and docs so execution uses `WorkflowRun`;
+  - implement resolved graph snapshot storage and recovery;
+  - implement namespace-local top-level `WorkflowRun.spec.uses` resolution;
+  - implement input binding for top-level reusable Workflow calls;
+  - implement inline WorkflowRun execution for `jobs` and `steps.run`;
+  - implement job-level reusable Workflow calls;
+  - implement step-level Action expansion;
+  - implement expression evaluation for `inputs`, `steps`, and `jobs` contexts;
+  - promote child Run outputs into WorkflowRun step/job/workflow outputs;
   - add E2E coverage for inline `WorkflowRun`, reusable Workflow calls, Action
-    calls, validation failures, and output propagation.
+    calls, validation failures, output propagation, and controller restart
+    recovery.
 - [ ] Dashboard: design and build a read-only web dashboard, similar in spirit
   to Tekton Dashboard, that can browse Runs by namespace and inspect status and
   logs.

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -169,13 +169,19 @@ controller wiring 累积不必要的冲突。
   - [x] 增加 `WorkflowRun` API types、CRD validation、status 和 controller skeleton；
   - [x] 将 `Workflow` API types 改为 reusable definitions；
   - [x] 增加 `Action` API types、CRD validation、status 和 controller skeleton；
-  - 实现 top-level、job 和 step calls 的 namespace-local `uses` resolution；
-  - 实现 input binding、expression context 和 output propagation；
   - [x] 为 reusable Workflow definitions 和 WorkflowRun skeleton 增加面向 workflow
     语义的 `krt wf` verbs；
   - [x] 更新 CLI verbs 和 docs，使 execution 使用 `WorkflowRun`；
+  - 实现 resolved graph snapshot storage 和 recovery；
+  - 实现 top-level `WorkflowRun.spec.uses` 的 namespace-local resolution；
+  - 实现 top-level reusable Workflow calls 的 input binding；
+  - 实现 inline WorkflowRun execution，覆盖 `jobs` 和 `steps.run`；
+  - 实现 job-level reusable Workflow calls；
+  - 实现 step-level Action expansion；
+  - 实现 `inputs`、`steps` 和 `jobs` contexts 的 expression evaluation；
+  - 将 child Run outputs 提升为 WorkflowRun step/job/workflow outputs；
   - 增加 E2E 覆盖 inline `WorkflowRun`、reusable Workflow calls、Action calls、
-    validation failures 和 output propagation。
+    validation failures、output propagation 和 controller restart recovery。
 - [ ] Dashboard：设计并实现只读 web dashboard，类似 Tekton Dashboard，可以按
   namespace 查看 Runs，并检查状态和日志。
   初始实现 TODO：


### PR DESCRIPTION
## Summary
- refine the WorkflowRun execution design with resolved graph snapshots, deterministic reference resolution, input binding, and output propagation rules
- document the narrow v0.x expression context and failure semantics
- split the roadmap Workflow reuse TODOs into smaller implementation steps

## Notes
- Docs-only PR.
- This does not change API types or controller behavior.
- Based on main after #260.

## Validation
- `GOBIN=/tmp/kruntimes-bin make site-build`
- `git diff --check upstream/main...HEAD`