### PR TITLE
feat(controller): resolve WorkflowRun reusable workflows

### DIFF
--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -423,5 +423,8 @@ Current implementation status:
   child Runs.
 - Inline WorkflowRuns initialize `status.jobs[*].pre` and ordered
   `status.jobs[*].steps`.
+- Top-level `WorkflowRun.spec.uses` resolves a same-namespace reusable
+  Workflow and initializes `status.jobs` from the referenced Workflow jobs.
+  Missing references fail the WorkflowRun before child Runs are created.
 - Old Workflow execution E2E coverage is skipped until WorkflowRun execution
   lands.

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -402,4 +402,7 @@ status:
 - `Workflow` 现在是 reusable definition skeleton，不再执行 child Runs。
 - Inline WorkflowRuns 会初始化 `status.jobs[*].pre` 和有序
   `status.jobs[*].steps`。
+- Top-level `WorkflowRun.spec.uses` 会解析同 namespace 下的 reusable
+  Workflow，并基于被引用 Workflow 的 jobs 初始化 `status.jobs`。Missing
+  references 会在创建 child Runs 前让 WorkflowRun 失败。
 - 旧 Workflow execution E2E coverage 暂时 skip，等待 WorkflowRun execution 实现后恢复。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -203,7 +203,8 @@ wiring from accumulating avoidable conflicts.
   - [x] update CLI verbs and docs so execution uses `WorkflowRun`;
   - [x] initialize lightweight `status.jobs[*].pre` and ordered `steps` for
     inline WorkflowRuns;
-  - implement namespace-local top-level `WorkflowRun.spec.uses` resolution;
+  - [x] implement namespace-local top-level `WorkflowRun.spec.uses`
+    resolution;
   - implement input binding for top-level reusable Workflow calls;
   - implement inline WorkflowRun execution for `jobs` and `steps.run`;
   - implement job-level reusable Workflow calls;

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -173,7 +173,8 @@ controller wiring 累积不必要的冲突。
     语义的 `krt wf` verbs；
   - [x] 更新 CLI verbs 和 docs，使 execution 使用 `WorkflowRun`；
   - [x] 为 inline WorkflowRuns 初始化轻量 `status.jobs[*].pre` 和有序 `steps`；
-  - 实现 top-level `WorkflowRun.spec.uses` 的 namespace-local resolution；
+  - [x] 实现 top-level `WorkflowRun.spec.uses` 的 namespace-local
+    resolution；
   - 实现 top-level reusable Workflow calls 的 input binding；
   - 实现 inline WorkflowRun execution，覆盖 `jobs` 和 `steps.run`；
   - 实现 job-level reusable Workflow calls；

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,6 +27,7 @@ type WorkflowRunReconciler struct {
 
 // +kubebuilder:rbac:groups=kruntimes.io,resources=workflowruns,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=kruntimes.io,resources=workflowruns/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=kruntimes.io,resources=workflows,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 func (r *WorkflowRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -41,16 +43,29 @@ func (r *WorkflowRunReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if workflowRun.Status.Phase == "" {
 		workflowRun.Status.Phase = v1alpha1.WorkflowPending
 	}
-	if workflowRun.Status.Jobs == nil && len(workflowRun.Spec.Jobs) > 0 {
-		workflowRun.Status.Jobs = resolvedInlineJobStatuses(workflowRun.Spec.Jobs)
-	}
-	apimeta.SetStatusCondition(&workflowRun.Status.Conditions, metav1.Condition{
+	condition := metav1.Condition{
 		Type:               workflowRunAcceptedCondition,
 		Status:             metav1.ConditionTrue,
 		Reason:             "Accepted",
 		Message:            "WorkflowRun accepted; execution is a follow-up implementation step",
 		ObservedGeneration: workflowRun.Generation,
-	})
+	}
+	if workflowRun.Status.Phase != v1alpha1.WorkflowFailed && workflowRun.Status.Jobs == nil {
+		jobs, err := r.resolveWorkflowRunJobs(ctx, &workflowRun)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
+			workflowRun.Status.Phase = v1alpha1.WorkflowFailed
+			workflowRun.Status.Message = err.Error()
+			condition.Status = metav1.ConditionFalse
+			condition.Reason = "WorkflowResolutionFailed"
+			condition.Message = err.Error()
+		} else if len(jobs) > 0 {
+			workflowRun.Status.Jobs = resolvedJobStatuses(jobs)
+		}
+	}
+	apimeta.SetStatusCondition(&workflowRun.Status.Conditions, condition)
 	if err := r.Status().Patch(ctx, &workflowRun, client.MergeFrom(base)); err != nil {
 		return ctrl.Result{}, fmt.Errorf("patch workflowrun status: %w", err)
 	}
