### PR TITLE
docs: split inline WorkflowRun execution plan

### DIFF
--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -320,6 +320,28 @@ This deliberately avoids adding a separate WorkflowRunInvocation API. Child
 Runs remain the durable execution records, and scheduler/runtimed continue to
 operate only on Runs.
 
+Inline WorkflowRun execution should land in small, reviewable steps:
+
+1. Before changing execution behavior, audit the existing E2E tests. Remove or
+   update stale cases that still exercise the old Workflow execution model so
+   `make e2e` can stay passing throughout the migration.
+2. Create only the first child Run for each ready inline job, record the child
+   Run name on the matching ordered step status, and make creation idempotent
+   by discovering existing child Runs through labels.
+3. Watch or reconcile child Runs owned by a WorkflowRun and copy terminal child
+   Run phase into the matching step status.
+4. When a step succeeds, create the next step Run in the same job; when a step
+   fails, is cancelled, or times out, fail the job and WorkflowRun.
+5. When all steps in a job succeed, mark the job succeeded and unblock jobs
+   whose `pre` dependencies have all succeeded.
+6. When all jobs succeed, mark the WorkflowRun succeeded; if any dependency
+   job fails, fail dependent jobs without creating child Runs.
+7. Add restart recovery tests that prove the controller can continue from
+   `status.jobs[*].steps[*].runName` and child Run labels without duplicating
+   Runs.
+8. Add E2E coverage only after the controller can execute an inline
+   WorkflowRun end to end.
+
 ## Expression Context
 
 For v0.x, expressions should stay intentionally small. They should support only
@@ -349,8 +371,6 @@ status:
     build:
       phase: Running
       pre: []
-      next:
-        - test
       steps:
         - name: package
           phase: Succeeded
@@ -406,15 +426,19 @@ the implementation lands.
 5. Implement lightweight DAG edge snapshotting and namespace-local top-level
    `WorkflowRun.spec.uses` resolution.
 6. Implement input binding for top-level reusable Workflow calls.
-7. Implement inline WorkflowRun execution for `jobs` and `steps.run`.
-8. Implement job-level reusable Workflow calls.
-9. Implement step-level Action expansion.
-10. Implement expression evaluation and output propagation.
-11. Update CLI verbs and docs to use `WorkflowRun` for execution.
-12. Add E2E coverage for inline `WorkflowRun`, reusable Workflow calls, Action
+7. Implement inline WorkflowRun first-step Run creation for ready jobs.
+8. Implement child Run status observation and step status updates.
+9. Implement next-step creation, job terminal handling, and WorkflowRun
+   terminal handling.
+10. Implement controller restart recovery for in-progress inline WorkflowRuns.
+11. Implement job-level reusable Workflow calls.
+12. Implement step-level Action expansion.
+13. Implement expression evaluation and output propagation.
+14. Update CLI verbs and docs to use `WorkflowRun` for execution.
+15. Add E2E coverage for inline `WorkflowRun`, reusable Workflow calls, Action
     calls, validation failures, output propagation, and controller restart
     recovery from the status DAG edges.
-13. Update the final v0.x demos after the reusable model is implemented.
+16. Update the final v0.x demos after the reusable model is implemented.
 
 Current implementation status:
 

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -305,6 +305,24 @@ runtimed 理解 Workflow 概念。
 这有意避免增加单独的 WorkflowRunInvocation API。Child Runs 仍然是持久 execution records，
 scheduler/runtimed 仍然只操作 Runs。
 
+Inline WorkflowRun execution 应拆成小的、可 review 的步骤落地：
+
+1. 在修改 execution behavior 前，先审计现有 E2E tests。移除或更新仍在测试旧
+   Workflow execution model 的失效 case，保证整个迁移过程中 `make e2e` 始终可以通过。
+2. 只为 ready inline jobs 创建第一个 child Run，将 child Run name 记录到对应的有序
+   step status，并通过 labels 发现已有 child Runs 来保证创建幂等。
+3. Watch 或 reconcile 属于 WorkflowRun 的 child Runs，并将 terminal child Run phase
+   复制到对应 step status。
+4. 当 step 成功时，在同一 job 内创建下一个 step Run；当 step failed、cancelled 或
+   timed out 时，将 job 和 WorkflowRun 标记为 failed。
+5. 当 job 内所有 steps 成功时，将 job 标记为 succeeded，并解锁所有 `pre`
+   dependencies 已成功的 jobs。
+6. 当所有 jobs 成功时，将 WorkflowRun 标记为 succeeded；如果任一 dependency job
+   失败，则不创建 child Runs，并将 dependent jobs 标记为 failed。
+7. 增加 restart recovery tests，证明 controller 可以从
+   `status.jobs[*].steps[*].runName` 和 child Run labels 继续执行，且不会重复创建 Runs。
+8. 只有当 controller 能端到端执行 inline WorkflowRun 后，再增加 E2E coverage。
+
 ## Expression Context
 
 对于 v0.x，expressions 应保持足够小，只支持来自已知 context 的 string interpolation：
