### PR TITLE
feat(controller): create WorkflowRun first-step Runs

### DIFF
--- a/api/v1alpha1/workflowrun_types.go
+++ b/api/v1alpha1/workflowrun_types.go
@@ -2,6 +2,18 @@ package v1alpha1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+const (
+	// WorkflowRunAcceptedCondition reports whether the WorkflowRun was accepted by the controller.
+	WorkflowRunAcceptedCondition = "Accepted"
+
+	// WorkflowRunUIDLabel identifies child Runs owned by a WorkflowRun.
+	WorkflowRunUIDLabel = "kruntimes.io/workflowrun-uid"
+	// WorkflowJobLabel identifies the workflow job that owns a child Run.
+	WorkflowJobLabel = "kruntimes.io/workflow-job"
+	// WorkflowStepLabel identifies the workflow step that owns a child Run.
+	WorkflowStepLabel = "kruntimes.io/workflow-step"
+)
+
 // +kubebuilder:object:generate=true
 // WorkflowRunSpec defines one workflow execution instance.
 // +kubebuilder:validation:XValidation:rule="has(self.jobs) != has(self.uses)",message="exactly one of jobs or uses must be set"

--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -328,18 +328,22 @@ Inline WorkflowRun execution should land in small, reviewable steps:
 2. Create only the first child Run for each ready inline job, record the child
    Run name on the matching ordered step status, and make creation idempotent
    by discovering existing child Runs through labels.
-3. Watch or reconcile child Runs owned by a WorkflowRun and copy terminal child
+3. Before adding more execution states, refactor the WorkflowRun controller
+   into a load/plan/apply state-machine shape: load the WorkflowRun and related
+   resources, derive the current state, switch on that state to produce the
+   intended actions, then apply Kubernetes writes.
+4. Watch or reconcile child Runs owned by a WorkflowRun and copy terminal child
    Run phase into the matching step status.
-4. When a step succeeds, create the next step Run in the same job; when a step
+5. When a step succeeds, create the next step Run in the same job; when a step
    fails, is cancelled, or times out, fail the job and WorkflowRun.
-5. When all steps in a job succeed, mark the job succeeded and unblock jobs
+6. When all steps in a job succeed, mark the job succeeded and unblock jobs
    whose `pre` dependencies have all succeeded.
-6. When all jobs succeed, mark the WorkflowRun succeeded; if any dependency
+7. When all jobs succeed, mark the WorkflowRun succeeded; if any dependency
    job fails, fail dependent jobs without creating child Runs.
-7. Add restart recovery tests that prove the controller can continue from
+8. Add restart recovery tests that prove the controller can continue from
    `status.jobs[*].steps[*].runName` and child Run labels without duplicating
    Runs.
-8. Add E2E coverage only after the controller can execute an inline
+9. Add E2E coverage only after the controller can execute an inline
    WorkflowRun end to end.
 
 ## Expression Context
@@ -453,5 +457,10 @@ Current implementation status:
 - Top-level reusable Workflow calls bind string inputs early: defaults are
   applied, missing required inputs fail, and unknown `with` keys fail. Bound
   values are not evaluated into child Runs until WorkflowRun execution lands.
+- Stale E2E stubs for the old Workflow execution model have been removed so
+  E2E stays focused on behavior that should still pass during the migration.
+- Inline WorkflowRuns create first-step child Runs for ready inline jobs and
+  record the child Run name in ordered step status. Child Run result
+  observation and next-step creation are still follow-up work.
 - Old Workflow execution E2E coverage is skipped until WorkflowRun execution
   lands.

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -311,17 +311,20 @@ Inline WorkflowRun execution 应拆成小的、可 review 的步骤落地：
    Workflow execution model 的失效 case，保证整个迁移过程中 `make e2e` 始终可以通过。
 2. 只为 ready inline jobs 创建第一个 child Run，将 child Run name 记录到对应的有序
    step status，并通过 labels 发现已有 child Runs 来保证创建幂等。
-3. Watch 或 reconcile 属于 WorkflowRun 的 child Runs，并将 terminal child Run phase
+3. 在增加更多 execution states 之前，将 WorkflowRun controller 重构为 load/plan/apply
+   的状态机形态：先加载 WorkflowRun 和相关资源，推导 current state，再根据 state
+   计算需要执行的 actions，最后执行 Kubernetes writes。
+4. Watch 或 reconcile 属于 WorkflowRun 的 child Runs，并将 terminal child Run phase
    复制到对应 step status。
