### PR TITLE
refactor(controller): structure WorkflowRun reconciliation

### DIFF
--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -321,10 +321,13 @@ Runs remain the durable execution records, and scheduler/runtimed continue to
 operate only on Runs.
 
 The WorkflowRun controller should keep reconciliation structured as
-load/plan/apply: load the WorkflowRun and related resources, plan the next
-execution state, switch on that state, and apply the resulting Kubernetes
-writes. This keeps new execution states explicit as child Run observation,
-next-step creation, restart recovery, and reusable call expansion land.
+load/plan/apply: load the WorkflowRun and all child Runs, derive the current
+state, compare it with the desired state, and plan exactly one operation. It
+then applies that operation and patches WorkflowRun status. A reconciliation
+must not loop through multiple operations or create multiple child Runs before
+the status update. This makes each transition durable and restart-safe, and
+keeps new execution states explicit as child Run observation, next-step
+creation, restart recovery, and reusable call expansion land.
 
 Inline WorkflowRun execution should land in small, reviewable steps:
 

--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -322,12 +322,15 @@ operate only on Runs.
 
 The WorkflowRun controller should keep reconciliation structured as
 load/plan/apply: load the WorkflowRun and all child Runs, derive the current
-state, compare it with the desired state, and plan exactly one operation. It
-then applies that operation and patches WorkflowRun status. A reconciliation
-must not loop through multiple operations or create multiple child Runs before
-the status update. This makes each transition durable and restart-safe, and
-keeps new execution states explicit as child Run observation, next-step
-creation, restart recovery, and reusable call expansion land.
+state, compare it with the desired state, and plan exactly one state
+transition. It then applies that transition and patches WorkflowRun status.
+A reconciliation must not loop through multiple state transitions before the
+status update. One `StartReadyJobs` transition may materialize every
+independent ready job, so those jobs remain parallel; it must not advance those
+jobs to a later execution state in the same reconciliation. This makes each
+transition durable and restart-safe, and keeps new execution states explicit as
+child Run observation, next-step creation, restart recovery, and reusable call
+expansion land.
 
 Inline WorkflowRun execution should land in small, reviewable steps:
 

--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -320,6 +320,12 @@ This deliberately avoids adding a separate WorkflowRunInvocation API. Child
 Runs remain the durable execution records, and scheduler/runtimed continue to
 operate only on Runs.
 
+The WorkflowRun controller should keep reconciliation structured as
+load/plan/apply: load the WorkflowRun and related resources, plan the next
+execution state, switch on that state, and apply the resulting Kubernetes
+writes. This keeps new execution states explicit as child Run observation,
+next-step creation, restart recovery, and reusable call expansion land.
+
 Inline WorkflowRun execution should land in small, reviewable steps:
 
 1. Before changing execution behavior, audit the existing E2E tests. Remove or
@@ -431,18 +437,20 @@ the implementation lands.
    `WorkflowRun.spec.uses` resolution.
 6. Implement input binding for top-level reusable Workflow calls.
 7. Implement inline WorkflowRun first-step Run creation for ready jobs.
-8. Implement child Run status observation and step status updates.
-9. Implement next-step creation, job terminal handling, and WorkflowRun
+8. Refactor WorkflowRun controller reconciliation into a load/plan/apply
+   state-machine structure.
+9. Implement child Run status observation and step status updates.
+10. Implement next-step creation, job terminal handling, and WorkflowRun
    terminal handling.
-10. Implement controller restart recovery for in-progress inline WorkflowRuns.
-11. Implement job-level reusable Workflow calls.
-12. Implement step-level Action expansion.
-13. Implement expression evaluation and output propagation.
-14. Update CLI verbs and docs to use `WorkflowRun` for execution.
-15. Add E2E coverage for inline `WorkflowRun`, reusable Workflow calls, Action
+11. Implement controller restart recovery for in-progress inline WorkflowRuns.
+12. Implement job-level reusable Workflow calls.
+13. Implement step-level Action expansion.
+14. Implement expression evaluation and output propagation.
+15. Update CLI verbs and docs to use `WorkflowRun` for execution.
+16. Add E2E coverage for inline `WorkflowRun`, reusable Workflow calls, Action
     calls, validation failures, output propagation, and controller restart
     recovery from the status DAG edges.
-16. Update the final v0.x demos after the reusable model is implemented.
+17. Update the final v0.x demos after the reusable model is implemented.
 
 Current implementation status:
 

--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -321,16 +321,22 @@ Runs remain the durable execution records, and scheduler/runtimed continue to
 operate only on Runs.
 
 The WorkflowRun controller should keep reconciliation structured as
-load/plan/apply: load the WorkflowRun and all child Runs, derive the current
-state, compare it with the desired state, and plan exactly one state
-transition. It then applies that transition and patches WorkflowRun status.
+load/plan/apply: load the WorkflowRun and all child Runs, derive its current
+state, choose one action for that state, apply the action, and patch
+WorkflowRun status. Current state and action are intentionally separate. The
+initial `Empty` state has an `Initialize` action, which validates controller-
+level semantics, resolves references and inputs, persists the execution graph,
+and sets `Accepted=True`. A failed initialization sets `Accepted=False` and
+does not create child Runs. Later execution actions must not modify `Accepted`:
+an accepted WorkflowRun can still fail while executing.
+
 A reconciliation must not loop through multiple state transitions before the
-status update. One `StartReadyJobs` transition may materialize every
-independent ready job, so those jobs remain parallel; it must not advance those
-jobs to a later execution state in the same reconciliation. This makes each
-transition durable and restart-safe, and keeps new execution states explicit as
-child Run observation, next-step creation, restart recovery, and reusable call
-expansion land.
+status update. One `StartReadyJobs` action may materialize every independent
+ready job, so those jobs remain parallel; it must not advance those jobs to a
+later execution state in the same reconciliation. This makes each transition
+durable and restart-safe, and keeps new execution states explicit as child Run
+observation, next-step creation, restart recovery, and reusable call expansion
+land.
 
 Inline WorkflowRun execution should land in small, reviewable steps:
 

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -306,13 +306,18 @@ runtimed 理解 Workflow 概念。
 scheduler/runtimed 仍然只操作 Runs。
 
 WorkflowRun controller 的 reconciliation 应保持 load/plan/apply 结构：加载
-WorkflowRun 和所有 child Runs，推导 current state，与 desired state 比较，并且只规划一个
-state transition。随后执行该 transition，再 patch WorkflowRun status。一次 reconciliation
-不能在 status 更新前循环执行多个 state transitions。一个 `StartReadyJobs` transition 可以
-materialize 所有彼此独立的 ready jobs，以保持 jobs 的并行性；但不能在同一次 reconciliation
-中把它们推进到更后的 execution state。这样每个 transition 都是 durable 且 restart-safe 的；
-后续引入 child Run observation、next-step creation、restart recovery 和 reusable call
-expansion 等 execution states 时，状态也会保持显式。
+WorkflowRun 和所有 child Runs，推导 current state，为该 state 选择一个 action，执行 action，
+再 patch WorkflowRun status。current state 与 action 有意分离。初始的 `Empty` state 对应
+`Initialize` action：它负责 validation controller-level semantics、resolve references 和
+inputs、persist execution graph，并设置 `Accepted=True`。初始化失败时设置 `Accepted=False`，
+且不能创建 child Runs。后续 execution actions 不得修改 `Accepted`：已经 accepted 的
+WorkflowRun 仍然可能在执行时失败。
+
+一次 reconciliation 不能在 status 更新前循环执行多个 state transitions。一个
+`StartReadyJobs` action 可以 materialize 所有彼此独立的 ready jobs，以保持 jobs 的并行性；
+但不能在同一次 reconciliation 中把它们推进到更后的 execution state。这样每个 transition
+都是 durable 且 restart-safe 的；后续引入 child Run observation、next-step creation、restart
+recovery 和 reusable call expansion 等 execution states 时，状态也会保持显式。
 
 Inline WorkflowRun execution 应拆成小的、可 review 的步骤落地：
 

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -306,9 +306,11 @@ runtimed 理解 Workflow 概念。
 scheduler/runtimed 仍然只操作 Runs。
 
 WorkflowRun controller 的 reconciliation 应保持 load/plan/apply 结构：加载
-WorkflowRun 和相关资源，规划下一个 execution state，根据 state 做 switch，再执行对应的
-Kubernetes writes。这样在继续加入 child Run observation、next-step creation、restart
-recovery 和 reusable call expansion 时，每个 execution state 都保持显式。
+WorkflowRun 和所有 child Runs，推导 current state，与 desired state 比较，并且只规划一个
+operation。随后执行该 operation，再 patch WorkflowRun status。一次 reconciliation 不能循环
+执行多个 operation，也不能在 status 更新前创建多个 child Runs。这样每个 transition 都是
+durable 且 restart-safe 的；后续引入 child Run observation、next-step creation、restart
+recovery 和 reusable call expansion 等 execution states 时，状态也会保持显式。
 
 Inline WorkflowRun execution 应拆成小的、可 review 的步骤落地：
 

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -305,6 +305,11 @@ runtimed 理解 Workflow 概念。
 这有意避免增加单独的 WorkflowRunInvocation API。Child Runs 仍然是持久 execution records，
 scheduler/runtimed 仍然只操作 Runs。
 
