### PR TITLE
feat(controller): bind WorkflowRun reusable inputs

### DIFF
--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -426,5 +426,8 @@ Current implementation status:
 - Top-level `WorkflowRun.spec.uses` resolves a same-namespace reusable
   Workflow and initializes `status.jobs` from the referenced Workflow jobs.
   Missing references fail the WorkflowRun before child Runs are created.
+- Top-level reusable Workflow calls bind string inputs early: defaults are
+  applied, missing required inputs fail, and unknown `with` keys fail. Bound
+  values are not evaluated into child Runs until WorkflowRun execution lands.
 - Old Workflow execution E2E coverage is skipped until WorkflowRun execution
   lands.

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -405,4 +405,7 @@ status:
 - Top-level `WorkflowRun.spec.uses` 会解析同 namespace 下的 reusable
   Workflow，并基于被引用 Workflow 的 jobs 初始化 `status.jobs`。Missing
   references 会在创建 child Runs 前让 WorkflowRun 失败。
+- Top-level reusable Workflow calls 会提前绑定 string inputs：应用 defaults，
+  missing required inputs 会失败，unknown `with` keys 也会失败。Bound values 会等到
+  WorkflowRun execution 实现后再用于 child Runs。
 - 旧 Workflow execution E2E coverage 暂时 skip，等待 WorkflowRun execution 实现后恢复。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -205,7 +205,7 @@ wiring from accumulating avoidable conflicts.
     inline WorkflowRuns;
   - [x] implement namespace-local top-level `WorkflowRun.spec.uses`
     resolution;
-  - implement input binding for top-level reusable Workflow calls;
+  - [x] implement input binding for top-level reusable Workflow calls;
   - implement inline WorkflowRun execution for `jobs` and `steps.run`;
   - implement job-level reusable Workflow calls;
   - implement step-level Action expansion;

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -175,7 +175,7 @@ controller wiring 累积不必要的冲突。
   - [x] 为 inline WorkflowRuns 初始化轻量 `status.jobs[*].pre` 和有序 `steps`；
   - [x] 实现 top-level `WorkflowRun.spec.uses` 的 namespace-local
     resolution；
-  - 实现 top-level reusable Workflow calls 的 input binding；
+  - [x] 实现 top-level reusable Workflow calls 的 input binding；
   - 实现 inline WorkflowRun execution，覆盖 `jobs` 和 `steps.run`；
   - 实现 job-level reusable Workflow calls；
   - 实现 step-level Action expansion；

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -17,6 +18,18 @@ import (
 )
 
 const workflowRunAcceptedCondition = "Accepted"