-4. 当 step 成功时，在同一 job 内创建下一个 step Run；当 step failed、cancelled 或
+5. 当 step 成功时，在同一 job 内创建下一个 step Run；当 step failed、cancelled 或
    timed out 时，将 job 和 WorkflowRun 标记为 failed。
-5. 当 job 内所有 steps 成功时，将 job 标记为 succeeded，并解锁所有 `pre`
+6. 当 job 内所有 steps 成功时，将 job 标记为 succeeded，并解锁所有 `pre`
    dependencies 已成功的 jobs。
-6. 当所有 jobs 成功时，将 WorkflowRun 标记为 succeeded；如果任一 dependency job
+7. 当所有 jobs 成功时，将 WorkflowRun 标记为 succeeded；如果任一 dependency job
    失败，则不创建 child Runs，并将 dependent jobs 标记为 failed。
-7. 增加 restart recovery tests，证明 controller 可以从
+8. 增加 restart recovery tests，证明 controller 可以从
    `status.jobs[*].steps[*].runName` 和 child Run labels 继续执行，且不会重复创建 Runs。
-8. 只有当 controller 能端到端执行 inline WorkflowRun 后，再增加 E2E coverage。
+9. 只有当 controller 能端到端执行 inline WorkflowRun 后，再增加 E2E coverage。
 
 ## Expression Context
 
@@ -427,4 +430,9 @@ status:
 - Top-level reusable Workflow calls 会提前绑定 string inputs：应用 defaults，
   missing required inputs 会失败，unknown `with` keys 也会失败。Bound values 会等到
   WorkflowRun execution 实现后再用于 child Runs。
+- 旧 Workflow execution model 的 stale E2E stubs 已删除，保证迁移期间 E2E 聚焦于
+  仍应保持 passing 的行为。
+- Inline WorkflowRuns 会为 ready inline jobs 创建 first-step child Runs，并将 child
+  Run name 记录到有序 step status 中。Child Run result observation 和 next-step
+  creation 仍是后续工作。
 - 旧 Workflow execution E2E coverage 暂时 skip，等待 WorkflowRun execution 实现后恢复。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -206,10 +206,12 @@ wiring from accumulating avoidable conflicts.
   - [x] implement namespace-local top-level `WorkflowRun.spec.uses`
     resolution;
   - [x] implement input binding for top-level reusable Workflow calls;
-  - audit existing E2E tests before inline execution changes, and remove or
+  - [x] audit existing E2E tests before inline execution changes, and remove or
     update stale cases that still use the old Workflow execution model so
     `make e2e` stays passing during the migration;
-  - implement inline WorkflowRun first-step Run creation for ready jobs;
+  - [x] implement inline WorkflowRun first-step Run creation for ready jobs;
+  - refactor WorkflowRun controller reconciliation into a load/plan/apply
+    state-machine structure before adding more execution cases;
   - implement child Run status observation and step status updates;
   - implement next-step creation, job terminal handling, and WorkflowRun
     terminal handling;

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -176,9 +176,11 @@ controller wiring 累积不必要的冲突。
   - [x] 实现 top-level `WorkflowRun.spec.uses` 的 namespace-local
     resolution；
   - [x] 实现 top-level reusable Workflow calls 的 input binding；
-  - 在 inline execution changes 开始前审计现有 E2E tests，移除或更新仍使用旧
+  - [x] 在 inline execution changes 开始前审计现有 E2E tests，移除或更新仍使用旧
     Workflow execution model 的失效 cases，保证迁移过程中 `make e2e` 始终可以通过；