+WorkflowRun controller 的 reconciliation 应保持 load/plan/apply 结构：加载
+WorkflowRun 和相关资源，规划下一个 execution state，根据 state 做 switch，再执行对应的
+Kubernetes writes。这样在继续加入 child Run observation、next-step creation、restart
+recovery 和 reusable call expansion 时，每个 execution state 都保持显式。
+
 Inline WorkflowRun execution 应拆成小的、可 review 的步骤落地：
 
 1. 在修改 execution behavior 前，先审计现有 E2E tests。移除或更新仍在测试旧
@@ -406,17 +411,18 @@ status:
    namespace-local resolution。
 6. 实现 top-level reusable Workflow calls 的 input binding。
 7. 实现 ready jobs 的 inline WorkflowRun first-step Run creation。
-8. 实现 child Run status observation 和 step status updates。
-9. 实现 next-step creation、job terminal handling 和 WorkflowRun terminal handling。
-10. 实现 in-progress inline WorkflowRuns 的 controller restart recovery。
-11. 实现 job-level reusable Workflow calls。
-12. 实现 step-level Action expansion。
-13. 实现 expression evaluation 和 output propagation。
-14. 更新 CLI verbs 和 docs，使 execution 使用 `WorkflowRun`。
-15. 增加 E2E 覆盖 inline `WorkflowRun`、reusable Workflow calls、Action calls、
+8. 将 WorkflowRun controller reconciliation 重构为 load/plan/apply 的状态机结构。
+9. 实现 child Run status observation 和 step status updates。
+10. 实现 next-step creation、job terminal handling 和 WorkflowRun terminal handling。
+11. 实现 in-progress inline WorkflowRuns 的 controller restart recovery。
+12. 实现 job-level reusable Workflow calls。
+13. 实现 step-level Action expansion。
+14. 实现 expression evaluation 和 output propagation。
+15. 更新 CLI verbs 和 docs，使 execution 使用 `WorkflowRun`。
+16. 增加 E2E 覆盖 inline `WorkflowRun`、reusable Workflow calls、Action calls、
     validation failures、output propagation，以及从 status DAG edges 进行 controller
     restart recovery。
-16. reusable model 实现后，更新最终 v0.x demos。
+17. reusable model 实现后，更新最终 v0.x demos。
 
 当前实现状态：
 

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -307,10 +307,12 @@ scheduler/runtimed 仍然只操作 Runs。
 
 WorkflowRun controller 的 reconciliation 应保持 load/plan/apply 结构：加载
 WorkflowRun 和所有 child Runs，推导 current state，与 desired state 比较，并且只规划一个
-operation。随后执行该 operation，再 patch WorkflowRun status。一次 reconciliation 不能循环
-执行多个 operation，也不能在 status 更新前创建多个 child Runs。这样每个 transition 都是
-durable 且 restart-safe 的；后续引入 child Run observation、next-step creation、restart
-recovery 和 reusable call expansion 等 execution states 时，状态也会保持显式。
+state transition。随后执行该 transition，再 patch WorkflowRun status。一次 reconciliation
+不能在 status 更新前循环执行多个 state transitions。一个 `StartReadyJobs` transition 可以
+materialize 所有彼此独立的 ready jobs，以保持 jobs 的并行性；但不能在同一次 reconciliation
+中把它们推进到更后的 execution state。这样每个 transition 都是 durable 且 restart-safe 的；
+后续引入 child Run observation、next-step creation、restart recovery 和 reusable call
+expansion 等 execution states 时，状态也会保持显式。
 
 Inline WorkflowRun execution 应拆成小的、可 review 的步骤落地：
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -210,7 +210,7 @@ wiring from accumulating avoidable conflicts.
     update stale cases that still use the old Workflow execution model so
     `make e2e` stays passing during the migration;
   - [x] implement inline WorkflowRun first-step Run creation for ready jobs;
-  - refactor WorkflowRun controller reconciliation into a load/plan/apply
+  - [x] refactor WorkflowRun controller reconciliation into a load/plan/apply
     state-machine structure before adding more execution cases;
   - implement child Run status observation and step status updates;
   - implement next-step creation, job terminal handling, and WorkflowRun

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -179,7 +179,7 @@ controller wiring 累积不必要的冲突。
   - [x] 在 inline execution changes 开始前审计现有 E2E tests，移除或更新仍使用旧
     Workflow execution model 的失效 cases，保证迁移过程中 `make e2e` 始终可以通过；
   - [x] 实现 ready jobs 的 inline WorkflowRun first-step Run creation；
