### PR TITLE
feat(controller): observe WorkflowRun child Runs

### DIFF
--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -338,6 +338,11 @@ durable and restart-safe, and keeps new execution states explicit as child Run
 observation, next-step creation, restart recovery, and reusable call expansion
 land.
 
+For an active WorkflowRun, `ObserveChildRuns` takes precedence over
+`StartReadyJobs`. When a child Run reaches a terminal phase, that reconciliation
+only copies the phase into the matching step status. The next reconciliation
+may then decide whether to create a next step or unblock dependent jobs.
+
 Inline WorkflowRun execution should land in small, reviewable steps:
 
 1. Before changing execution behavior, audit the existing E2E tests. Remove or

--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -482,5 +482,8 @@ Current implementation status:
 - Inline WorkflowRuns create first-step child Runs for ready inline jobs and
   record the child Run name in ordered step status. Child Run result
   observation and next-step creation are still follow-up work.
+- WorkflowRuns observe terminal child Run phases and copy them into the
+  matching step status. Next-step creation and job/WorkflowRun terminal
+  handling are still follow-up work.
 - Old Workflow execution E2E coverage is skipped until WorkflowRun execution
   lands.

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -319,6 +319,10 @@ WorkflowRun 仍然可能在执行时失败。
 都是 durable 且 restart-safe 的；后续引入 child Run observation、next-step creation、restart
 recovery 和 reusable call expansion 等 execution states 时，状态也会保持显式。
 
+对于 active WorkflowRun，`ObserveChildRuns` 的优先级高于 `StartReadyJobs`。当 child Run
+进入 terminal phase 时，该次 reconciliation 只将 phase 复制到对应的 step status。下一次
+reconciliation 才能决定是否创建 next step 或解除 dependency jobs 的阻塞。
+
 Inline WorkflowRun execution 应拆成小的、可 review 的步骤落地：
 
 1. 在修改 execution behavior 前，先审计现有 E2E tests。移除或更新仍在测试旧

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -450,4 +450,6 @@ status:
 - Inline WorkflowRuns 会为 ready inline jobs 创建 first-step child Runs，并将 child
   Run name 记录到有序 step status 中。Child Run result observation 和 next-step
   creation 仍是后续工作。
+- WorkflowRuns 会观察 terminal child Run phases，并复制到匹配的 step status。
+  Next-step creation 和 job/WorkflowRun terminal handling 仍是后续工作。
 - 旧 Workflow execution E2E coverage 暂时 skip，等待 WorkflowRun execution 实现后恢复。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -212,7 +212,7 @@ wiring from accumulating avoidable conflicts.
   - [x] implement inline WorkflowRun first-step Run creation for ready jobs;
   - [x] refactor WorkflowRun controller reconciliation into a load/plan/apply
     state-machine structure before adding more execution cases;
-  - implement child Run status observation and step status updates;
+  - [x] implement child Run status observation and step status updates;
   - implement next-step creation, job terminal handling, and WorkflowRun
     terminal handling;
   - implement controller restart recovery for in-progress inline WorkflowRuns;

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -181,7 +181,7 @@ controller wiring 累积不必要的冲突。
   - [x] 实现 ready jobs 的 inline WorkflowRun first-step Run creation；
   - [x] 在增加更多 execution cases 前，将 WorkflowRun controller reconciliation
     重构为 load/plan/apply 的状态机结构；