+
+type workflowInputBindingError struct {
+	err error
+}
+
+func (e *workflowInputBindingError) Error() string {
+	return e.err.Error()
+}
+
+func (e *workflowInputBindingError) Unwrap() error {
+	return e.err
+}
 
 // WorkflowRunReconciler owns WorkflowRun execution-instance status.
 type WorkflowRunReconciler struct {
@@ -53,13 +66,18 @@ func (r *WorkflowRunReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if workflowRun.Status.Phase != v1alpha1.WorkflowFailed && workflowRun.Status.Jobs == nil {
 		jobs, err := r.resolveWorkflowRunJobs(ctx, &workflowRun)
 		if err != nil {
-			if !apierrors.IsNotFound(err) {
+			var inputErr *workflowInputBindingError
+			switch {
+			case apierrors.IsNotFound(err):
+				condition.Reason = "WorkflowResolutionFailed"
+			case errors.As(err, &inputErr):
+				condition.Reason = "WorkflowInputBindingFailed"
+			default:
 				return ctrl.Result{}, err
 			}
 			workflowRun.Status.Phase = v1alpha1.WorkflowFailed
 			workflowRun.Status.Message = err.Error()
 			condition.Status = metav1.ConditionFalse
-			condition.Reason = "WorkflowResolutionFailed"
 			condition.Message = err.Error()
 		} else if len(jobs) > 0 {
 			workflowRun.Status.Jobs = resolvedJobStatuses(jobs)
@@ -92,7 +110,37 @@ func (r *WorkflowRunReconciler) resolveWorkflowRunJobs(ctx context.Context, work
 	if err := r.Get(ctx, key, &workflow); err != nil {
 		return nil, fmt.Errorf("get workflow %s/%s: %w", workflowRun.Namespace, workflowRun.Spec.Uses, err)
 	}
+	if _, err := bindWorkflowInputs(workflow.Spec.Inputs, workflowRun.Spec.With); err != nil {
+		return nil, &workflowInputBindingError{err: fmt.Errorf("bind workflow inputs for %s/%s: %w", workflowRun.Namespace, workflowRun.Spec.Uses, err)}
+	}
 	return workflow.Spec.Jobs, nil
+}
+
+func bindWorkflowInputs(inputs map[string]v1alpha1.WorkflowInputSpec, with map[string]string) (map[string]string, error) {
+	for name := range with {
+		if _, ok := inputs[name]; !ok {
+			return nil, fmt.Errorf("unknown input %q", name)
+		}
+	}
+
+	bound := make(map[string]string, len(inputs))
+	names := make([]string, 0, len(inputs))
+	for name := range inputs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		input := inputs[name]
+		value, ok := with[name]
+		if !ok {
+			value = input.Default
+		}
+		if value == "" && input.Required && !ok && input.Default == "" {
+			return nil, fmt.Errorf("missing required input %q", name)
+		}
+		bound[name] = value
+	}
+	return bound, nil
 }
 
 func resolvedJobStatuses(jobs map[string]v1alpha1.JobSpec) map[string]v1alpha1.JobStatus {

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -163,6 +163,10 @@ func TestWorkflowRunReconcilerResolvesReusableWorkflow(t *testing.T) {
 	workflow := &v1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{Name: "build-and-test", Namespace: "default"},
 		Spec: v1alpha1.WorkflowSpec{
+			Inputs: map[string]v1alpha1.WorkflowInputSpec{
+				"ref":    {Required: true},
+				"target": {Default: "linux-amd64"},
+			},
 			Jobs: map[string]v1alpha1.JobSpec{
 				"build": {
 					RunsOn: "bash",
@@ -263,5 +267,139 @@ func TestWorkflowRunReconcilerFailsWhenReusableWorkflowMissing(t *testing.T) {
 	cond := apimeta.FindStatusCondition(updated.Status.Conditions, workflowRunAcceptedCondition)
 	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WorkflowResolutionFailed" {
 		t.Fatalf("condition = %#v, want resolution failure", cond)
+	}
+}
+
+func TestWorkflowRunReconcilerFailsWhenWorkflowInputUnknown(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	workflow := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "build-and-test", Namespace: "default"},
+		Spec: v1alpha1.WorkflowSpec{
+			Inputs: map[string]v1alpha1.WorkflowInputSpec{
+				"ref": {Required: true},
+			},
+			Jobs: map[string]v1alpha1.JobSpec{
+				"build": {
+					RunsOn: "bash",
+					Steps:  []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}},
+				},
+			},
+		},
+	}
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default", Generation: 7},
+		Spec: v1alpha1.WorkflowRunSpec{
+			Uses: "build-and-test",
+			With: map[string]string{
+				"ref":     "main",
+				"unknown": "value",
+			},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(workflow, workflowRun).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: workflowRun.Namespace,
+		Name:      workflowRun.Name,
+	}}
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile workflowrun: %v", err)
+	}
+
+	var updated v1alpha1.WorkflowRun
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
+		t.Fatalf("get workflowrun: %v", err)
+	}
+	if updated.Status.Phase != v1alpha1.WorkflowFailed {
+		t.Fatalf("phase = %q, want %q", updated.Status.Phase, v1alpha1.WorkflowFailed)
+	}
+	if !strings.Contains(updated.Status.Message, `unknown input "unknown"`) {
+		t.Fatalf("message = %q, want unknown input", updated.Status.Message)
+	}
+	cond := apimeta.FindStatusCondition(updated.Status.Conditions, workflowRunAcceptedCondition)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WorkflowInputBindingFailed" {
+		t.Fatalf("condition = %#v, want input binding failure", cond)
+	}
+}
+
+func TestWorkflowRunReconcilerFailsWhenWorkflowInputRequired(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	workflow := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "build-and-test", Namespace: "default"},
+		Spec: v1alpha1.WorkflowSpec{
+			Inputs: map[string]v1alpha1.WorkflowInputSpec{
+				"ref": {Required: true},
+			},
+			Jobs: map[string]v1alpha1.JobSpec{
+				"build": {
+					RunsOn: "bash",
+					Steps:  []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}},
+				},
+			},
+		},
+	}
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default", Generation: 8},
+		Spec: v1alpha1.WorkflowRunSpec{
+			Uses: "build-and-test",
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(workflow, workflowRun).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: workflowRun.Namespace,
+		Name:      workflowRun.Name,
+	}}
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile workflowrun: %v", err)
+	}
+
+	var updated v1alpha1.WorkflowRun
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
+		t.Fatalf("get workflowrun: %v", err)
+	}
+	if updated.Status.Phase != v1alpha1.WorkflowFailed {
+		t.Fatalf("phase = %q, want %q", updated.Status.Phase, v1alpha1.WorkflowFailed)
+	}
+	if !strings.Contains(updated.Status.Message, `missing required input "ref"`) {
+		t.Fatalf("message = %q, want missing required input", updated.Status.Message)
+	}
+	cond := apimeta.FindStatusCondition(updated.Status.Conditions, workflowRunAcceptedCondition)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WorkflowInputBindingFailed" {
+		t.Fatalf("condition = %#v, want input binding failure", cond)
+	}
+}
+
+func TestBindWorkflowInputsAppliesDefaults(t *testing.T) {
+	bound, err := bindWorkflowInputs(
+		map[string]v1alpha1.WorkflowInputSpec{
+			"ref":    {Required: true},
+			"target": {Default: "linux-amd64"},
+		},
+		map[string]string{"ref": "main"},
+	)
+	if err != nil {
+		t.Fatalf("bindWorkflowInputs() error = %v", err)
+	}
+	if bound["ref"] != "main" || bound["target"] != "linux-amd64" {
+		t.Fatalf("bound inputs = %#v, want ref and default target", bound)
 	}
 }


### PR DESCRIPTION
## Summary
- bind top-level reusable Workflow inputs during `WorkflowRun.spec.uses` resolution
- apply default input values and reject missing required inputs
- reject unknown `spec.with` keys before initializing job status
- report input binding failures with a distinct `WorkflowInputBindingFailed` condition reason
- update workflow design docs and roadmap status in English and Chinese

## Scope
- Does not persist bound input values in WorkflowRun status.
- Does not evaluate expressions into child Runs yet.
- Does not implement WorkflowRun execution.

## Validation
- `GOCACHE=/tmp/go-build make generate manifests`
- `GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/controller -count=1`
- `GOCACHE=/tmp/go-build make test`
- `GOCACHE=/tmp/go-build make test-integration`
- `GOBIN=/tmp/kruntimes-bin make site-build`
- `git diff --check`
- after rebasing on merged #263: `git diff --check upstream/main...HEAD`