-  - 在增加更多 execution cases 前，将 WorkflowRun controller reconciliation
+  - [x] 在增加更多 execution cases 前，将 WorkflowRun controller reconciliation
     重构为 load/plan/apply 的状态机结构；
   - 实现 child Run status observation 和 step status updates；
   - 实现 next-step creation、job terminal handling 和 WorkflowRun terminal handling；

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -38,11 +38,10 @@ func (e *workflowInputBindingError) Unwrap() error {
 type workflowRunReconcileState string
 
 const (
-	workflowRunStateResolveJobs        workflowRunReconcileState = "ResolveJobs"
-	workflowRunStateCreateFirstStepRun workflowRunReconcileState = "CreateFirstStepRun"
-	workflowRunStateRecordFirstStepRun workflowRunReconcileState = "RecordFirstStepRun"
-	workflowRunStateFailReadyJob       workflowRunReconcileState = "FailReadyJob"
-	workflowRunStatePatchStatus        workflowRunReconcileState = "PatchStatus"
+	workflowRunStateResolveJobs    workflowRunReconcileState = "ResolveJobs"
+	workflowRunStateStartReadyJobs workflowRunReconcileState = "StartReadyJobs"
+	workflowRunStateFailReadyJob   workflowRunReconcileState = "FailReadyJob"
+	workflowRunStatePatchStatus    workflowRunReconcileState = "PatchStatus"
 )
 
 type workflowRunResources struct {
@@ -52,7 +51,7 @@ type workflowRunResources struct {
 
 type workflowRunPlan struct {
 	state workflowRunReconcileState
-	job   string
+	jobs  []string
 }
 
 // WorkflowRunReconciler owns WorkflowRun execution-instance status.
@@ -146,6 +145,7 @@ func planWorkflowRun(resources *workflowRunResources) workflowRunPlan {
 		jobNames = append(jobNames, jobName)
 	}
 	sort.Strings(jobNames)
+	readyJobs := make([]string, 0, len(jobNames))
 	for _, jobName := range jobNames {
 		job := workflowRun.Spec.Jobs[jobName]
 		status := workflowRun.Status.Jobs[jobName]
@@ -153,15 +153,15 @@ func planWorkflowRun(resources *workflowRunResources) workflowRunPlan {
 			continue
 		}
 		if len(job.Steps) == 0 || len(status.Steps) == 0 || job.RunsOn == "" {
-			return workflowRunPlan{state: workflowRunStateFailReadyJob, job: jobName}
+			return workflowRunPlan{state: workflowRunStateFailReadyJob, jobs: []string{jobName}}
 		}
 		if status.Steps[0].RunName != "" {
 			continue
 		}
-		if _, ok := resources.childRuns[workflowStepKey(jobName, job.Steps[0].Name)]; ok {
-			return workflowRunPlan{state: workflowRunStateRecordFirstStepRun, job: jobName}
-		}
-		return workflowRunPlan{state: workflowRunStateCreateFirstStepRun, job: jobName}
+		readyJobs = append(readyJobs, jobName)
+	}
+	if len(readyJobs) > 0 {
+		return workflowRunPlan{state: workflowRunStateStartReadyJobs, jobs: readyJobs}
 	}
 
 	return workflowRunPlan{state: workflowRunStatePatchStatus}
@@ -196,12 +196,10 @@ func (r *WorkflowRunReconciler) applyWorkflowRunPlan(ctx context.Context, resour
 	switch plan.state {
 	case workflowRunStateResolveJobs:
 		return r.applyResolveWorkflowRunJobs(ctx, workflowRun, condition)
-	case workflowRunStateCreateFirstStepRun:
-		return r.applyCreateFirstStepRun(ctx, workflowRun, plan.job)
-	case workflowRunStateRecordFirstStepRun:
-		return applyRecordFirstStepRun(workflowRun, resources.childRuns, plan.job)
+	case workflowRunStateStartReadyJobs:
+		return r.applyStartReadyJobs(ctx, resources, plan.jobs)
 	case workflowRunStateFailReadyJob:
-		applyFailReadyJob(workflowRun, plan.job)
+		applyFailReadyJob(workflowRun, plan.jobs[0])
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = "WorkflowExecutionFailed"
 		condition.Message = workflowRun.Status.Message
@@ -287,33 +285,30 @@ func resolvedJobStatuses(jobs map[string]v1alpha1.JobSpec) map[string]v1alpha1.J
 	return statuses
 }
 
-func (r *WorkflowRunReconciler) applyCreateFirstStepRun(ctx context.Context, workflowRun *v1alpha1.WorkflowRun, jobName string) error {
-	job := workflowRun.Spec.Jobs[jobName]
-	run := buildStepRun(workflowRun, jobName, job, job.Steps[0], workflowStepLabels(workflowRun, jobName, job.Steps[0].Name))
-	if err := controllerutil.SetControllerReference(workflowRun, run, r.Scheme); err != nil {
-		return fmt.Errorf("set workflowrun owner reference on run %s/%s: %w", run.Namespace, run.Name, err)
-	}
-	if err := r.Create(ctx, run); err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return fmt.Errorf("create child run %s/%s: %w", run.Namespace, run.Name, err)
+func (r *WorkflowRunReconciler) applyStartReadyJobs(ctx context.Context, resources *workflowRunResources, jobNames []string) error {
+	workflowRun := resources.workflowRun
+	for _, jobName := range jobNames {
+		job := workflowRun.Spec.Jobs[jobName]
+		step := job.Steps[0]
+		run := resources.childRuns[workflowStepKey(jobName, step.Name)]
+		if run == nil {
+			run = buildStepRun(workflowRun, jobName, job, step, workflowStepLabels(workflowRun, jobName, step.Name))
+			if err := controllerutil.SetControllerReference(workflowRun, run, r.Scheme); err != nil {
+				return fmt.Errorf("set workflowrun owner reference on run %s/%s: %w", run.Namespace, run.Name, err)
+			}
+			if err := r.Create(ctx, run); err != nil {
+				if !apierrors.IsAlreadyExists(err) {
+					return fmt.Errorf("create child run %s/%s: %w", run.Namespace, run.Name, err)
+				}
+				var existing v1alpha1.Run
+				if getErr := r.Get(ctx, client.ObjectKeyFromObject(run), &existing); getErr != nil {
+					return fmt.Errorf("get existing child run %s/%s after create conflict: %w", run.Namespace, run.Name, getErr)
+				}
+				run = &existing
+			}
 		}
-		var existing v1alpha1.Run
-		if getErr := r.Get(ctx, client.ObjectKeyFromObject(run), &existing); getErr != nil {
-			return fmt.Errorf("get existing child run %s/%s after create conflict: %w", run.Namespace, run.Name, getErr)
-		}
-		run = &existing
+		recordFirstStepRun(workflowRun, jobName, run.Name)
 	}
-	recordFirstStepRun(workflowRun, jobName, run.Name)
-	return nil
-}
-
-func applyRecordFirstStepRun(workflowRun *v1alpha1.WorkflowRun, childRuns map[string]*v1alpha1.Run, jobName string) error {
-	job := workflowRun.Spec.Jobs[jobName]
-	run := childRuns[workflowStepKey(jobName, job.Steps[0].Name)]
-	if run == nil {
-		return fmt.Errorf("child run for workflowrun %s/%s job %s first step is missing", workflowRun.Namespace, workflowRun.Name, jobName)
-	}
-	recordFirstStepRun(workflowRun, jobName, run.Name)
 	return nil
 }
 

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -35,13 +35,21 @@ func (e *workflowInputBindingError) Unwrap() error {
 	return e.err
 }
 
-type workflowRunReconcileState string
+type workflowRunState string
 
 const (
-	workflowRunStateResolveJobs    workflowRunReconcileState = "ResolveJobs"
-	workflowRunStateStartReadyJobs workflowRunReconcileState = "StartReadyJobs"
-	workflowRunStateFailReadyJob   workflowRunReconcileState = "FailReadyJob"
-	workflowRunStatePatchStatus    workflowRunReconcileState = "PatchStatus"
+	workflowRunStateEmpty    workflowRunState = "Empty"
+	workflowRunStatePending  workflowRunState = "Pending"
+	workflowRunStateRunning  workflowRunState = "Running"
+	workflowRunStateTerminal workflowRunState = "Terminal"
+)
+
+type workflowRunAction string
+
+const (
+	workflowRunActionNone           workflowRunAction = "None"
+	workflowRunActionInitialize     workflowRunAction = "Initialize"
+	workflowRunActionStartReadyJobs workflowRunAction = "StartReadyJobs"
 )
 
 type workflowRunResources struct {
@@ -50,8 +58,9 @@ type workflowRunResources struct {
 }
 
 type workflowRunPlan struct {
-	state workflowRunReconcileState
-	jobs  []string
+	state  workflowRunState
+	action workflowRunAction
+	jobs   []string
 }
 
 // WorkflowRunReconciler owns WorkflowRun execution-instance status.
@@ -78,17 +87,14 @@ func (r *WorkflowRunReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	base := workflowRun.DeepCopy()
-	if workflowRun.Status.Phase == "" {
-		workflowRun.Status.Phase = v1alpha1.WorkflowPending
-	}
-
-	condition := acceptedWorkflowRunCondition(workflowRun)
 	plan := planWorkflowRun(resources)
-	if err := r.applyWorkflowRunPlan(ctx, resources, plan, &condition); err != nil {
+	if plan.action == workflowRunActionNone {
+		return ctrl.Result{}, nil
+	}
+	if err := r.applyWorkflowRunAction(ctx, resources, plan); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	apimeta.SetStatusCondition(&workflowRun.Status.Conditions, condition)
 	if err := r.Status().Patch(ctx, workflowRun, client.MergeFrom(base)); err != nil {
 		return ctrl.Result{}, fmt.Errorf("patch workflowrun status: %w", err)
 	}
@@ -118,26 +124,16 @@ func (r *WorkflowRunReconciler) loadWorkflowRunResources(ctx context.Context, ke
 	return &workflowRunResources{workflowRun: workflowRun, childRuns: childRuns}, nil
 }
 
-func acceptedWorkflowRunCondition(workflowRun *v1alpha1.WorkflowRun) metav1.Condition {
-	if existing := apimeta.FindStatusCondition(workflowRun.Status.Conditions, v1alpha1.WorkflowRunAcceptedCondition); existing != nil && existing.ObservedGeneration == workflowRun.Generation {
-		return *existing
-	}
-	return metav1.Condition{
-		Type:               v1alpha1.WorkflowRunAcceptedCondition,
-		Status:             metav1.ConditionTrue,
-		Reason:             "Accepted",
-		Message:            "WorkflowRun accepted; execution is a follow-up implementation step",
-		ObservedGeneration: workflowRun.Generation,
-	}
-}
-
 func planWorkflowRun(resources *workflowRunResources) workflowRunPlan {
 	workflowRun := resources.workflowRun
-	if workflowRun.Status.Phase != v1alpha1.WorkflowFailed && workflowRun.Status.Jobs == nil {
-		return workflowRunPlan{state: workflowRunStateResolveJobs}
+	state := workflowRunStateFor(workflowRun)
+	plan := workflowRunPlan{state: state, action: workflowRunActionNone}
+	if state == workflowRunStateEmpty {
+		plan.action = workflowRunActionInitialize
+		return plan
 	}
-	if workflowRun.Status.Phase == v1alpha1.WorkflowFailed || workflowRun.Status.Phase == v1alpha1.WorkflowSucceeded || len(workflowRun.Spec.Jobs) == 0 || len(workflowRun.Status.Jobs) == 0 {
-		return workflowRunPlan{state: workflowRunStatePatchStatus}
+	if state == workflowRunStateTerminal || len(workflowRun.Spec.Jobs) == 0 || len(workflowRun.Status.Jobs) == 0 {
+		return plan
 	}
 
 	jobNames := make([]string, 0, len(workflowRun.Spec.Jobs))
@@ -147,13 +143,9 @@ func planWorkflowRun(resources *workflowRunResources) workflowRunPlan {
 	sort.Strings(jobNames)
 	readyJobs := make([]string, 0, len(jobNames))
 	for _, jobName := range jobNames {
-		job := workflowRun.Spec.Jobs[jobName]
 		status := workflowRun.Status.Jobs[jobName]
 		if !jobReadyToStart(status, workflowRun.Status.Jobs) {
 			continue
-		}
-		if len(job.Steps) == 0 || len(status.Steps) == 0 || job.RunsOn == "" {
-			return workflowRunPlan{state: workflowRunStateFailReadyJob, jobs: []string{jobName}}
 		}
 		if status.Steps[0].RunName != "" {
 			continue
@@ -161,48 +153,50 @@ func planWorkflowRun(resources *workflowRunResources) workflowRunPlan {
 		readyJobs = append(readyJobs, jobName)
 	}
 	if len(readyJobs) > 0 {
-		return workflowRunPlan{state: workflowRunStateStartReadyJobs, jobs: readyJobs}
+		plan.action = workflowRunActionStartReadyJobs
+		plan.jobs = readyJobs
 	}
-
-	return workflowRunPlan{state: workflowRunStatePatchStatus}
+	return plan
 }
 
-func (r *WorkflowRunReconciler) applyResolveWorkflowRunJobs(ctx context.Context, workflowRun *v1alpha1.WorkflowRun, condition *metav1.Condition) error {
+func workflowRunStateFor(workflowRun *v1alpha1.WorkflowRun) workflowRunState {
+	if workflowRun.Status.Phase == v1alpha1.WorkflowFailed || workflowRun.Status.Phase == v1alpha1.WorkflowSucceeded {
+		return workflowRunStateTerminal
+	}
+	if workflowRun.Status.Jobs == nil {
+		return workflowRunStateEmpty
+	}
+	if workflowRun.Status.Phase == v1alpha1.WorkflowRunning {
+		return workflowRunStateRunning
+	}
+	return workflowRunStatePending
+}
+
+func (r *WorkflowRunReconciler) applyInitializeWorkflowRun(ctx context.Context, workflowRun *v1alpha1.WorkflowRun) error {
 	jobs, err := r.resolveWorkflowRunJobs(ctx, workflowRun)
 	if err != nil {
-		var inputErr *workflowInputBindingError
-		switch {
-		case apierrors.IsNotFound(err):
-			condition.Reason = "WorkflowResolutionFailed"
-		case errors.As(err, &inputErr):
-			condition.Reason = "WorkflowInputBindingFailed"
-		default:
-			return err
+		if reason, rejected := workflowRunRejectionReason(err); rejected {
+			return rejectWorkflowRun(workflowRun, reason, err.Error())
 		}
-		workflowRun.Status.Phase = v1alpha1.WorkflowFailed
-		workflowRun.Status.Message = err.Error()
-		condition.Status = metav1.ConditionFalse
-		condition.Message = err.Error()
-		return nil
+		return err
 	}
-	if len(jobs) > 0 {
-		workflowRun.Status.Jobs = resolvedJobStatuses(jobs)
+	if err := validateResolvedWorkflowJobs(jobs); err != nil {
+		return rejectWorkflowRun(workflowRun, "WorkflowValidationFailed", err.Error())
 	}
+	workflowRun.Status.Phase = v1alpha1.WorkflowPending
+	workflowRun.Status.Message = ""
+	workflowRun.Status.Jobs = resolvedJobStatuses(jobs)
+	setWorkflowRunAcceptedCondition(workflowRun, metav1.ConditionTrue, "Accepted", "WorkflowRun accepted and initialized")
 	return nil
 }
 
-func (r *WorkflowRunReconciler) applyWorkflowRunPlan(ctx context.Context, resources *workflowRunResources, plan workflowRunPlan, condition *metav1.Condition) error {
+func (r *WorkflowRunReconciler) applyWorkflowRunAction(ctx context.Context, resources *workflowRunResources, plan workflowRunPlan) error {
 	workflowRun := resources.workflowRun
-	switch plan.state {
-	case workflowRunStateResolveJobs:
-		return r.applyResolveWorkflowRunJobs(ctx, workflowRun, condition)
-	case workflowRunStateStartReadyJobs:
+	switch plan.action {
+	case workflowRunActionInitialize:
+		return r.applyInitializeWorkflowRun(ctx, workflowRun)
+	case workflowRunActionStartReadyJobs:
 		return r.applyStartReadyJobs(ctx, resources, plan.jobs)
-	case workflowRunStateFailReadyJob:
-		applyFailReadyJob(workflowRun, plan.jobs[0])
-		condition.Status = metav1.ConditionFalse
-		condition.Reason = "WorkflowExecutionFailed"
-		condition.Message = workflowRun.Status.Message
 	}
 	return nil
 }
@@ -231,6 +225,56 @@ func (r *WorkflowRunReconciler) resolveWorkflowRunJobs(ctx context.Context, work
 		return nil, &workflowInputBindingError{err: fmt.Errorf("bind workflow inputs for %s/%s: %w", workflowRun.Namespace, workflowRun.Spec.Uses, err)}
 	}
 	return workflow.Spec.Jobs, nil
+}
+
+func workflowRunRejectionReason(err error) (string, bool) {
+	var inputErr *workflowInputBindingError
+	switch {
+	case apierrors.IsNotFound(err):
+		return "WorkflowResolutionFailed", true
+	case errors.As(err, &inputErr):
+		return "WorkflowInputBindingFailed", true
+	default:
+		return "", false
+	}
+}
+
+func validateResolvedWorkflowJobs(jobs map[string]v1alpha1.JobSpec) error {
+	jobNames := make([]string, 0, len(jobs))
+	for jobName := range jobs {
+		jobNames = append(jobNames, jobName)
+	}
+	sort.Strings(jobNames)
+	for _, jobName := range jobNames {
+		job := jobs[jobName]
+		if job.Uses != "" {
+			return fmt.Errorf("job %q uses reusable workflow %q, but job-level uses is not implemented yet", jobName, job.Uses)
+		}
+		if job.RunsOn == "" {
+			return fmt.Errorf("job %q must set runs-on before creating child Runs", jobName)
+		}
+		if len(job.Steps) == 0 {
+			return fmt.Errorf("job %q must contain at least one step before creating child Runs", jobName)
+		}
+	}
+	return nil
+}
+
+func rejectWorkflowRun(workflowRun *v1alpha1.WorkflowRun, reason string, message string) error {
+	workflowRun.Status.Phase = v1alpha1.WorkflowFailed
+	workflowRun.Status.Message = message
+	setWorkflowRunAcceptedCondition(workflowRun, metav1.ConditionFalse, reason, message)
+	return nil
+}
+
+func setWorkflowRunAcceptedCondition(workflowRun *v1alpha1.WorkflowRun, status metav1.ConditionStatus, reason string, message string) {
+	apimeta.SetStatusCondition(&workflowRun.Status.Conditions, metav1.Condition{
+		Type:               v1alpha1.WorkflowRunAcceptedCondition,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: workflowRun.Generation,
+	})
 }
 
 func bindWorkflowInputs(inputs map[string]v1alpha1.WorkflowInputSpec, with map[string]string) (map[string]string, error) {
@@ -319,23 +363,6 @@ func recordFirstStepRun(workflowRun *v1alpha1.WorkflowRun, jobName string, runNa
 	status.Steps[0].RunName = runName
 	workflowRun.Status.Jobs[jobName] = status
 	workflowRun.Status.Phase = v1alpha1.WorkflowRunning
-}
-
-func applyFailReadyJob(workflowRun *v1alpha1.WorkflowRun, jobName string) {
-	job := workflowRun.Spec.Jobs[jobName]
-	status := workflowRun.Status.Jobs[jobName]
-	workflowRun.Status.Phase = v1alpha1.WorkflowFailed
-	if len(job.Steps) == 0 || len(status.Steps) == 0 {
-		if job.Uses != "" {
-			workflowRun.Status.Message = fmt.Sprintf("job %q uses reusable workflow %q, but job-level uses is not implemented yet", jobName, job.Uses)
-		} else {
-			workflowRun.Status.Message = fmt.Sprintf("job %q must contain at least one step before creating child Runs", jobName)
-		}
-	} else {
-		workflowRun.Status.Message = fmt.Sprintf("job %q must set runs-on before creating child Runs", jobName)
-	}
-	status.Phase = v1alpha1.JobFailed
-	workflowRun.Status.Jobs[jobName] = status
 }
 
 func jobReadyToStart(status v1alpha1.JobStatus, jobs map[string]v1alpha1.JobStatus) bool {

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -38,10 +38,22 @@ func (e *workflowInputBindingError) Unwrap() error {
 type workflowRunReconcileState string
 
 const (
-	workflowRunStateResolveJobs          workflowRunReconcileState = "ResolveJobs"
-	workflowRunStateStartReadyInlineJobs workflowRunReconcileState = "StartReadyInlineJobs"
-	workflowRunStatePatchStatus          workflowRunReconcileState = "PatchStatus"
+	workflowRunStateResolveJobs        workflowRunReconcileState = "ResolveJobs"
+	workflowRunStateCreateFirstStepRun workflowRunReconcileState = "CreateFirstStepRun"
+	workflowRunStateRecordFirstStepRun workflowRunReconcileState = "RecordFirstStepRun"
+	workflowRunStateFailReadyJob       workflowRunReconcileState = "FailReadyJob"
+	workflowRunStatePatchStatus        workflowRunReconcileState = "PatchStatus"
 )
+
+type workflowRunResources struct {
+	workflowRun *v1alpha1.WorkflowRun
+	childRuns   map[string]*v1alpha1.Run
+}
+
+type workflowRunPlan struct {
+	state workflowRunReconcileState
+	job   string
+}
 
 // WorkflowRunReconciler owns WorkflowRun execution-instance status.
 type WorkflowRunReconciler struct {
@@ -57,10 +69,11 @@ type WorkflowRunReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 func (r *WorkflowRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	var workflowRun v1alpha1.WorkflowRun
-	if err := r.Get(ctx, req.NamespacedName, &workflowRun); err != nil {
+	resources, err := r.loadWorkflowRunResources(ctx, req.NamespacedName)
+	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	workflowRun := resources.workflowRun
 	if !workflowRun.DeletionTimestamp.IsZero() {
 		return ctrl.Result{}, nil
 	}
@@ -70,31 +83,46 @@ func (r *WorkflowRunReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		workflowRun.Status.Phase = v1alpha1.WorkflowPending
 	}
 
-	condition := acceptedWorkflowRunCondition(&workflowRun)
-	for {
-		switch workflowRunStateFor(&workflowRun) {
-		case workflowRunStateResolveJobs:
-			if err := r.applyResolveWorkflowRunJobs(ctx, &workflowRun, &condition); err != nil {
-				return ctrl.Result{}, err
-			}
-			continue
-		case workflowRunStateStartReadyInlineJobs:
-			if err := r.applyStartReadyInlineJobs(ctx, &workflowRun, &condition); err != nil {
-				return ctrl.Result{}, err
-			}
-		case workflowRunStatePatchStatus:
-		}
-		break
+	condition := acceptedWorkflowRunCondition(workflowRun)
+	plan := planWorkflowRun(resources)
+	if err := r.applyWorkflowRunPlan(ctx, resources, plan, &condition); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	apimeta.SetStatusCondition(&workflowRun.Status.Conditions, condition)
-	if err := r.Status().Patch(ctx, &workflowRun, client.MergeFrom(base)); err != nil {
+	if err := r.Status().Patch(ctx, workflowRun, client.MergeFrom(base)); err != nil {
 		return ctrl.Result{}, fmt.Errorf("patch workflowrun status: %w", err)
 	}
 	return ctrl.Result{}, nil
 }
 
+func (r *WorkflowRunReconciler) loadWorkflowRunResources(ctx context.Context, key client.ObjectKey) (*workflowRunResources, error) {
+	workflowRun := &v1alpha1.WorkflowRun{}
+	if err := r.Get(ctx, key, workflowRun); err != nil {
+		return nil, err
+	}
+
+	var runs v1alpha1.RunList
+	labels := client.MatchingLabels{v1alpha1.WorkflowRunUIDLabel: string(workflowRun.UID)}
+	if err := r.List(ctx, &runs, client.InNamespace(workflowRun.Namespace), labels); err != nil {
+		return nil, fmt.Errorf("list child runs for workflowrun %s/%s: %w", workflowRun.Namespace, workflowRun.Name, err)
+	}
+	childRuns := make(map[string]*v1alpha1.Run, len(runs.Items))
+	for i := range runs.Items {
+		run := &runs.Items[i]
+		key := workflowStepKey(run.Labels[v1alpha1.WorkflowJobLabel], run.Labels[v1alpha1.WorkflowStepLabel])
+		if existing, ok := childRuns[key]; !ok || run.Name < existing.Name {
+			childRuns[key] = run.DeepCopy()
+		}
+	}
+
+	return &workflowRunResources{workflowRun: workflowRun, childRuns: childRuns}, nil
+}
+
 func acceptedWorkflowRunCondition(workflowRun *v1alpha1.WorkflowRun) metav1.Condition {
+	if existing := apimeta.FindStatusCondition(workflowRun.Status.Conditions, v1alpha1.WorkflowRunAcceptedCondition); existing != nil && existing.ObservedGeneration == workflowRun.Generation {
+		return *existing
+	}
 	return metav1.Condition{
 		Type:               v1alpha1.WorkflowRunAcceptedCondition,
 		Status:             metav1.ConditionTrue,
@@ -104,14 +132,39 @@ func acceptedWorkflowRunCondition(workflowRun *v1alpha1.WorkflowRun) metav1.Cond
 	}
 }
 
-func workflowRunStateFor(workflowRun *v1alpha1.WorkflowRun) workflowRunReconcileState {
+func planWorkflowRun(resources *workflowRunResources) workflowRunPlan {
+	workflowRun := resources.workflowRun
 	if workflowRun.Status.Phase != v1alpha1.WorkflowFailed && workflowRun.Status.Jobs == nil {
-		return workflowRunStateResolveJobs
+		return workflowRunPlan{state: workflowRunStateResolveJobs}
 	}
-	if workflowRun.Status.Phase == v1alpha1.WorkflowPending && len(workflowRun.Spec.Jobs) > 0 && len(workflowRun.Status.Jobs) > 0 {
-		return workflowRunStateStartReadyInlineJobs
+	if workflowRun.Status.Phase == v1alpha1.WorkflowFailed || workflowRun.Status.Phase == v1alpha1.WorkflowSucceeded || len(workflowRun.Spec.Jobs) == 0 || len(workflowRun.Status.Jobs) == 0 {
+		return workflowRunPlan{state: workflowRunStatePatchStatus}
 	}
-	return workflowRunStatePatchStatus
+
+	jobNames := make([]string, 0, len(workflowRun.Spec.Jobs))
+	for jobName := range workflowRun.Spec.Jobs {
+		jobNames = append(jobNames, jobName)
+	}
+	sort.Strings(jobNames)
+	for _, jobName := range jobNames {
+		job := workflowRun.Spec.Jobs[jobName]
+		status := workflowRun.Status.Jobs[jobName]
+		if !jobReadyToStart(status, workflowRun.Status.Jobs) {
+			continue
+		}
+		if len(job.Steps) == 0 || len(status.Steps) == 0 || job.RunsOn == "" {
+			return workflowRunPlan{state: workflowRunStateFailReadyJob, job: jobName}
+		}
+		if status.Steps[0].RunName != "" {
+			continue
+		}
+		if _, ok := resources.childRuns[workflowStepKey(jobName, job.Steps[0].Name)]; ok {
+			return workflowRunPlan{state: workflowRunStateRecordFirstStepRun, job: jobName}
+		}
+		return workflowRunPlan{state: workflowRunStateCreateFirstStepRun, job: jobName}
+	}
+
+	return workflowRunPlan{state: workflowRunStatePatchStatus}
 }
 
 func (r *WorkflowRunReconciler) applyResolveWorkflowRunJobs(ctx context.Context, workflowRun *v1alpha1.WorkflowRun, condition *metav1.Condition) error {
@@ -138,11 +191,17 @@ func (r *WorkflowRunReconciler) applyResolveWorkflowRunJobs(ctx context.Context,
 	return nil
 }
 
-func (r *WorkflowRunReconciler) applyStartReadyInlineJobs(ctx context.Context, workflowRun *v1alpha1.WorkflowRun, condition *metav1.Condition) error {
-	if err := r.startReadyInlineJobs(ctx, workflowRun); err != nil {
-		return err
-	}
-	if workflowRun.Status.Phase == v1alpha1.WorkflowFailed {
+func (r *WorkflowRunReconciler) applyWorkflowRunPlan(ctx context.Context, resources *workflowRunResources, plan workflowRunPlan, condition *metav1.Condition) error {
+	workflowRun := resources.workflowRun
+	switch plan.state {
+	case workflowRunStateResolveJobs:
+		return r.applyResolveWorkflowRunJobs(ctx, workflowRun, condition)
+	case workflowRunStateCreateFirstStepRun:
+		return r.applyCreateFirstStepRun(ctx, workflowRun, plan.job)
+	case workflowRunStateRecordFirstStepRun:
+		return applyRecordFirstStepRun(workflowRun, resources.childRuns, plan.job)
+	case workflowRunStateFailReadyJob:
+		applyFailReadyJob(workflowRun, plan.job)
 		condition.Status = metav1.ConditionFalse
 		condition.Reason = "WorkflowExecutionFailed"
 		condition.Message = workflowRun.Status.Message
@@ -228,60 +287,60 @@ func resolvedJobStatuses(jobs map[string]v1alpha1.JobSpec) map[string]v1alpha1.J
 	return statuses
 }
 
-func (r *WorkflowRunReconciler) startReadyInlineJobs(ctx context.Context, workflowRun *v1alpha1.WorkflowRun) error {
-	type readyJob struct {
-		name   string
-		spec   v1alpha1.JobSpec
-		status v1alpha1.JobStatus
+func (r *WorkflowRunReconciler) applyCreateFirstStepRun(ctx context.Context, workflowRun *v1alpha1.WorkflowRun, jobName string) error {
+	job := workflowRun.Spec.Jobs[jobName]
+	run := buildStepRun(workflowRun, jobName, job, job.Steps[0], workflowStepLabels(workflowRun, jobName, job.Steps[0].Name))
+	if err := controllerutil.SetControllerReference(workflowRun, run, r.Scheme); err != nil {
+		return fmt.Errorf("set workflowrun owner reference on run %s/%s: %w", run.Namespace, run.Name, err)
 	}
-	jobNames := make([]string, 0, len(workflowRun.Spec.Jobs))
-	for jobName := range workflowRun.Spec.Jobs {
-		jobNames = append(jobNames, jobName)
+	if err := r.Create(ctx, run); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("create child run %s/%s: %w", run.Namespace, run.Name, err)
+		}
+		var existing v1alpha1.Run
+		if getErr := r.Get(ctx, client.ObjectKeyFromObject(run), &existing); getErr != nil {
+			return fmt.Errorf("get existing child run %s/%s after create conflict: %w", run.Namespace, run.Name, getErr)
+		}
+		run = &existing
 	}
-	sort.Strings(jobNames)
-	readyJobs := make([]readyJob, 0, len(jobNames))
-	for _, jobName := range jobNames {
-		job := workflowRun.Spec.Jobs[jobName]
-		status := workflowRun.Status.Jobs[jobName]
-		if !jobReadyToStart(status, workflowRun.Status.Jobs) {
-			continue
-		}
-		if len(job.Steps) == 0 || len(status.Steps) == 0 {
-			workflowRun.Status.Phase = v1alpha1.WorkflowFailed
-			if job.Uses != "" {
-				workflowRun.Status.Message = fmt.Sprintf("job %q uses reusable workflow %q, but job-level uses is not implemented yet", jobName, job.Uses)
-			} else {
-				workflowRun.Status.Message = fmt.Sprintf("job %q must contain at least one step before creating child Runs", jobName)
-			}
-			status.Phase = v1alpha1.JobFailed
-			workflowRun.Status.Jobs[jobName] = status
-			return nil
-		}
-		if status.Steps[0].RunName != "" {
-			continue
-		}
-		if job.RunsOn == "" {
-			workflowRun.Status.Phase = v1alpha1.WorkflowFailed
-			workflowRun.Status.Message = fmt.Sprintf("job %q must set runs-on before creating child Runs", jobName)
-			status.Phase = v1alpha1.JobFailed
-			workflowRun.Status.Jobs[jobName] = status
-			return nil
-		}
-		readyJobs = append(readyJobs, readyJob{name: jobName, spec: job, status: status})
-	}
-	for _, ready := range readyJobs {
-		run, err := r.ensureStepRun(ctx, workflowRun, ready.name, ready.spec, ready.spec.Steps[0])
-		if err != nil {
-			return err
-		}
-		status := ready.status
-		status.Phase = v1alpha1.JobRunning
-		status.Steps[0].Phase = v1alpha1.StepRunning
-		status.Steps[0].RunName = run.Name
-		workflowRun.Status.Jobs[ready.name] = status
-		workflowRun.Status.Phase = v1alpha1.WorkflowRunning
-	}
+	recordFirstStepRun(workflowRun, jobName, run.Name)
 	return nil
+}
+
+func applyRecordFirstStepRun(workflowRun *v1alpha1.WorkflowRun, childRuns map[string]*v1alpha1.Run, jobName string) error {
+	job := workflowRun.Spec.Jobs[jobName]
+	run := childRuns[workflowStepKey(jobName, job.Steps[0].Name)]
+	if run == nil {
+		return fmt.Errorf("child run for workflowrun %s/%s job %s first step is missing", workflowRun.Namespace, workflowRun.Name, jobName)
+	}
+	recordFirstStepRun(workflowRun, jobName, run.Name)
+	return nil
+}
+
+func recordFirstStepRun(workflowRun *v1alpha1.WorkflowRun, jobName string, runName string) {
+	status := workflowRun.Status.Jobs[jobName]
+	status.Phase = v1alpha1.JobRunning
+	status.Steps[0].Phase = v1alpha1.StepRunning
+	status.Steps[0].RunName = runName
+	workflowRun.Status.Jobs[jobName] = status
+	workflowRun.Status.Phase = v1alpha1.WorkflowRunning
+}
+
+func applyFailReadyJob(workflowRun *v1alpha1.WorkflowRun, jobName string) {
+	job := workflowRun.Spec.Jobs[jobName]
+	status := workflowRun.Status.Jobs[jobName]
+	workflowRun.Status.Phase = v1alpha1.WorkflowFailed
+	if len(job.Steps) == 0 || len(status.Steps) == 0 {
+		if job.Uses != "" {
+			workflowRun.Status.Message = fmt.Sprintf("job %q uses reusable workflow %q, but job-level uses is not implemented yet", jobName, job.Uses)
+		} else {
+			workflowRun.Status.Message = fmt.Sprintf("job %q must contain at least one step before creating child Runs", jobName)
+		}
+	} else {
+		workflowRun.Status.Message = fmt.Sprintf("job %q must set runs-on before creating child Runs", jobName)
+	}
+	status.Phase = v1alpha1.JobFailed
+	workflowRun.Status.Jobs[jobName] = status
 }
 
 func jobReadyToStart(status v1alpha1.JobStatus, jobs map[string]v1alpha1.JobStatus) bool {
@@ -294,36 +353,6 @@ func jobReadyToStart(status v1alpha1.JobStatus, jobs map[string]v1alpha1.JobStat
 		}
 	}
 	return true
-}
-
-func (r *WorkflowRunReconciler) ensureStepRun(ctx context.Context, workflowRun *v1alpha1.WorkflowRun, jobName string, job v1alpha1.JobSpec, step v1alpha1.StepSpec) (*v1alpha1.Run, error) {
-	labels := workflowStepLabels(workflowRun, jobName, step.Name)
-	var existing v1alpha1.RunList
-	if err := r.List(ctx, &existing, client.InNamespace(workflowRun.Namespace), client.MatchingLabels(labels)); err != nil {
-		return nil, fmt.Errorf("list child runs for workflowrun %s/%s job %s step %s: %w", workflowRun.Namespace, workflowRun.Name, jobName, step.Name, err)
-	}
-	if len(existing.Items) > 0 {
-		sort.Slice(existing.Items, func(i, j int) bool {
-			return existing.Items[i].Name < existing.Items[j].Name
-		})
-		return &existing.Items[0], nil
-	}
-
-	run := buildStepRun(workflowRun, jobName, job, step, labels)
-	if err := controllerutil.SetControllerReference(workflowRun, run, r.Scheme); err != nil {
-		return nil, fmt.Errorf("set workflowrun owner reference on run %s/%s: %w", run.Namespace, run.Name, err)
-	}
-	if err := r.Create(ctx, run); err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return nil, fmt.Errorf("create child run %s/%s: %w", run.Namespace, run.Name, err)
-		}
-		var created v1alpha1.Run
-		if getErr := r.Get(ctx, client.ObjectKeyFromObject(run), &created); getErr != nil {
-			return nil, fmt.Errorf("get existing child run %s/%s after create conflict: %w", run.Namespace, run.Name, getErr)
-		}
-		return &created, nil
-	}
-	return run, nil
 }
 
 func buildStepRun(workflowRun *v1alpha1.WorkflowRun, jobName string, job v1alpha1.JobSpec, step v1alpha1.StepSpec, labels map[string]string) *v1alpha1.Run {
@@ -360,6 +389,10 @@ func workflowStepLabels(workflowRun *v1alpha1.WorkflowRun, jobName string, stepN
 		v1alpha1.WorkflowJobLabel:    jobName,
 		v1alpha1.WorkflowStepLabel:   stepName,
 	}
+}
+
+func workflowStepKey(jobName string, stepName string) string {
+	return jobName + "\x00" + stepName
 }
 
 func workflowStepRunName(workflowRunName string, jobName string, stepName string) string {

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -35,6 +35,14 @@ func (e *workflowInputBindingError) Unwrap() error {
 	return e.err
 }
 
+type workflowRunReconcileState string
+
+const (
+	workflowRunStateResolveJobs          workflowRunReconcileState = "ResolveJobs"
+	workflowRunStateStartReadyInlineJobs workflowRunReconcileState = "StartReadyInlineJobs"
+	workflowRunStatePatchStatus          workflowRunReconcileState = "PatchStatus"
+)
+
 // WorkflowRunReconciler owns WorkflowRun execution-instance status.
 type WorkflowRunReconciler struct {
 	client.Client
@@ -61,48 +69,85 @@ func (r *WorkflowRunReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if workflowRun.Status.Phase == "" {
 		workflowRun.Status.Phase = v1alpha1.WorkflowPending
 	}
-	condition := metav1.Condition{
+
+	condition := acceptedWorkflowRunCondition(&workflowRun)
+	for {
+		switch workflowRunStateFor(&workflowRun) {
+		case workflowRunStateResolveJobs:
+			if err := r.applyResolveWorkflowRunJobs(ctx, &workflowRun, &condition); err != nil {
+				return ctrl.Result{}, err
+			}
+			continue
+		case workflowRunStateStartReadyInlineJobs:
+			if err := r.applyStartReadyInlineJobs(ctx, &workflowRun, &condition); err != nil {
+				return ctrl.Result{}, err
+			}
+		case workflowRunStatePatchStatus:
+		}
+		break
+	}
+
+	apimeta.SetStatusCondition(&workflowRun.Status.Conditions, condition)
+	if err := r.Status().Patch(ctx, &workflowRun, client.MergeFrom(base)); err != nil {
+		return ctrl.Result{}, fmt.Errorf("patch workflowrun status: %w", err)
+	}
+	return ctrl.Result{}, nil
+}
+
+func acceptedWorkflowRunCondition(workflowRun *v1alpha1.WorkflowRun) metav1.Condition {
+	return metav1.Condition{
 		Type:               v1alpha1.WorkflowRunAcceptedCondition,
 		Status:             metav1.ConditionTrue,
 		Reason:             "Accepted",
 		Message:            "WorkflowRun accepted; execution is a follow-up implementation step",
 		ObservedGeneration: workflowRun.Generation,
 	}
+}
+
+func workflowRunStateFor(workflowRun *v1alpha1.WorkflowRun) workflowRunReconcileState {
 	if workflowRun.Status.Phase != v1alpha1.WorkflowFailed && workflowRun.Status.Jobs == nil {
-		jobs, err := r.resolveWorkflowRunJobs(ctx, &workflowRun)
-		if err != nil {
-			var inputErr *workflowInputBindingError
-			switch {
-			case apierrors.IsNotFound(err):
-				condition.Reason = "WorkflowResolutionFailed"
-			case errors.As(err, &inputErr):
-				condition.Reason = "WorkflowInputBindingFailed"
-			default:
-				return ctrl.Result{}, err
-			}
-			workflowRun.Status.Phase = v1alpha1.WorkflowFailed
-			workflowRun.Status.Message = err.Error()
-			condition.Status = metav1.ConditionFalse
-			condition.Message = err.Error()
-		} else if len(jobs) > 0 {
-			workflowRun.Status.Jobs = resolvedJobStatuses(jobs)
-		}
+		return workflowRunStateResolveJobs
 	}
 	if workflowRun.Status.Phase == v1alpha1.WorkflowPending && len(workflowRun.Spec.Jobs) > 0 && len(workflowRun.Status.Jobs) > 0 {
-		if err := r.startReadyInlineJobs(ctx, &workflowRun); err != nil {
-			return ctrl.Result{}, err
-		}
-		if workflowRun.Status.Phase == v1alpha1.WorkflowFailed {
-			condition.Status = metav1.ConditionFalse
-			condition.Reason = "WorkflowExecutionFailed"
-			condition.Message = workflowRun.Status.Message
-		}
+		return workflowRunStateStartReadyInlineJobs
 	}
-	apimeta.SetStatusCondition(&workflowRun.Status.Conditions, condition)
-	if err := r.Status().Patch(ctx, &workflowRun, client.MergeFrom(base)); err != nil {
-		return ctrl.Result{}, fmt.Errorf("patch workflowrun status: %w", err)
+	return workflowRunStatePatchStatus
+}
+
+func (r *WorkflowRunReconciler) applyResolveWorkflowRunJobs(ctx context.Context, workflowRun *v1alpha1.WorkflowRun, condition *metav1.Condition) error {
+	jobs, err := r.resolveWorkflowRunJobs(ctx, workflowRun)
+	if err != nil {
+		var inputErr *workflowInputBindingError
+		switch {
+		case apierrors.IsNotFound(err):
+			condition.Reason = "WorkflowResolutionFailed"
+		case errors.As(err, &inputErr):
+			condition.Reason = "WorkflowInputBindingFailed"
+		default:
+			return err
+		}
+		workflowRun.Status.Phase = v1alpha1.WorkflowFailed
+		workflowRun.Status.Message = err.Error()
+		condition.Status = metav1.ConditionFalse
+		condition.Message = err.Error()
+		return nil
 	}
-	return ctrl.Result{}, nil
+	if len(jobs) > 0 {
+		workflowRun.Status.Jobs = resolvedJobStatuses(jobs)
+	}
+	return nil
+}
+
+func (r *WorkflowRunReconciler) applyStartReadyInlineJobs(ctx context.Context, workflowRun *v1alpha1.WorkflowRun, condition *metav1.Condition) error {
+	if err := r.startReadyInlineJobs(ctx, workflowRun); err != nil {
+		return err
+	}
+	if workflowRun.Status.Phase == v1alpha1.WorkflowFailed {
+		condition.Status = metav1.ConditionFalse
+		condition.Reason = "WorkflowExecutionFailed"
+		condition.Message = workflowRun.Status.Message
+	}
+	return nil
 }
 
 // SetupWithManager registers the WorkflowRun reconciler.

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -117,7 +117,7 @@ func TestWorkflowRunReconcilerAcceptsWorkflowRun(t *testing.T) {
 	}
 }
 
-func TestWorkflowRunReconcilerCreatesOneReadyJobPerReconcile(t *testing.T) {
+func TestWorkflowRunReconcilerStartsAllIndependentReadyJobs(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := v1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add scheme: %v", err)
@@ -142,9 +142,7 @@ func TestWorkflowRunReconcilerCreatesOneReadyJobPerReconcile(t *testing.T) {
 	reconcileWorkflowRun(t, reconciler, req, 1)
 	assertChildRunCount(t, c, workflowRun.Namespace, 0)
 
-	// Each following reconcile creates at most one Run, in stable job-name order.
-	reconcileWorkflowRun(t, reconciler, req, 1)
-	assertChildRunCount(t, c, workflowRun.Namespace, 1)
+	// A single StartReadyJobs transition creates all independent ready jobs.
 	reconcileWorkflowRun(t, reconciler, req, 1)
 	assertChildRunCount(t, c, workflowRun.Namespace, 2)
 }

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -147,6 +147,28 @@ func TestWorkflowRunReconcilerStartsAllIndependentReadyJobs(t *testing.T) {
 	assertChildRunCount(t, c, workflowRun.Namespace, 2)
 }
 
+func TestPlanWorkflowRunSeparatesCurrentStateFromAction(t *testing.T) {
+	empty := &v1alpha1.WorkflowRun{}
+	plan := planWorkflowRun(&workflowRunResources{workflowRun: empty})
+	if plan.state != workflowRunStateEmpty || plan.action != workflowRunActionInitialize {
+		t.Fatalf("empty plan = %#v, want Empty + Initialize", plan)
+	}
+
+	pending := &v1alpha1.WorkflowRun{
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"build": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}}},
+		}},
+		Status: v1alpha1.WorkflowRunStatus{
+			Phase: v1alpha1.WorkflowPending,
+			Jobs:  resolvedJobStatuses(map[string]v1alpha1.JobSpec{"build": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}}}}),
+		},
+	}
+	plan = planWorkflowRun(&workflowRunResources{workflowRun: pending})
+	if plan.state != workflowRunStatePending || plan.action != workflowRunActionStartReadyJobs || len(plan.jobs) != 1 || plan.jobs[0] != "build" {
+		t.Fatalf("pending plan = %#v, want Pending + StartReadyJobs(build)", plan)
+	}
+}
+
 func TestJobReadyToStartChecksDependencyStatus(t *testing.T) {
 	status := v1alpha1.JobStatus{
 		Phase: v1alpha1.JobWaiting,
@@ -165,7 +187,7 @@ func TestJobReadyToStartChecksDependencyStatus(t *testing.T) {
 	}
 }
 
-func TestWorkflowRunReconcilerFailsReadyJobWithoutInlineSteps(t *testing.T) {
+func TestWorkflowRunReconcilerRejectsUnsupportedJobLevelUsesDuringInitialization(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := v1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add scheme: %v", err)
@@ -204,8 +226,12 @@ func TestWorkflowRunReconcilerFailsReadyJobWithoutInlineSteps(t *testing.T) {
 	if !strings.Contains(updated.Status.Message, "job-level uses is not implemented yet") {
 		t.Fatalf("message = %q, want job-level uses not implemented", updated.Status.Message)
 	}
-	if updated.Status.Jobs["release"].Phase != v1alpha1.JobFailed {
-		t.Fatalf("job phase = %q, want %q", updated.Status.Jobs["release"].Phase, v1alpha1.JobFailed)
+	if updated.Status.Jobs != nil {
+		t.Fatalf("jobs = %#v, want nil for rejected workflowrun", updated.Status.Jobs)
+	}
+	cond := apimeta.FindStatusCondition(updated.Status.Conditions, v1alpha1.WorkflowRunAcceptedCondition)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WorkflowValidationFailed" {
+		t.Fatalf("condition = %#v, want validation rejection", cond)
 	}
 }
 
@@ -268,7 +294,7 @@ func TestWorkflowRunReconcilerReusesExistingFirstStepRun(t *testing.T) {
 	}
 }
 
-func TestWorkflowRunReconcilerFailsReadyJobWithoutRuntime(t *testing.T) {
+func TestWorkflowRunReconcilerRejectsJobWithoutRuntimeDuringInitialization(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := v1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add scheme: %v", err)
@@ -304,15 +330,15 @@ func TestWorkflowRunReconcilerFailsReadyJobWithoutRuntime(t *testing.T) {
 	if updated.Status.Phase != v1alpha1.WorkflowFailed {
 		t.Fatalf("phase = %q, want %q", updated.Status.Phase, v1alpha1.WorkflowFailed)
 	}
-	if updated.Status.Jobs["build"].Phase != v1alpha1.JobFailed {
-		t.Fatalf("build phase = %q, want %q", updated.Status.Jobs["build"].Phase, v1alpha1.JobFailed)
+	if updated.Status.Jobs != nil {
+		t.Fatalf("jobs = %#v, want nil for rejected workflowrun", updated.Status.Jobs)
 	}
 	if !strings.Contains(updated.Status.Message, `job "build" must set runs-on`) {
 		t.Fatalf("message = %q, want missing runs-on", updated.Status.Message)
 	}
 	cond := apimeta.FindStatusCondition(updated.Status.Conditions, v1alpha1.WorkflowRunAcceptedCondition)
-	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WorkflowExecutionFailed" {
-		t.Fatalf("condition = %#v, want execution failure", cond)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WorkflowValidationFailed" {
+		t.Fatalf("condition = %#v, want validation rejection", cond)
 	}
 	var childRuns v1alpha1.RunList
 	if err := c.List(context.Background(), &childRuns, client.InNamespace(workflowRun.Namespace)); err != nil {

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -52,9 +52,7 @@ func TestWorkflowRunReconcilerAcceptsWorkflowRun(t *testing.T) {
 		Namespace: workflowRun.Namespace,
 		Name:      workflowRun.Name,
 	}}
-	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
-		t.Fatalf("reconcile workflowrun: %v", err)
-	}
+	reconcileWorkflowRun(t, reconciler, req, 2)
 
 	var updated v1alpha1.WorkflowRun
 	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
@@ -119,6 +117,38 @@ func TestWorkflowRunReconcilerAcceptsWorkflowRun(t *testing.T) {
 	}
 }
 
+func TestWorkflowRunReconcilerCreatesOneReadyJobPerReconcile(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "parallel", Namespace: "default", UID: "workflowrun-uid"},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"alpha": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "first", Run: "echo alpha"}}},
+			"beta":  {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "first", Run: "echo beta"}}},
+		}},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(workflowRun).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(workflowRun)}
+
+	// The first reconcile only persists the resolved graph.
+	reconcileWorkflowRun(t, reconciler, req, 1)
+	assertChildRunCount(t, c, workflowRun.Namespace, 0)
+
+	// Each following reconcile creates at most one Run, in stable job-name order.
+	reconcileWorkflowRun(t, reconciler, req, 1)
+	assertChildRunCount(t, c, workflowRun.Namespace, 1)
+	reconcileWorkflowRun(t, reconciler, req, 1)
+	assertChildRunCount(t, c, workflowRun.Namespace, 2)
+}
+
 func TestJobReadyToStartChecksDependencyStatus(t *testing.T) {
 	status := v1alpha1.JobStatus{
 		Phase: v1alpha1.JobWaiting,
@@ -164,9 +194,7 @@ func TestWorkflowRunReconcilerFailsReadyJobWithoutInlineSteps(t *testing.T) {
 		Namespace: workflowRun.Namespace,
 		Name:      workflowRun.Name,
 	}}
-	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
-		t.Fatalf("reconcile workflowrun: %v", err)
-	}
+	reconcileWorkflowRun(t, reconciler, req, 2)
 
 	var updated v1alpha1.WorkflowRun
 	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
@@ -223,9 +251,7 @@ func TestWorkflowRunReconcilerReusesExistingFirstStepRun(t *testing.T) {
 		Namespace: workflowRun.Namespace,
 		Name:      workflowRun.Name,
 	}}
-	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
-		t.Fatalf("reconcile workflowrun: %v", err)
-	}
+	reconcileWorkflowRun(t, reconciler, req, 2)
 
 	var updated v1alpha1.WorkflowRun
 	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
@@ -271,9 +297,7 @@ func TestWorkflowRunReconcilerFailsReadyJobWithoutRuntime(t *testing.T) {
 		Namespace: workflowRun.Namespace,
 		Name:      workflowRun.Name,
 	}}
-	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
-		t.Fatalf("reconcile workflowrun: %v", err)
-	}
+	reconcileWorkflowRun(t, reconciler, req, 2)
 
 	var updated v1alpha1.WorkflowRun
 	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
@@ -341,9 +365,7 @@ func TestWorkflowRunReconcilerPreservesResolvedJobStatus(t *testing.T) {
 		Namespace: workflowRun.Namespace,
 		Name:      workflowRun.Name,
 	}}
-	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
-		t.Fatalf("reconcile workflowrun: %v", err)
-	}
+	reconcileWorkflowRun(t, reconciler, req, 2)
 
 	var updated v1alpha1.WorkflowRun
 	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
@@ -405,9 +427,7 @@ func TestWorkflowRunReconcilerResolvesReusableWorkflow(t *testing.T) {
 		Namespace: workflowRun.Namespace,
 		Name:      workflowRun.Name,
 	}}
-	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
-		t.Fatalf("reconcile workflowrun: %v", err)
-	}
+	reconcileWorkflowRun(t, reconciler, req, 2)
 
 	var updated v1alpha1.WorkflowRun
 	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
@@ -454,9 +474,7 @@ func TestWorkflowRunReconcilerFailsWhenReusableWorkflowMissing(t *testing.T) {
 		Namespace: workflowRun.Namespace,
 		Name:      workflowRun.Name,
 	}}
-	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
-		t.Fatalf("reconcile workflowrun: %v", err)
-	}
+	reconcileWorkflowRun(t, reconciler, req, 2)
 
 	var updated v1alpha1.WorkflowRun
 	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
@@ -518,9 +536,7 @@ func TestWorkflowRunReconcilerFailsWhenWorkflowInputUnknown(t *testing.T) {
 		Namespace: workflowRun.Namespace,
 		Name:      workflowRun.Name,
 	}}
-	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
-		t.Fatalf("reconcile workflowrun: %v", err)
-	}
+	reconcileWorkflowRun(t, reconciler, req, 2)
 
 	var updated v1alpha1.WorkflowRun
 	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
@@ -575,9 +591,7 @@ func TestWorkflowRunReconcilerFailsWhenWorkflowInputRequired(t *testing.T) {
 		Namespace: workflowRun.Namespace,
 		Name:      workflowRun.Name,
 	}}
-	if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
-		t.Fatalf("reconcile workflowrun: %v", err)
-	}
+	reconcileWorkflowRun(t, reconciler, req, 2)
 
 	var updated v1alpha1.WorkflowRun
 	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
@@ -613,4 +627,24 @@ func TestBindWorkflowInputsAppliesDefaults(t *testing.T) {
 
 func ptrTo(value string) *string {
 	return &value
+}
+
+func reconcileWorkflowRun(t *testing.T, reconciler *WorkflowRunReconciler, req ctrl.Request, times int) {
+	t.Helper()
+	for range times {
+		if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
+			t.Fatalf("reconcile workflowrun: %v", err)
+		}
+	}
+}
+
+func assertChildRunCount(t *testing.T, c client.Client, namespace string, want int) {
+	t.Helper()
+	var runs v1alpha1.RunList
+	if err := c.List(context.Background(), &runs, client.InNamespace(namespace)); err != nil {
+		t.Fatalf("list child runs: %v", err)
+	}
+	if len(runs.Items) != want {
+		t.Fatalf("child runs = %#v, want %d", runs.Items, want)
+	}
 }


### PR DESCRIPTION
## Summary
- refactor WorkflowRun reconciliation into explicit load/plan/apply-style state handling
- keep existing first-step Run creation behavior unchanged
- update Workflow reuse design docs and roadmap to mark the prerequisite refactor complete

## Why
This addresses the roadmap gate added in #266 before adding more WorkflowRun execution cases such as child Run observation and next-step handling.

## Tests
- `GOCACHE=/tmp/go-build GOFLAGS=-buildvcs=false go test ./internal/controller -count=1`
- `GOCACHE=/tmp/go-build make test`
- `GOCACHE=/tmp/go-build make test-integration`
- `GOBIN=/tmp/kruntimes-bin make site-build`
- `git diff --check`