-  - 实现 child Run status observation 和 step status updates；
+  - [x] 实现 child Run status observation 和 step status updates；
   - 实现 next-step creation、job terminal handling 和 WorkflowRun terminal handling；
   - 实现 in-progress inline WorkflowRuns 的 controller restart recovery；
   - 实现 job-level reusable Workflow calls；

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -47,9 +47,10 @@ const (
 type workflowRunAction string
 
 const (
-	workflowRunActionNone           workflowRunAction = "None"
-	workflowRunActionInitialize     workflowRunAction = "Initialize"
-	workflowRunActionStartReadyJobs workflowRunAction = "StartReadyJobs"
+	workflowRunActionNone             workflowRunAction = "None"
+	workflowRunActionInitialize       workflowRunAction = "Initialize"
+	workflowRunActionObserveChildRuns workflowRunAction = "ObserveChildRuns"
+	workflowRunActionStartReadyJobs   workflowRunAction = "StartReadyJobs"
 )
 
 type workflowRunResources struct {
@@ -135,6 +136,10 @@ func planWorkflowRun(resources *workflowRunResources) workflowRunPlan {
 	if state == workflowRunStateTerminal || len(workflowRun.Spec.Jobs) == 0 || len(workflowRun.Status.Jobs) == 0 {
 		return plan
 	}
+	if childRunsNeedObservation(resources) {
+		plan.action = workflowRunActionObserveChildRuns
+		return plan
+	}
 
 	jobNames := make([]string, 0, len(workflowRun.Spec.Jobs))
 	for jobName := range workflowRun.Spec.Jobs {
@@ -195,6 +200,9 @@ func (r *WorkflowRunReconciler) applyWorkflowRunAction(ctx context.Context, reso
 	switch plan.action {
 	case workflowRunActionInitialize:
 		return r.applyInitializeWorkflowRun(ctx, workflowRun)
+	case workflowRunActionObserveChildRuns:
+		applyObserveChildRuns(resources)
+		return nil
 	case workflowRunActionStartReadyJobs:
 		return r.applyStartReadyJobs(ctx, resources, plan.jobs)
 	}
@@ -205,6 +213,7 @@ func (r *WorkflowRunReconciler) applyWorkflowRunAction(ctx context.Context, reso
 func (r *WorkflowRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.WorkflowRun{}).
+		Owns(&v1alpha1.Run{}).
 		Complete(r)
 }
 
@@ -375,6 +384,76 @@ func jobReadyToStart(status v1alpha1.JobStatus, jobs map[string]v1alpha1.JobStat
 		}
 	}
 	return true
+}
+
+func childRunsNeedObservation(resources *workflowRunResources) bool {
+	workflowRun := resources.workflowRun
+	for _, run := range resources.childRuns {
+		stepPhase, terminal := terminalRunStepPhase(run.Status.Phase)
+		if !terminal {
+			continue
+		}
+		jobStatus, ok := workflowRun.Status.Jobs[run.Labels[v1alpha1.WorkflowJobLabel]]
+		if !ok {
+			continue
+		}
+		for _, step := range jobStatus.Steps {
+			if step.Name != run.Labels[v1alpha1.WorkflowStepLabel] {
+				continue
+			}
+			if (step.RunName == "" || step.RunName == run.Name) && (step.RunName != run.Name || step.Phase != stepPhase) {
+				return true
+			}
+			break
+		}
+	}
+	return false
+}
+
+func applyObserveChildRuns(resources *workflowRunResources) {
+	workflowRun := resources.workflowRun
+	keys := make([]string, 0, len(resources.childRuns))
+	for key := range resources.childRuns {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		run := resources.childRuns[key]
+		stepPhase, terminal := terminalRunStepPhase(run.Status.Phase)
+		if !terminal {
+			continue
+		}
+		jobName := run.Labels[v1alpha1.WorkflowJobLabel]
+		stepName := run.Labels[v1alpha1.WorkflowStepLabel]
+		jobStatus, ok := workflowRun.Status.Jobs[jobName]
+		if !ok {
+			continue
+		}
+		for i := range jobStatus.Steps {
+			step := &jobStatus.Steps[i]
+			if step.Name != stepName {
+				continue
+			}
+			if step.RunName != "" && step.RunName != run.Name {
+				break
+			}
+			step.RunName = run.Name
+			step.Phase = stepPhase
+			workflowRun.Status.Jobs[jobName] = jobStatus
+			break
+		}
+	}
+}
+
+func terminalRunStepPhase(phase v1alpha1.RunPhase) (v1alpha1.StepPhase, bool) {
+	switch phase {
+	case v1alpha1.RunSucceeded:
+		return v1alpha1.StepSucceeded, true
+	case v1alpha1.RunFailed, v1alpha1.RunTimeout, v1alpha1.RunCancelled:
+		return v1alpha1.StepFailed, true
+	default:
+		return "", false
+	}
 }
 
 func buildStepRun(workflowRun *v1alpha1.WorkflowRun, jobName string, job v1alpha1.JobSpec, step v1alpha1.StepSpec, labels map[string]string) *v1alpha1.Run {

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -169,6 +169,31 @@ func TestPlanWorkflowRunSeparatesCurrentStateFromAction(t *testing.T) {
 	}
 }
 
+func TestPlanWorkflowRunObservesChildRunsBeforeStartingReadyJobs(t *testing.T) {
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{UID: "workflowrun-uid"},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"build": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}}},
+			"lint":  {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "check", Run: "make lint"}}},
+		}},
+		Status: v1alpha1.WorkflowRunStatus{
+			Phase: v1alpha1.WorkflowRunning,
+			Jobs: map[string]v1alpha1.JobStatus{
+				"build": {Phase: v1alpha1.JobRunning, Steps: []v1alpha1.StepStatus{{Name: "compile", Phase: v1alpha1.StepRunning, RunName: "build-run"}}},
+				"lint":  {Phase: v1alpha1.JobPending, Steps: []v1alpha1.StepStatus{{Name: "check", Phase: v1alpha1.StepPending}}},
+			},
+		},
+	}
+	buildRun := workflowChildRun(workflowRun, "build", "compile", "build-run", v1alpha1.RunSucceeded)
+	plan := planWorkflowRun(&workflowRunResources{
+		workflowRun: workflowRun,
+		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): buildRun},
+	})
+	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionObserveChildRuns {
+		t.Fatalf("plan = %#v, want Running + ObserveChildRuns", plan)
+	}
+}
+
 func TestJobReadyToStartChecksDependencyStatus(t *testing.T) {
 	status := v1alpha1.JobStatus{
 		Phase: v1alpha1.JobWaiting,
@@ -346,6 +371,57 @@ func TestWorkflowRunReconcilerRejectsJobWithoutRuntimeDuringInitialization(t *te
 	}
 	if len(childRuns.Items) != 0 {
 		t.Fatalf("child runs = %#v, want none", childRuns.Items)
+	}
+}
+
+func TestWorkflowRunReconcilerObservesTerminalChildRuns(t *testing.T) {
+	for _, test := range []struct {
+		runPhase  v1alpha1.RunPhase
+		stepPhase v1alpha1.StepPhase
+	}{
+		{runPhase: v1alpha1.RunSucceeded, stepPhase: v1alpha1.StepSucceeded},
+		{runPhase: v1alpha1.RunFailed, stepPhase: v1alpha1.StepFailed},
+		{runPhase: v1alpha1.RunTimeout, stepPhase: v1alpha1.StepFailed},
+		{runPhase: v1alpha1.RunCancelled, stepPhase: v1alpha1.StepFailed},
+	} {
+		t.Run(string(test.runPhase), func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := v1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatalf("add scheme: %v", err)
+			}
+			workflowRun := &v1alpha1.WorkflowRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", UID: "workflowrun-uid"},
+				Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+					"build": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}}},
+				}},
+				Status: v1alpha1.WorkflowRunStatus{
+					Phase: v1alpha1.WorkflowRunning,
+					Jobs: map[string]v1alpha1.JobStatus{
+						"build": {Phase: v1alpha1.JobRunning, Steps: []v1alpha1.StepStatus{{Name: "compile", Phase: v1alpha1.StepRunning, RunName: "build-run"}}},
+					},
+				},
+			}
+			run := workflowChildRun(workflowRun, "build", "compile", "build-run", test.runPhase)
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(workflowRun, run).
+				WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+				Build()
+			reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+			reconcileWorkflowRun(t, reconciler, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(workflowRun)}, 1)
+
+			var updated v1alpha1.WorkflowRun
+			if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
+				t.Fatalf("get workflowrun: %v", err)
+			}
+			step := updated.Status.Jobs["build"].Steps[0]
+			if step.Phase != test.stepPhase || step.RunName != run.Name {
+				t.Fatalf("step = %#v, want %s %s", step, test.stepPhase, run.Name)
+			}
+			if updated.Status.Jobs["build"].Phase != v1alpha1.JobRunning || updated.Status.Phase != v1alpha1.WorkflowRunning {
+				t.Fatalf("status = %#v, want job and workflow to remain running", updated.Status)
+			}
+		})
 	}
 }
 