@@ -333,8 +351,6 @@ status:
     build:
       phase: Running
       pre: []
-      next:
-        - test
       steps:
         - name: package
           phase: Succeeded
@@ -386,15 +402,18 @@ status:
 5. 实现轻量 DAG edge snapshotting 和 top-level `WorkflowRun.spec.uses` 的
    namespace-local resolution。
 6. 实现 top-level reusable Workflow calls 的 input binding。
-7. 实现 inline WorkflowRun execution，覆盖 `jobs` 和 `steps.run`。
-8. 实现 job-level reusable Workflow calls。
-9. 实现 step-level Action expansion。
-10. 实现 expression evaluation 和 output propagation。
-11. 更新 CLI verbs 和 docs，使 execution 使用 `WorkflowRun`。
-12. 增加 E2E 覆盖 inline `WorkflowRun`、reusable Workflow calls、Action calls、
+7. 实现 ready jobs 的 inline WorkflowRun first-step Run creation。
+8. 实现 child Run status observation 和 step status updates。
+9. 实现 next-step creation、job terminal handling 和 WorkflowRun terminal handling。
+10. 实现 in-progress inline WorkflowRuns 的 controller restart recovery。
+11. 实现 job-level reusable Workflow calls。
+12. 实现 step-level Action expansion。
+13. 实现 expression evaluation 和 output propagation。
+14. 更新 CLI verbs 和 docs，使 execution 使用 `WorkflowRun`。
+15. 增加 E2E 覆盖 inline `WorkflowRun`、reusable Workflow calls、Action calls、
     validation failures、output propagation，以及从 status DAG edges 进行 controller
     restart recovery。
-13. reusable model 实现后，更新最终 v0.x demos。
+16. reusable model 实现后，更新最终 v0.x demos。
 
 当前实现状态：
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -206,7 +206,14 @@ wiring from accumulating avoidable conflicts.
   - [x] implement namespace-local top-level `WorkflowRun.spec.uses`
     resolution;
   - [x] implement input binding for top-level reusable Workflow calls;
-  - implement inline WorkflowRun execution for `jobs` and `steps.run`;
+  - audit existing E2E tests before inline execution changes, and remove or
+    update stale cases that still use the old Workflow execution model so
+    `make e2e` stays passing during the migration;
+  - implement inline WorkflowRun first-step Run creation for ready jobs;
+  - implement child Run status observation and step status updates;
+  - implement next-step creation, job terminal handling, and WorkflowRun
+    terminal handling;
+  - implement controller restart recovery for in-progress inline WorkflowRuns;
   - implement job-level reusable Workflow calls;
   - implement step-level Action expansion;
   - implement expression evaluation for `inputs`, `steps`, and `jobs` contexts;

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -176,7 +176,12 @@ controller wiring 累积不必要的冲突。
   - [x] 实现 top-level `WorkflowRun.spec.uses` 的 namespace-local
     resolution；
   - [x] 实现 top-level reusable Workflow calls 的 input binding；
-  - 实现 inline WorkflowRun execution，覆盖 `jobs` 和 `steps.run`；
+  - 在 inline execution changes 开始前审计现有 E2E tests，移除或更新仍使用旧
+    Workflow execution model 的失效 cases，保证迁移过程中 `make e2e` 始终可以通过；
+  - 实现 ready jobs 的 inline WorkflowRun first-step Run creation；
+  - 实现 child Run status observation 和 step status updates；
+  - 实现 next-step creation、job terminal handling 和 WorkflowRun terminal handling；
+  - 实现 in-progress inline WorkflowRuns 的 controller restart recovery；
   - 实现 job-level reusable Workflow calls；
   - 实现 step-level Action expansion；
   - 实现 `inputs`、`steps` 和 `jobs` contexts 的 expression evaluation；


### PR DESCRIPTION
## Summary
- split inline WorkflowRun execution into smaller reviewable implementation steps
- add the same execution breakdown to the workflow reuse design docs in English and Chinese
- expand the roadmap TODOs so follow-up PRs can land incrementally
- remove stale `next` fields from the workflow status examples so docs match the current status model

## Validation
- `GOBIN=/tmp/kruntimes-bin make site-build`
- `git diff --check upstream/main...HEAD`

Docs-only change; no code tests run.