### PR TITLE
feat(controller): finalize WorkflowRun jobs

### DIFF
--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -313,8 +313,9 @@ The first version should support one execution strategy:
    the next step after a successful predecessor in a running job.
 5. When a step Run succeeds, collect outputs; the following reconciliation
    includes its next step with any other runnable steps.
-6. When all steps in a job succeed, evaluate job outputs and mark the job
-   succeeded.
+6. Aggregate observed terminal step states into the job state: all succeeded
+   steps succeed the job, while any failed step fails it. Job output evaluation
+   is deferred until output propagation is implemented.
 7. After all executable jobs have reached a terminal state, evaluate
    WorkflowRun outputs and determine its terminal state.
 

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -301,7 +301,9 @@ runtimed 理解 Workflow 概念。
    中 successful predecessor 之后的下一个 step。
 5. 当 step Run 成功时收集 outputs；下一次 reconciliation 会将其 next step 与其他
    runnable steps 一起处理。
-6. 当 job 内所有 steps 成功时，计算 job outputs，并将 job 标记为 succeeded。
+6. 将 observed terminal step states 聚合为 job state：所有 steps succeeded 时 job
+   succeeded，任一 step failed 时 job failed。job output evaluation 延后到实现 output
+   propagation 时处理。
 7. 当所有可执行 jobs 到达 terminal state 后，计算 WorkflowRun outputs，并确定
    WorkflowRun 的 terminal state。
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -218,7 +218,7 @@ wiring from accumulating avoidable conflicts.
     a failure, dependency-blocked jobs are `Skipped`, and WorkflowRun aggregates
     after executable jobs settle;
   - [x] implement next-step creation after observed step success;
-  - implement job terminal-state aggregation from observed step states;
+  - [x] implement job terminal-state aggregation from observed step states;
   - implement failed-dependency propagation and WorkflowRun terminal handling;
   - implement controller restart recovery for in-progress inline WorkflowRuns;
   - implement job-level reusable Workflow calls;

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -186,7 +186,7 @@ controller wiring 累积不必要的冲突。
     WorkflowRun terminal-status semantics：failure 后 independent jobs 继续，
     dependency-blocked jobs 为 `Skipped`，WorkflowRun 在 executable jobs settled 后聚合；
   - [x] 实现 observed step success 后的 next-step creation；
-  - 根据 observed step states 实现 job terminal-state aggregation；
+  - [x] 根据 observed step states 实现 job terminal-state aggregation；
   - 实现 failed-dependency propagation 和 WorkflowRun terminal handling；
   - 实现 in-progress inline WorkflowRuns 的 controller restart recovery；
   - 实现 job-level reusable Workflow calls；

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -51,6 +51,7 @@ const (
 	workflowRunActionInitialize         workflowRunAction = "Initialize"
 	workflowRunActionObserveChildRuns   workflowRunAction = "ObserveChildRuns"
 	workflowRunActionStartRunnableSteps workflowRunAction = "StartRunnableSteps"
+	workflowRunActionFinalizeJobs       workflowRunAction = "FinalizeJobs"
 )
 
 type workflowRunResources struct {
@@ -62,6 +63,7 @@ type workflowRunPlan struct {
 	state   workflowRunState
 	action  workflowRunAction
 	targets []workflowRunStepTarget
+	jobs    []string
 }
 
 type workflowRunStepTarget struct {
@@ -145,9 +147,15 @@ func planWorkflowRun(resources *workflowRunResources) workflowRunPlan {
 		plan.action = workflowRunActionObserveChildRuns
 		return plan
 	}
+	if jobNames := jobsWithTerminalStepStates(workflowRun); len(jobNames) > 0 {
+		plan.action = workflowRunActionFinalizeJobs
+		plan.jobs = jobNames
+		return plan
+	}
 	if targets := runnableStepTargets(workflowRun); len(targets) > 0 {
 		plan.action = workflowRunActionStartRunnableSteps
 		plan.targets = targets
+		return plan
 	}
 	return plan
 }
@@ -193,6 +201,9 @@ func (r *WorkflowRunReconciler) applyWorkflowRunAction(ctx context.Context, reso
 		return nil
 	case workflowRunActionStartRunnableSteps:
 		return r.applyStartRunnableSteps(ctx, resources, plan.targets)
+	case workflowRunActionFinalizeJobs:
+		applyFinalizeJobs(workflowRun, plan.jobs)
+		return nil
 	}
 	return nil
 }
@@ -409,6 +420,52 @@ func nextStepToStart(status v1alpha1.JobStatus) (int, bool) {
 		return 0, false
 	}
 	return 0, false