@@ -670,5 +746,21 @@ func assertChildRunCount(t *testing.T, c client.Client, namespace string, want i
 	}
 	if len(runs.Items) != want {
 		t.Fatalf("child runs = %#v, want %d", runs.Items, want)
+	}
+}
+
+func workflowChildRun(workflowRun *v1alpha1.WorkflowRun, jobName string, stepName string, runName string, phase v1alpha1.RunPhase) *v1alpha1.Run {
+	return &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      runName,
+			Namespace: workflowRun.Namespace,
+			Labels:    workflowStepLabels(workflowRun, jobName, stepName),
+		},
+		Spec: v1alpha1.RunSpec{
+			Runtime: "bash",
+			Source:  &v1alpha1.CodeSource{Inline: ptrTo("make build")},
+			Mode:    v1alpha1.RunMode{Task: &v1alpha1.RunTaskMode{}},
+		},
+		Status: v1alpha1.RunStatus{Phase: phase},
 	}
 }


### PR DESCRIPTION
## Summary
- watch child `Run` objects owned by `WorkflowRun`
- observe terminal child Run phases and copy them into matching ordered step status
- map `RunSucceeded` to `StepSucceeded` and failed/timeout/cancelled Run phases to `StepFailed`
- keep next-step creation and job/WorkflowRun terminal handling out of scope
- update workflow reuse docs and roadmap status in English and Chinese

## Stacked PR
- Base branch: `feat/workflowrun-first-step`
- Depends on #266. Rebase this PR onto `main` after #266 merges.

## Validation
- `GOCACHE=/tmp/go-build make generate manifests`
- `GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/controller -count=1`
- `GOCACHE=/tmp/go-build make test`
- `GOCACHE=/tmp/go-build make test-integration`
- `GOBIN=/tmp/kruntimes-bin make site-build`
- `git diff --check`

E2E was not rerun here because #266 already passed `make e2e`; this stacked PR only adds controller unit-tested observation logic and does not alter e2e manifests.