@@ -64,7 +79,23 @@ func (r *WorkflowRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func resolvedInlineJobStatuses(jobs map[string]v1alpha1.JobSpec) map[string]v1alpha1.JobStatus {
+func (r *WorkflowRunReconciler) resolveWorkflowRunJobs(ctx context.Context, workflowRun *v1alpha1.WorkflowRun) (map[string]v1alpha1.JobSpec, error) {
+	if len(workflowRun.Spec.Jobs) > 0 {
+		return workflowRun.Spec.Jobs, nil
+	}
+	if workflowRun.Spec.Uses == "" {
+		return nil, nil
+	}
+
+	var workflow v1alpha1.Workflow
+	key := client.ObjectKey{Namespace: workflowRun.Namespace, Name: workflowRun.Spec.Uses}
+	if err := r.Get(ctx, key, &workflow); err != nil {
+		return nil, fmt.Errorf("get workflow %s/%s: %w", workflowRun.Namespace, workflowRun.Spec.Uses, err)
+	}
+	return workflow.Spec.Jobs, nil
+}
+
+func resolvedJobStatuses(jobs map[string]v1alpha1.JobSpec) map[string]v1alpha1.JobStatus {
 	statuses := make(map[string]v1alpha1.JobStatus, len(jobs))
 	for jobName, job := range jobs {
 		pre := append([]string(nil), job.Needs...)

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -150,5 +151,117 @@ func TestWorkflowRunReconcilerPreservesResolvedJobStatus(t *testing.T) {
 	}
 	if len(status.Steps) != 1 || status.Steps[0].RunName != "existing-run" {
 		t.Fatalf("steps = %#v, want existing run preserved", status.Steps)
+	}
+}
+
+func TestWorkflowRunReconcilerResolvesReusableWorkflow(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	workflow := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "build-and-test", Namespace: "default"},
+		Spec: v1alpha1.WorkflowSpec{
+			Jobs: map[string]v1alpha1.JobSpec{
+				"build": {
+					RunsOn: "bash",
+					Steps:  []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}},
+				},
+				"test": {
+					RunsOn: "bash",
+					Needs:  []string{"build"},
+					Steps:  []v1alpha1.StepSpec{{Name: "unit", Run: "make test"}},
+				},
+			},
+		},
+	}
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default", Generation: 5},
+		Spec: v1alpha1.WorkflowRunSpec{
+			Uses: "build-and-test",
+			With: map[string]string{"ref": "main"},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(workflow, workflowRun).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: workflowRun.Namespace,
+		Name:      workflowRun.Name,
+	}}
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile workflowrun: %v", err)
+	}
+
+	var updated v1alpha1.WorkflowRun
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
+		t.Fatalf("get workflowrun: %v", err)
+	}
+	if updated.Status.Phase != v1alpha1.WorkflowPending {
+		t.Fatalf("phase = %q, want %q", updated.Status.Phase, v1alpha1.WorkflowPending)
+	}
+	if len(updated.Status.Jobs) != 2 {
+		t.Fatalf("jobs = %#v, want 2 resolved jobs", updated.Status.Jobs)
+	}
+	if got := updated.Status.Jobs["build"]; got.Phase != v1alpha1.JobPending || len(got.Pre) != 0 || len(got.Steps) != 1 || got.Steps[0].Name != "compile" {
+		t.Fatalf("build status = %#v, want pending compile step", got)
+	}
+	if got := updated.Status.Jobs["test"]; got.Phase != v1alpha1.JobWaiting || len(got.Pre) != 1 || got.Pre[0] != "build" {
+		t.Fatalf("test status = %#v, want waiting on build", got)
+	}
+	cond := apimeta.FindStatusCondition(updated.Status.Conditions, workflowRunAcceptedCondition)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("condition = %#v, want accepted true", cond)
+	}
+}
+
+func TestWorkflowRunReconcilerFailsWhenReusableWorkflowMissing(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default", Generation: 6},
+		Spec: v1alpha1.WorkflowRunSpec{
+			Uses: "missing-workflow",
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(workflowRun).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: workflowRun.Namespace,
+		Name:      workflowRun.Name,
+	}}
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile workflowrun: %v", err)
+	}
+
+	var updated v1alpha1.WorkflowRun
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
+		t.Fatalf("get workflowrun: %v", err)
+	}
+	if updated.Status.Phase != v1alpha1.WorkflowFailed {
+		t.Fatalf("phase = %q, want %q", updated.Status.Phase, v1alpha1.WorkflowFailed)
+	}
+	if updated.Status.Jobs != nil {
+		t.Fatalf("jobs = %#v, want nil on failed resolution", updated.Status.Jobs)
+	}
+	if !strings.Contains(updated.Status.Message, "missing-workflow") {
+		t.Fatalf("message = %q, want missing workflow name", updated.Status.Message)
+	}
+	cond := apimeta.FindStatusCondition(updated.Status.Conditions, workflowRunAcceptedCondition)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WorkflowResolutionFailed" {
+		t.Fatalf("condition = %#v, want resolution failure", cond)
 	}
 }


### PR DESCRIPTION
## Summary
- resolve top-level `WorkflowRun.spec.uses` to a same-namespace reusable `Workflow`
- initialize `status.jobs` from referenced Workflow jobs using the same lightweight `pre` + ordered steps model
- fail WorkflowRuns early when the referenced Workflow is missing
- update workflow design docs and roadmap status in English and Chinese

## Scope
- Does not implement input binding for `spec.with`.
- Does not execute child Runs yet.
- Does not resolve job-level Workflow calls or step-level Actions.

## Validation
- `GOCACHE=/tmp/go-build make generate manifests`
- `GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/controller -count=1`
- `GOCACHE=/tmp/go-build make test`
- `GOCACHE=/tmp/go-build make test-integration`
- `GOBIN=/tmp/kruntimes-bin make site-build`
- `git diff --check`