-  - 实现 ready jobs 的 inline WorkflowRun first-step Run creation；
+  - [x] 实现 ready jobs 的 inline WorkflowRun first-step Run creation；
+  - 在增加更多 execution cases 前，将 WorkflowRun controller reconciliation
+    重构为 load/plan/apply 的状态机结构；
   - 实现 child Run status observation 和 step status updates；
   - 实现 next-step creation、job terminal handling 和 WorkflowRun terminal handling；
   - 实现 in-progress inline WorkflowRuns 的 controller restart recovery；

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -2,22 +2,26 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
+	"strings"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 )
-
-const workflowRunAcceptedCondition = "Accepted"
 
 type workflowInputBindingError struct {
 	err error
@@ -41,6 +45,7 @@ type WorkflowRunReconciler struct {
 // +kubebuilder:rbac:groups=kruntimes.io,resources=workflowruns,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups=kruntimes.io,resources=workflowruns/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=kruntimes.io,resources=workflows,verbs=get;list;watch
+// +kubebuilder:rbac:groups=kruntimes.io,resources=runs,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 func (r *WorkflowRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -57,7 +62,7 @@ func (r *WorkflowRunReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		workflowRun.Status.Phase = v1alpha1.WorkflowPending
 	}
 	condition := metav1.Condition{
-		Type:               workflowRunAcceptedCondition,
+		Type:               v1alpha1.WorkflowRunAcceptedCondition,
 		Status:             metav1.ConditionTrue,
 		Reason:             "Accepted",
 		Message:            "WorkflowRun accepted; execution is a follow-up implementation step",
@@ -81,6 +86,16 @@ func (r *WorkflowRunReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			condition.Message = err.Error()
 		} else if len(jobs) > 0 {
 			workflowRun.Status.Jobs = resolvedJobStatuses(jobs)
+		}
+	}
+	if workflowRun.Status.Phase == v1alpha1.WorkflowPending && len(workflowRun.Spec.Jobs) > 0 && len(workflowRun.Status.Jobs) > 0 {
+		if err := r.startReadyInlineJobs(ctx, &workflowRun); err != nil {
+			return ctrl.Result{}, err
+		}
+		if workflowRun.Status.Phase == v1alpha1.WorkflowFailed {
+			condition.Status = metav1.ConditionFalse
+			condition.Reason = "WorkflowExecutionFailed"
+			condition.Message = workflowRun.Status.Message
 		}
 	}
 	apimeta.SetStatusCondition(&workflowRun.Status.Conditions, condition)
@@ -146,7 +161,7 @@ func bindWorkflowInputs(inputs map[string]v1alpha1.WorkflowInputSpec, with map[s
 func resolvedJobStatuses(jobs map[string]v1alpha1.JobSpec) map[string]v1alpha1.JobStatus {
 	statuses := make(map[string]v1alpha1.JobStatus, len(jobs))
 	for jobName, job := range jobs {
-		pre := append([]string(nil), job.Needs...)
+		pre := slices.Clone(job.Needs)
 		sort.Strings(pre)
 		phase := v1alpha1.JobPending
 		if len(pre) > 0 {
@@ -166,4 +181,154 @@ func resolvedJobStatuses(jobs map[string]v1alpha1.JobSpec) map[string]v1alpha1.J
 		}
 	}
 	return statuses
+}
+
+func (r *WorkflowRunReconciler) startReadyInlineJobs(ctx context.Context, workflowRun *v1alpha1.WorkflowRun) error {
+	type readyJob struct {
+		name   string
+		spec   v1alpha1.JobSpec
+		status v1alpha1.JobStatus
+	}
+	jobNames := make([]string, 0, len(workflowRun.Spec.Jobs))
+	for jobName := range workflowRun.Spec.Jobs {
+		jobNames = append(jobNames, jobName)
+	}
+	sort.Strings(jobNames)
+	readyJobs := make([]readyJob, 0, len(jobNames))
+	for _, jobName := range jobNames {
+		job := workflowRun.Spec.Jobs[jobName]
+		status := workflowRun.Status.Jobs[jobName]
+		if !jobReadyToStart(status, workflowRun.Status.Jobs) {
+			continue
+		}
+		if len(job.Steps) == 0 || len(status.Steps) == 0 {
+			workflowRun.Status.Phase = v1alpha1.WorkflowFailed
+			if job.Uses != "" {
+				workflowRun.Status.Message = fmt.Sprintf("job %q uses reusable workflow %q, but job-level uses is not implemented yet", jobName, job.Uses)
+			} else {
+				workflowRun.Status.Message = fmt.Sprintf("job %q must contain at least one step before creating child Runs", jobName)
+			}
+			status.Phase = v1alpha1.JobFailed
+			workflowRun.Status.Jobs[jobName] = status
+			return nil
+		}
+		if status.Steps[0].RunName != "" {
+			continue
+		}
+		if job.RunsOn == "" {
+			workflowRun.Status.Phase = v1alpha1.WorkflowFailed
+			workflowRun.Status.Message = fmt.Sprintf("job %q must set runs-on before creating child Runs", jobName)
+			status.Phase = v1alpha1.JobFailed
+			workflowRun.Status.Jobs[jobName] = status
+			return nil
+		}
+		readyJobs = append(readyJobs, readyJob{name: jobName, spec: job, status: status})
+	}
+	for _, ready := range readyJobs {
+		run, err := r.ensureStepRun(ctx, workflowRun, ready.name, ready.spec, ready.spec.Steps[0])
+		if err != nil {
+			return err
+		}
+		status := ready.status
+		status.Phase = v1alpha1.JobRunning
+		status.Steps[0].Phase = v1alpha1.StepRunning
+		status.Steps[0].RunName = run.Name
+		workflowRun.Status.Jobs[ready.name] = status
+		workflowRun.Status.Phase = v1alpha1.WorkflowRunning
+	}
+	return nil
+}
+
+func jobReadyToStart(status v1alpha1.JobStatus, jobs map[string]v1alpha1.JobStatus) bool {
+	if status.Phase != v1alpha1.JobPending && status.Phase != v1alpha1.JobWaiting {
+		return false
+	}
+	for _, pre := range status.Pre {
+		if jobs[pre].Phase != v1alpha1.JobSucceeded {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *WorkflowRunReconciler) ensureStepRun(ctx context.Context, workflowRun *v1alpha1.WorkflowRun, jobName string, job v1alpha1.JobSpec, step v1alpha1.StepSpec) (*v1alpha1.Run, error) {
+	labels := workflowStepLabels(workflowRun, jobName, step.Name)
+	var existing v1alpha1.RunList
+	if err := r.List(ctx, &existing, client.InNamespace(workflowRun.Namespace), client.MatchingLabels(labels)); err != nil {
+		return nil, fmt.Errorf("list child runs for workflowrun %s/%s job %s step %s: %w", workflowRun.Namespace, workflowRun.Name, jobName, step.Name, err)
+	}
+	if len(existing.Items) > 0 {
+		sort.Slice(existing.Items, func(i, j int) bool {
+			return existing.Items[i].Name < existing.Items[j].Name
+		})
+		return &existing.Items[0], nil
+	}
+
+	run := buildStepRun(workflowRun, jobName, job, step, labels)
+	if err := controllerutil.SetControllerReference(workflowRun, run, r.Scheme); err != nil {
+		return nil, fmt.Errorf("set workflowrun owner reference on run %s/%s: %w", run.Namespace, run.Name, err)
+	}
+	if err := r.Create(ctx, run); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return nil, fmt.Errorf("create child run %s/%s: %w", run.Namespace, run.Name, err)
+		}
+		var created v1alpha1.Run
+		if getErr := r.Get(ctx, client.ObjectKeyFromObject(run), &created); getErr != nil {
+			return nil, fmt.Errorf("get existing child run %s/%s after create conflict: %w", run.Namespace, run.Name, getErr)
+		}
+		return &created, nil
+	}
+	return run, nil
+}
+
+func buildStepRun(workflowRun *v1alpha1.WorkflowRun, jobName string, job v1alpha1.JobSpec, step v1alpha1.StepSpec, labels map[string]string) *v1alpha1.Run {
+	inline := step.Run
+	env := make([]corev1.EnvVar, 0, len(step.Env))
+	envNames := make([]string, 0, len(step.Env))
+	for name := range step.Env {
+		envNames = append(envNames, name)
+	}
+	sort.Strings(envNames)
+	for _, name := range envNames {
+		env = append(env, corev1.EnvVar{Name: name, Value: step.Env[name]})
+	}
+	return &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      workflowStepRunName(workflowRun.Name, jobName, step.Name),
+			Namespace: workflowRun.Namespace,
+			Labels:    labels,
+		},
+		Spec: v1alpha1.RunSpec{
+			Runtime: job.RunsOn,
+			Source:  &v1alpha1.CodeSource{Inline: &inline},
+			Mode: v1alpha1.RunMode{Task: &v1alpha1.RunTaskMode{
+				Args: slices.Clone(step.Args),
+			}},
+			Env: env,
+		},
+	}
+}
+
+func workflowStepLabels(workflowRun *v1alpha1.WorkflowRun, jobName string, stepName string) map[string]string {
+	return map[string]string{
+		v1alpha1.WorkflowRunUIDLabel: string(workflowRun.UID),
+		v1alpha1.WorkflowJobLabel:    jobName,
+		v1alpha1.WorkflowStepLabel:   stepName,
+	}
+}
+
+func workflowStepRunName(workflowRunName string, jobName string, stepName string) string {
+	sum := sha256.Sum256([]byte(jobName + "/" + stepName))
+	suffix := hex.EncodeToString(sum[:])[:10]
+	const maxNameLength = 253
+	maxPrefixLength := maxNameLength - len(suffix) - 1
+	prefix := workflowRunName
+	if len(prefix) > maxPrefixLength {
+		prefix = prefix[:maxPrefixLength]
+		prefix = strings.TrimRight(prefix, "-.")
+	}
+	if prefix == "" {
+		return suffix
+	}
+	return prefix + "-" + suffix
 }

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -23,7 +23,7 @@ func TestWorkflowRunReconcilerAcceptsWorkflowRun(t *testing.T) {
 	}
 
 	workflowRun := &v1alpha1.WorkflowRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", Generation: 3},
+		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", UID: "workflowrun-uid", Generation: 3},
 		Spec: v1alpha1.WorkflowRunSpec{
 			Jobs: map[string]v1alpha1.JobSpec{
 				"build": {
@@ -60,12 +60,12 @@ func TestWorkflowRunReconcilerAcceptsWorkflowRun(t *testing.T) {
 	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
 		t.Fatalf("get workflowrun: %v", err)
 	}
-	if updated.Status.Phase != v1alpha1.WorkflowPending {
-		t.Fatalf("phase = %q, want %q", updated.Status.Phase, v1alpha1.WorkflowPending)
+	if updated.Status.Phase != v1alpha1.WorkflowRunning {
+		t.Fatalf("phase = %q, want %q", updated.Status.Phase, v1alpha1.WorkflowRunning)
 	}
 	build := updated.Status.Jobs["build"]
-	if build.Phase != v1alpha1.JobPending {
-		t.Fatalf("build phase = %q, want %q", build.Phase, v1alpha1.JobPending)
+	if build.Phase != v1alpha1.JobRunning {
+		t.Fatalf("build phase = %q, want %q", build.Phase, v1alpha1.JobRunning)
 	}
 	if len(build.Pre) != 0 {
 		t.Fatalf("build pre = %v, want empty", build.Pre)
@@ -74,9 +74,34 @@ func TestWorkflowRunReconcilerAcceptsWorkflowRun(t *testing.T) {
 		t.Fatalf("build steps = %#v, want checkout, package", build.Steps)
 	}
 	for _, step := range build.Steps {
-		if step.Phase != v1alpha1.StepPending {
-			t.Fatalf("step %s phase = %q, want %q", step.Name, step.Phase, v1alpha1.StepPending)
+		if step.Name == "checkout" {
+			if step.Phase != v1alpha1.StepRunning || step.RunName == "" {
+				t.Fatalf("step %s = %#v, want running with runName", step.Name, step)
+			}
+			continue
 		}
+		if step.Phase != v1alpha1.StepPending || step.RunName != "" {
+			t.Fatalf("step %s = %#v, want pending without runName", step.Name, step)
+		}
+	}
+	var childRuns v1alpha1.RunList
+	if err := c.List(context.Background(), &childRuns, client.InNamespace(workflowRun.Namespace)); err != nil {
+		t.Fatalf("list child runs: %v", err)
+	}
+	if len(childRuns.Items) != 1 {
+		t.Fatalf("child runs = %#v, want one first-step run", childRuns.Items)
+	}
+	childRun := childRuns.Items[0]
+	if childRun.Spec.Runtime != "bash" || childRun.Spec.Source == nil || childRun.Spec.Source.Inline == nil || *childRun.Spec.Source.Inline != "git status" {
+		t.Fatalf("child run spec = %#v, want bash inline git status", childRun.Spec)
+	}
+	if childRun.Labels[v1alpha1.WorkflowRunUIDLabel] != string(workflowRun.UID) ||
+		childRun.Labels[v1alpha1.WorkflowJobLabel] != "build" ||
+		childRun.Labels[v1alpha1.WorkflowStepLabel] != "checkout" {
+		t.Fatalf("child run labels = %v, want workflow/job/step labels", childRun.Labels)
+	}
+	if len(childRun.OwnerReferences) != 1 || childRun.OwnerReferences[0].Name != workflowRun.Name {
+		t.Fatalf("owner references = %#v, want WorkflowRun owner", childRun.OwnerReferences)
 	}
 	testJob := updated.Status.Jobs["test"]
 	if testJob.Phase != v1alpha1.JobWaiting {
@@ -85,12 +110,194 @@ func TestWorkflowRunReconcilerAcceptsWorkflowRun(t *testing.T) {
 	if len(testJob.Pre) != 1 || testJob.Pre[0] != "build" {
 		t.Fatalf("test pre = %v, want [build]", testJob.Pre)
 	}
-	cond := apimeta.FindStatusCondition(updated.Status.Conditions, workflowRunAcceptedCondition)
+	cond := apimeta.FindStatusCondition(updated.Status.Conditions, v1alpha1.WorkflowRunAcceptedCondition)
 	if cond == nil {
-		t.Fatalf("missing %s condition", workflowRunAcceptedCondition)
+		t.Fatalf("missing %s condition", v1alpha1.WorkflowRunAcceptedCondition)
 	}
 	if cond.Status != metav1.ConditionTrue || cond.ObservedGeneration != workflowRun.Generation {
 		t.Fatalf("condition = %#v, want true observed generation %d", cond, workflowRun.Generation)
+	}
+}
+
+func TestJobReadyToStartChecksDependencyStatus(t *testing.T) {
+	status := v1alpha1.JobStatus{
+		Phase: v1alpha1.JobWaiting,
+		Pre:   []string{"build"},
+	}
+	jobs := map[string]v1alpha1.JobStatus{
+		"build": {Phase: v1alpha1.JobRunning},
+	}
+	if jobReadyToStart(status, jobs) {
+		t.Fatal("job with running dependency is ready, want not ready")
+	}
+
+	jobs["build"] = v1alpha1.JobStatus{Phase: v1alpha1.JobSucceeded}
+	if !jobReadyToStart(status, jobs) {
+		t.Fatal("job with succeeded dependency is not ready, want ready")
+	}
+}
+
+func TestWorkflowRunReconcilerFailsReadyJobWithoutInlineSteps(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default", UID: "workflowrun-uid", Generation: 3},
+		Spec: v1alpha1.WorkflowRunSpec{
+			Jobs: map[string]v1alpha1.JobSpec{
+				"release": {
+					Uses: "build-and-test",
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(workflowRun).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: workflowRun.Namespace,
+		Name:      workflowRun.Name,
+	}}
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile workflowrun: %v", err)
+	}
+
+	var updated v1alpha1.WorkflowRun
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
+		t.Fatalf("get workflowrun: %v", err)
+	}
+	if updated.Status.Phase != v1alpha1.WorkflowFailed {
+		t.Fatalf("phase = %q, want %q", updated.Status.Phase, v1alpha1.WorkflowFailed)
+	}
+	if !strings.Contains(updated.Status.Message, "job-level uses is not implemented yet") {
+		t.Fatalf("message = %q, want job-level uses not implemented", updated.Status.Message)
+	}
+	if updated.Status.Jobs["release"].Phase != v1alpha1.JobFailed {
+		t.Fatalf("job phase = %q, want %q", updated.Status.Jobs["release"].Phase, v1alpha1.JobFailed)
+	}
+}
+
+func TestWorkflowRunReconcilerReusesExistingFirstStepRun(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", UID: "workflowrun-uid", Generation: 3},
+		Spec: v1alpha1.WorkflowRunSpec{
+			Jobs: map[string]v1alpha1.JobSpec{
+				"build": {
+					RunsOn: "bash",
+					Steps:  []v1alpha1.StepSpec{{Name: "checkout", Run: "git status"}},
+				},
+			},
+		},
+	}
+	existingRun := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-first-step",
+			Namespace: workflowRun.Namespace,
+			Labels:    workflowStepLabels(workflowRun, "build", "checkout"),
+		},
+		Spec: v1alpha1.RunSpec{
+			Runtime: "bash",
+			Source:  &v1alpha1.CodeSource{Inline: ptrTo("git status")},
+			Mode:    v1alpha1.RunMode{Task: &v1alpha1.RunTaskMode{}},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(workflowRun, existingRun).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: workflowRun.Namespace,
+		Name:      workflowRun.Name,
+	}}
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile workflowrun: %v", err)
+	}
+
+	var updated v1alpha1.WorkflowRun
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
+		t.Fatalf("get workflowrun: %v", err)
+	}
+	step := updated.Status.Jobs["build"].Steps[0]
+	if step.RunName != existingRun.Name || step.Phase != v1alpha1.StepRunning {
+		t.Fatalf("step = %#v, want existing run marked running", step)
+	}
+	var childRuns v1alpha1.RunList
+	if err := c.List(context.Background(), &childRuns, client.InNamespace(workflowRun.Namespace)); err != nil {
+		t.Fatalf("list child runs: %v", err)
+	}
+	if len(childRuns.Items) != 1 {
+		t.Fatalf("child runs = %#v, want existing run only", childRuns.Items)
+	}
+}
+
+func TestWorkflowRunReconcilerFailsReadyJobWithoutRuntime(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", UID: "workflowrun-uid", Generation: 3},
+		Spec: v1alpha1.WorkflowRunSpec{
+			Jobs: map[string]v1alpha1.JobSpec{
+				"build": {
+					Steps: []v1alpha1.StepSpec{{Name: "checkout", Run: "git status"}},
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(workflowRun).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{
+		Namespace: workflowRun.Namespace,
+		Name:      workflowRun.Name,
+	}}
+	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("reconcile workflowrun: %v", err)
+	}
+
+	var updated v1alpha1.WorkflowRun
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
+		t.Fatalf("get workflowrun: %v", err)
+	}
+	if updated.Status.Phase != v1alpha1.WorkflowFailed {
+		t.Fatalf("phase = %q, want %q", updated.Status.Phase, v1alpha1.WorkflowFailed)
+	}
+	if updated.Status.Jobs["build"].Phase != v1alpha1.JobFailed {
+		t.Fatalf("build phase = %q, want %q", updated.Status.Jobs["build"].Phase, v1alpha1.JobFailed)
+	}
+	if !strings.Contains(updated.Status.Message, `job "build" must set runs-on`) {
+		t.Fatalf("message = %q, want missing runs-on", updated.Status.Message)
+	}
+	cond := apimeta.FindStatusCondition(updated.Status.Conditions, v1alpha1.WorkflowRunAcceptedCondition)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WorkflowExecutionFailed" {
+		t.Fatalf("condition = %#v, want execution failure", cond)
+	}
+	var childRuns v1alpha1.RunList
+	if err := c.List(context.Background(), &childRuns, client.InNamespace(workflowRun.Namespace)); err != nil {
+		t.Fatalf("list child runs: %v", err)
+	}
+	if len(childRuns.Items) != 0 {
+		t.Fatalf("child runs = %#v, want none", childRuns.Items)
 	}
 }
 
@@ -218,7 +425,7 @@ func TestWorkflowRunReconcilerResolvesReusableWorkflow(t *testing.T) {
 	if got := updated.Status.Jobs["test"]; got.Phase != v1alpha1.JobWaiting || len(got.Pre) != 1 || got.Pre[0] != "build" {
 		t.Fatalf("test status = %#v, want waiting on build", got)
 	}
-	cond := apimeta.FindStatusCondition(updated.Status.Conditions, workflowRunAcceptedCondition)
+	cond := apimeta.FindStatusCondition(updated.Status.Conditions, v1alpha1.WorkflowRunAcceptedCondition)
 	if cond == nil || cond.Status != metav1.ConditionTrue {
 		t.Fatalf("condition = %#v, want accepted true", cond)
 	}
@@ -264,7 +471,7 @@ func TestWorkflowRunReconcilerFailsWhenReusableWorkflowMissing(t *testing.T) {
 	if !strings.Contains(updated.Status.Message, "missing-workflow") {
 		t.Fatalf("message = %q, want missing workflow name", updated.Status.Message)
 	}
-	cond := apimeta.FindStatusCondition(updated.Status.Conditions, workflowRunAcceptedCondition)
+	cond := apimeta.FindStatusCondition(updated.Status.Conditions, v1alpha1.WorkflowRunAcceptedCondition)
 	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WorkflowResolutionFailed" {
 		t.Fatalf("condition = %#v, want resolution failure", cond)
 	}
@@ -325,7 +532,7 @@ func TestWorkflowRunReconcilerFailsWhenWorkflowInputUnknown(t *testing.T) {
 	if !strings.Contains(updated.Status.Message, `unknown input "unknown"`) {
 		t.Fatalf("message = %q, want unknown input", updated.Status.Message)
 	}
-	cond := apimeta.FindStatusCondition(updated.Status.Conditions, workflowRunAcceptedCondition)
+	cond := apimeta.FindStatusCondition(updated.Status.Conditions, v1alpha1.WorkflowRunAcceptedCondition)
 	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WorkflowInputBindingFailed" {
 		t.Fatalf("condition = %#v, want input binding failure", cond)
 	}
@@ -382,7 +589,7 @@ func TestWorkflowRunReconcilerFailsWhenWorkflowInputRequired(t *testing.T) {
 	if !strings.Contains(updated.Status.Message, `missing required input "ref"`) {
 		t.Fatalf("message = %q, want missing required input", updated.Status.Message)
 	}
-	cond := apimeta.FindStatusCondition(updated.Status.Conditions, workflowRunAcceptedCondition)
+	cond := apimeta.FindStatusCondition(updated.Status.Conditions, v1alpha1.WorkflowRunAcceptedCondition)
 	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WorkflowInputBindingFailed" {
 		t.Fatalf("condition = %#v, want input binding failure", cond)
 	}
@@ -402,4 +609,8 @@ func TestBindWorkflowInputsAppliesDefaults(t *testing.T) {
 	if bound["ref"] != "main" || bound["target"] != "linux-amd64" {
 		t.Fatalf("bound inputs = %#v, want ref and default target", bound)
 	}
+}
+
+func ptrTo(value string) *string {
+	return &value
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1266,22 +1266,6 @@ func TestPythonInlineRun(t *testing.T) {
 	t.Logf("Python Run completed successfully: %s", run.Status.Message)
 }
 
-func TestWorkflowSingleJob(t *testing.T) {
-	t.Skip("Workflow execution moved to WorkflowRun; restore coverage with WorkflowRun execution")
-}
-
-func TestWorkflowChildRunCancellationFailsWorkflow(t *testing.T) {
-	t.Skip("Workflow execution moved to WorkflowRun; restore cancellation coverage with WorkflowRun execution")
-}
-
-func TestWorkflowLongNamesCreateHashedChildRun(t *testing.T) {
-	t.Skip("Workflow execution moved to WorkflowRun; restore child Run naming coverage with WorkflowRun execution")
-}
-
-func TestWorkflowStepOutputs(t *testing.T) {
-	t.Skip("Workflow execution moved to WorkflowRun; restore output coverage with WorkflowRun execution")
-}
-
 func TestRunInvalidOutputsDoesNotRetry(t *testing.T) {
 	ensureRuntime(t, "bash", bashRuntimeImage(), 9091)
 
@@ -1396,10 +1380,6 @@ echo "succeeded on attempt $count"
 		t.Fatalf("expected at least 3 attempts, got %d", run.Status.Attempt)
 	}
 	t.Logf("Run succeeded after %d attempts: %s", run.Status.Attempt, run.Status.Message)
-}
-
-func TestWorkflowTopoOrder(t *testing.T) {
-	t.Skip("Workflow execution moved to WorkflowRun; restore ordering coverage with WorkflowRun execution")
 }
 
 func TestStaleRunNoRetry(t *testing.T) {


### PR DESCRIPTION
## Summary
- create the first child Run for each ready inline WorkflowRun job
- record the child Run name on the matching ordered step status and mark the job/step running
- make first-step creation idempotent by discovering existing child Runs through workflow/job/step labels
- fail ready inline jobs early when `runs-on` is missing, before creating child Runs
- remove stale skipped E2E tests for the old Workflow execution model
- update workflow reuse docs and roadmap status in English and Chinese

## Scope
- Does not observe child Run terminal status yet.
- Does not create next-step Runs yet.
- Does not implement job or WorkflowRun success completion yet.

## Validation
- E2E audit: `rg -n 'TestWorkflow|Workflow execution moved to WorkflowRun|t\\.Skip\\(\"Workflow' test/e2e` returned no stale old-Workflow E2E stubs\n- `GOCACHE=/tmp/go-build make generate manifests`\n- `GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/controller -count=1`\n- `GOCACHE=/tmp/go-build make test`\n- `GOCACHE=/tmp/go-build make test-integration`\n- `GOBIN=/tmp/kruntimes-bin make site-build`\n- `GOCACHE=/tmp/go-build make e2e`\n- `git diff --check`