+}
+
+func jobsWithTerminalStepStates(workflowRun *v1alpha1.WorkflowRun) []string {
+	jobNames := make([]string, 0, len(workflowRun.Status.Jobs))
+	for jobName, status := range workflowRun.Status.Jobs {
+		if status.Phase != v1alpha1.JobRunning {
+			continue
+		}
+		if _, ok := terminalJobPhase(status); ok {
+			jobNames = append(jobNames, jobName)
+		}
+	}
+	sort.Strings(jobNames)
+	return jobNames
+}
+
+func terminalJobPhase(status v1alpha1.JobStatus) (v1alpha1.JobPhase, bool) {
+	if len(status.Steps) == 0 {
+		return "", false
+	}
+	allSucceeded := true
+	for _, step := range status.Steps {
+		switch step.Phase {
+		case v1alpha1.StepFailed:
+			return v1alpha1.JobFailed, true
+		case v1alpha1.StepSucceeded:
+		default:
+			allSucceeded = false
+		}
+	}
+	if allSucceeded {
+		return v1alpha1.JobSucceeded, true
+	}
+	return "", false
+}
+
+func applyFinalizeJobs(workflowRun *v1alpha1.WorkflowRun, jobNames []string) {
+	for _, jobName := range jobNames {
+		status := workflowRun.Status.Jobs[jobName]
+		phase, ok := terminalJobPhase(status)
+		if !ok {
+			continue
+		}
+		status.Phase = phase
+		workflowRun.Status.Jobs[jobName] = status
+	}
 }
 
 func jobReadyToStart(status v1alpha1.JobStatus, jobs map[string]v1alpha1.JobStatus) bool {

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -220,6 +220,27 @@ func TestPlanWorkflowRunStartsAllRunnableSteps(t *testing.T) {
 	}
 }
 
+func TestPlanWorkflowRunFinalizesTerminalJobsBeforeStartingReadyJobs(t *testing.T) {
+	workflowRun := &v1alpha1.WorkflowRun{
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"build": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}}},
+			"lint":  {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "check", Run: "make lint"}}},
+		}},
+		Status: v1alpha1.WorkflowRunStatus{
+			Phase: v1alpha1.WorkflowRunning,
+			Jobs: map[string]v1alpha1.JobStatus{
+				"build": {Phase: v1alpha1.JobRunning, Steps: []v1alpha1.StepStatus{{Name: "compile", Phase: v1alpha1.StepSucceeded, RunName: "compile-run"}}},
+				"lint":  {Phase: v1alpha1.JobPending, Steps: []v1alpha1.StepStatus{{Name: "check", Phase: v1alpha1.StepPending}}},
+			},
+		},
+	}
+
+	plan := planWorkflowRun(&workflowRunResources{workflowRun: workflowRun})
+	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionFinalizeJobs || len(plan.jobs) != 1 || plan.jobs[0] != "build" {
+		t.Fatalf("plan = %#v, want Running + FinalizeJobs(build)", plan)
+	}
+}
+
 func TestJobReadyToStartChecksDependencyStatus(t *testing.T) {
 	status := v1alpha1.JobStatus{
 		Phase: v1alpha1.JobWaiting,
@@ -539,6 +560,61 @@ func TestWorkflowRunReconcilerCreatesNextStepAfterObservedSuccess(t *testing.T) 
 	}
 	if lintRun.Spec.Source == nil || lintRun.Spec.Source.Inline == nil || *lintRun.Spec.Source.Inline != "make lint" {
 		t.Fatalf("lint run spec = %#v, want lint command", lintRun.Spec)
+	}
+}
+
+func TestWorkflowRunReconcilerFinalizesJobAfterObservedTerminalStep(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		runPhase v1alpha1.RunPhase
+		jobPhase v1alpha1.JobPhase
+	}{
+		{name: "succeeded", runPhase: v1alpha1.RunSucceeded, jobPhase: v1alpha1.JobSucceeded},
+		{name: "failed", runPhase: v1alpha1.RunFailed, jobPhase: v1alpha1.JobFailed},
+		{name: "timed-out", runPhase: v1alpha1.RunTimeout, jobPhase: v1alpha1.JobFailed},
+		{name: "cancelled", runPhase: v1alpha1.RunCancelled, jobPhase: v1alpha1.JobFailed},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := v1alpha1.AddToScheme(scheme); err != nil {
+				t.Fatalf("add scheme: %v", err)
+			}
+
+			workflowRun := &v1alpha1.WorkflowRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", UID: "workflowrun-uid"},
+				Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+					"build": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}}},
+				}},
+				Status: v1alpha1.WorkflowRunStatus{
+					Phase: v1alpha1.WorkflowRunning,
+					Jobs: map[string]v1alpha1.JobStatus{
+						"build": {Phase: v1alpha1.JobRunning, Steps: []v1alpha1.StepStatus{{Name: "compile", Phase: v1alpha1.StepRunning, RunName: "compile-run"}}},
+					},
+				},
+			}
+			run := workflowChildRun(workflowRun, "build", "compile", "compile-run", test.runPhase)
+			c := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(workflowRun, run).
+				WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+				Build()
+			reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+			req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(workflowRun)}
+
+			// Observation and job finalization are separate durable transitions.
+			reconcileWorkflowRun(t, reconciler, req, 2)
+
+			var updated v1alpha1.WorkflowRun
+			if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
+				t.Fatalf("get workflowrun: %v", err)
+			}
+			if updated.Status.Jobs["build"].Phase != test.jobPhase {
+				t.Fatalf("job phase = %q, want %q", updated.Status.Jobs["build"].Phase, test.jobPhase)
+			}
+			if updated.Status.Phase != v1alpha1.WorkflowRunning {
+				t.Fatalf("workflow phase = %q, want %q before WorkflowRun terminal aggregation", updated.Status.Phase, v1alpha1.WorkflowRunning)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a `FinalizeJobs` reconciliation action after child Run observation
- aggregate terminal step statuses into `JobSucceeded` or `JobFailed`
- retain merged #277 `StartRunnableSteps` behavior for first and subsequent runnable steps
- preserve WorkflowRun-level terminal aggregation and failed-dependency propagation for later PRs
- clarify deferred job-output evaluation and update the bilingual roadmap

## Validation
- `make test`
- `make test-integration`
- `make site-build`

This PR now targets `main` directly because #277 has merged.