### PR TITLE
refactor(controller): derive WorkflowRun status before actions

### DIFF
--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -324,28 +324,29 @@ Runs remain the durable execution records, and scheduler/runtimed continue to
 operate only on Runs.
 
 The WorkflowRun controller should keep reconciliation structured as
-load/plan/apply: load the WorkflowRun and all child Runs, derive its current
-state, choose one action for that state, apply the action, and patch
-WorkflowRun status. Current state and action are intentionally separate. The
-initial `Empty` state has an `Initialize` action, which validates controller-
-level semantics, resolves references and inputs, persists the execution graph,
-and sets `Accepted=True`. A failed initialization sets `Accepted=False` and
-does not create child Runs. Later execution actions must not modify `Accepted`:
-an accepted WorkflowRun can still fail while executing.
+load/calculate/apply/patch: load the WorkflowRun and all child Runs, derive the
+desired status and current state from those resources, calculate one action,
+apply the action, incorporate its result into the desired status, and patch
+status only when it differs from the persisted status. Status projection is
+part of every reconciliation; observing child Runs and aggregating terminal
+steps into job phases are not separate actions. Current state and action remain
+intentionally separate. The initial `Empty` state has an `Initialize` action,
+which validates controller-level semantics, resolves references and inputs,
+persists the execution graph, and sets `Accepted=True`. A failed initialization
+sets `Accepted=False` and does not create child Runs. Later execution actions
+must not modify `Accepted`: an accepted WorkflowRun can still fail while
+executing.
 
-A reconciliation must not loop through multiple state transitions before the
+A reconciliation must not loop through multiple external actions before the
 status update. One `StartRunnableSteps` action may materialize every currently
-runnable step, including first steps for dependency-ready jobs and next steps
-whose predecessors succeeded. Each job contributes at most one target, so the
-action does not advance a job through multiple execution states in the same
-reconciliation. This makes each transition durable and restart-safe, and keeps
-new execution states explicit as child Run observation, restart recovery, and
-reusable call expansion land.
-
-For an active WorkflowRun, `ObserveChildRuns` takes precedence over
-`StartRunnableSteps`. When a child Run reaches a terminal phase, that reconciliation
-only copies the phase into the matching step status. The next reconciliation
-may then decide whether to create a next step or unblock dependent jobs.
+runnable step, including steps made runnable by status derived at the start of
+that reconciliation. Each job contributes at most one target, so the action
+does not advance a job through multiple execution operations in the same
+reconciliation. If the action fails, the controller returns the error without
+patching status. If it succeeds, created Run identities and running phases are
+added to the desired status before the single conditional status patch. This
+keeps external operations explicit, idempotent, and restart-safe without using
+extra reconciliations for internal status projection.
 
 ## Failure, Cancellation, and Terminal Semantics
 
@@ -383,9 +384,9 @@ Inline WorkflowRun execution should land in small, reviewable steps:
    Run name on the matching ordered step status, and make creation idempotent
    by discovering existing child Runs through labels.
 3. Before adding more execution states, refactor the WorkflowRun controller
-   into a load/plan/apply state-machine shape: load the WorkflowRun and related
-   resources, derive the current state, switch on that state to produce the
-   intended actions, then apply Kubernetes writes.
+   into a load/calculate/apply/patch shape: load the WorkflowRun and related
+   resources, derive desired status and current state, calculate one external
+   action, apply it, incorporate its result, and conditionally patch status.
 4. Watch or reconcile child Runs owned by a WorkflowRun and copy terminal child
    Run phase into the matching step status.
 5. Define and review failure, cancellation, and terminal-status semantics:
@@ -491,8 +492,9 @@ the implementation lands.
    `WorkflowRun.spec.uses` resolution.
 6. Implement input binding for top-level reusable Workflow calls.
 7. Implement inline WorkflowRun first-step Run creation for ready jobs.
-8. Refactor WorkflowRun controller reconciliation into a load/plan/apply
-   state-machine structure.
+8. Refactor WorkflowRun controller reconciliation into a
+   load/calculate/apply/patch structure with default status projection and
+   external side effects represented as actions.
 9. Implement child Run status observation and step status updates.
 10. Define and review child failure, cancellation, dependency propagation, and
     WorkflowRun terminal-status semantics: independent jobs continue, blocked

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -310,24 +310,23 @@ runtimed 理解 Workflow 概念。
 这有意避免增加单独的 WorkflowRunInvocation API。Child Runs 仍然是持久 execution records，
 scheduler/runtimed 仍然只操作 Runs。
 
-WorkflowRun controller 的 reconciliation 应保持 load/plan/apply 结构：加载
-WorkflowRun 和所有 child Runs，推导 current state，为该 state 选择一个 action，执行 action，
-再 patch WorkflowRun status。current state 与 action 有意分离。初始的 `Empty` state 对应
-`Initialize` action：它负责 validation controller-level semantics、resolve references 和
-inputs、persist execution graph，并设置 `Accepted=True`。初始化失败时设置 `Accepted=False`，
-且不能创建 child Runs。后续 execution actions 不得修改 `Accepted`：已经 accepted 的
-WorkflowRun 仍然可能在执行时失败。
+WorkflowRun controller 的 reconciliation 应保持 load/calculate/apply/patch 结构：加载
+WorkflowRun 和所有 child Runs，根据这些 resources 推导 desired status 和 current state，
+计算一个 action，执行 action，将执行结果合并进 desired status，并仅在 desired status 与
+已持久化 status 存在差异时 patch。status projection 是每次 reconciliation 的默认步骤；
+观察 child Runs 以及将 terminal steps 聚合为 job phase 不应成为独立 action。current state
+与 action 仍然有意分离。初始的 `Empty` state 对应 `Initialize` action：它负责 validation
+controller-level semantics、resolve references 和 inputs、persist execution graph，并设置
+`Accepted=True`。初始化失败时设置 `Accepted=False`，且不能创建 child Runs。后续 execution
+actions 不得修改 `Accepted`：已经 accepted 的 WorkflowRun 仍然可能在执行时失败。
 
-一次 reconciliation 不能在 status 更新前循环执行多个 state transitions。一个
-`StartRunnableSteps` action 可以 materialize 所有当前 runnable steps，包括 dependency-ready
-jobs 的 first steps，以及 predecessor succeeded 后的 next steps。每个 job 最多贡献一个 target，
-故 action 不会在同一次 reconciliation 中将同一个 job 推进多个 execution states。这样每个
-transition 都是 durable 且 restart-safe 的；后续引入 child Run observation、restart recovery 和
-reusable call expansion 等 execution states 时，状态也会保持显式。
-
-对于 active WorkflowRun，`ObserveChildRuns` 的优先级高于 `StartRunnableSteps`。当 child Run
-进入 terminal phase 时，该次 reconciliation 只将 phase 复制到对应的 step status。下一次
-reconciliation 才能决定是否创建 next step 或解除 dependency jobs 的阻塞。
+一次 reconciliation 不能在 status 更新前循环执行多个 external actions。一个
+`StartRunnableSteps` action 可以 materialize 所有当前 runnable steps，包括本轮开始时根据
+resources 推导状态后刚刚变为 runnable 的 steps。每个 job 最多贡献一个 target，因此 action
+不会在同一次 reconciliation 中让同一个 job 执行多个 execution operations。action 失败时，
+controller 直接返回 error，不 patch status；action 成功时，将新建 Run 的 identity 和 running
+phase 合并进 desired status，再执行一次有条件的 status patch。这样 external operations 保持
+显式、幂等且 restart-safe，同时不会为内部 status projection 额外消耗 reconciliation。
 
 ## Failure、Cancellation 和 Terminal Semantics
 
@@ -357,9 +356,9 @@ Inline WorkflowRun execution 应拆成小的、可 review 的步骤落地：
    Workflow execution model 的失效 case，保证整个迁移过程中 `make e2e` 始终可以通过。
 2. 只为 ready inline jobs 创建第一个 child Run，将 child Run name 记录到对应的有序
    step status，并通过 labels 发现已有 child Runs 来保证创建幂等。
-3. 在增加更多 execution states 之前，将 WorkflowRun controller 重构为 load/plan/apply
-   的状态机形态：先加载 WorkflowRun 和相关资源，推导 current state，再根据 state
-   计算需要执行的 actions，最后执行 Kubernetes writes。
+3. 在增加更多 execution states 之前，将 WorkflowRun controller 重构为
+   load/calculate/apply/patch 形态：加载 WorkflowRun 和相关资源，推导 desired status
+   与 current state，计算一个 external action，执行后合并结果，并按需 patch status。
 4. Watch 或 reconcile 属于 WorkflowRun 的 child Runs，并将 terminal child Run phase
    复制到对应 step status。
 5. 定义并 review failure、cancellation 和 terminal-status semantics：failure 后
@@ -455,7 +454,8 @@ status:
    namespace-local resolution。
 6. 实现 top-level reusable Workflow calls 的 input binding。
 7. 实现 ready jobs 的 inline WorkflowRun first-step Run creation。
-8. 将 WorkflowRun controller reconciliation 重构为 load/plan/apply 的状态机结构。
+8. 将 WorkflowRun controller reconciliation 重构为 load/calculate/apply/patch 结构：
+   默认推导 status，并将 external side effects 建模为 actions。
 9. 实现 child Run status observation 和 step status updates。
 10. 定义并 review child failure、cancellation、dependency propagation 和 WorkflowRun
     terminal-status semantics：independent jobs 继续，blocked dependents 为 `Skipped`，

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -210,8 +210,9 @@ wiring from accumulating avoidable conflicts.
     update stale cases that still use the old Workflow execution model so
     `make e2e` stays passing during the migration;
   - [x] implement inline WorkflowRun first-step Run creation for ready jobs;
-  - [x] refactor WorkflowRun controller reconciliation into a load/plan/apply
-    state-machine structure before adding more execution cases;
+  - [x] refactor WorkflowRun controller reconciliation into a
+    load/calculate/apply/patch structure where status is derived on every
+    reconciliation and only external side effects are actions;
   - [x] implement child Run status observation and step status updates;
   - [x] define and review child failure, cancellation, dependency propagation,
     and WorkflowRun terminal-status semantics: independent jobs continue after

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -179,8 +179,9 @@ controller wiring 累积不必要的冲突。
   - [x] 在 inline execution changes 开始前审计现有 E2E tests，移除或更新仍使用旧
     Workflow execution model 的失效 cases，保证迁移过程中 `make e2e` 始终可以通过；
   - [x] 实现 ready jobs 的 inline WorkflowRun first-step Run creation；
-  - [x] 在增加更多 execution cases 前，将 WorkflowRun controller reconciliation
-    重构为 load/plan/apply 的状态机结构；
+  - [x] 将 WorkflowRun controller reconciliation 重构为
+    load/calculate/apply/patch 结构：每次 reconciliation 默认推导 status，只有 external
+    side effects 才建模为 actions；
   - [x] 实现 child Run status observation 和 step status updates；
   - [x] 定义并 review child failure、cancellation、dependency propagation 和
     WorkflowRun terminal-status semantics：failure 后 independent jobs 继续，

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -431,8 +431,11 @@ func terminalJobPhase(status v1alpha1.JobStatus) (v1alpha1.JobPhase, bool) {
 }
 
 func deriveWorkflowRunStatus(resources *workflowRunResources) {
-	projectTerminalChildRuns(resources)
-	workflowRun := resources.workflowRun
+	deriveStepStatusesFromChildRuns(resources)
+	deriveJobStatuses(resources.workflowRun)
+}
+
+func deriveJobStatuses(workflowRun *v1alpha1.WorkflowRun) {
 	for jobName, status := range workflowRun.Status.Jobs {
 		if status.Phase != v1alpha1.JobRunning {
 			continue
@@ -458,7 +461,7 @@ func jobReadyToStart(status v1alpha1.JobStatus, jobs map[string]v1alpha1.JobStat
 	return true
 }
 
-func projectTerminalChildRuns(resources *workflowRunResources) {
+func deriveStepStatusesFromChildRuns(resources *workflowRunResources) {
 	workflowRun := resources.workflowRun
 	keys := make([]string, 0, len(resources.childRuns))
 	for key := range resources.childRuns {

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,9 +50,7 @@ type workflowRunAction string
 const (
 	workflowRunActionNone               workflowRunAction = "None"
 	workflowRunActionInitialize         workflowRunAction = "Initialize"
-	workflowRunActionObserveChildRuns   workflowRunAction = "ObserveChildRuns"
 	workflowRunActionStartRunnableSteps workflowRunAction = "StartRunnableSteps"
-	workflowRunActionFinalizeJobs       workflowRunAction = "FinalizeJobs"
 )
 
 type workflowRunResources struct {
@@ -63,7 +62,6 @@ type workflowRunPlan struct {
 	state   workflowRunState
 	action  workflowRunAction
 	targets []workflowRunStepTarget
-	jobs    []string
 }
 
 type workflowRunStepTarget struct {
@@ -95,15 +93,19 @@ func (r *WorkflowRunReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	base := workflowRun.DeepCopy()
-	plan := planWorkflowRun(resources)
-	if plan.action == workflowRunActionNone {
-		return ctrl.Result{}, nil
-	}
-	if err := r.applyWorkflowRunAction(ctx, resources, plan); err != nil {
-		return ctrl.Result{}, err
+	resources.workflowRun = workflowRun.DeepCopy()
+	plan := calculateWorkflowRunPlan(resources)
+	if plan.action != workflowRunActionNone {
+		if err := r.applyWorkflowRunAction(ctx, resources, plan); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
-	if err := r.Status().Patch(ctx, workflowRun, client.MergeFrom(base)); err != nil {
+	desired := resources.workflowRun
+	if apiequality.Semantic.DeepEqual(base.Status, desired.Status) {
+		return ctrl.Result{}, nil
+	}
+	if err := r.Status().Patch(ctx, desired, client.MergeFrom(base)); err != nil {
 		return ctrl.Result{}, fmt.Errorf("patch workflowrun status: %w", err)
 	}
 	return ctrl.Result{}, nil
@@ -132,7 +134,8 @@ func (r *WorkflowRunReconciler) loadWorkflowRunResources(ctx context.Context, ke
 	return &workflowRunResources{workflowRun: workflowRun, childRuns: childRuns}, nil
 }
 
-func planWorkflowRun(resources *workflowRunResources) workflowRunPlan {
+func calculateWorkflowRunPlan(resources *workflowRunResources) workflowRunPlan {
+	deriveWorkflowRunStatus(resources)
 	workflowRun := resources.workflowRun
 	state := workflowRunStateFor(workflowRun)
 	plan := workflowRunPlan{state: state, action: workflowRunActionNone}
@@ -141,15 +144,6 @@ func planWorkflowRun(resources *workflowRunResources) workflowRunPlan {
 		return plan
 	}
 	if state == workflowRunStateTerminal || len(workflowRun.Spec.Jobs) == 0 || len(workflowRun.Status.Jobs) == 0 {
-		return plan
-	}
-	if childRunsNeedObservation(resources) {
-		plan.action = workflowRunActionObserveChildRuns
-		return plan
-	}
-	if jobNames := jobsWithTerminalStepStates(workflowRun); len(jobNames) > 0 {
-		plan.action = workflowRunActionFinalizeJobs
-		plan.jobs = jobNames
 		return plan
 	}
 	if targets := runnableStepTargets(workflowRun); len(targets) > 0 {
@@ -196,14 +190,8 @@ func (r *WorkflowRunReconciler) applyWorkflowRunAction(ctx context.Context, reso
 	switch plan.action {
 	case workflowRunActionInitialize:
 		return r.applyInitializeWorkflowRun(ctx, workflowRun)
-	case workflowRunActionObserveChildRuns:
-		applyObserveChildRuns(resources)
-		return nil
 	case workflowRunActionStartRunnableSteps:
 		return r.applyStartRunnableSteps(ctx, resources, plan.targets)
-	case workflowRunActionFinalizeJobs:
-		applyFinalizeJobs(workflowRun, plan.jobs)
-		return nil
 	}
 	return nil
 }
@@ -422,20 +410,6 @@ func nextStepToStart(status v1alpha1.JobStatus) (int, bool) {
 	return 0, false
 }
 
-func jobsWithTerminalStepStates(workflowRun *v1alpha1.WorkflowRun) []string {
-	jobNames := make([]string, 0, len(workflowRun.Status.Jobs))
-	for jobName, status := range workflowRun.Status.Jobs {
-		if status.Phase != v1alpha1.JobRunning {
-			continue
-		}
-		if _, ok := terminalJobPhase(status); ok {
-			jobNames = append(jobNames, jobName)
-		}
-	}
-	sort.Strings(jobNames)
-	return jobNames
-}
-
 func terminalJobPhase(status v1alpha1.JobStatus) (v1alpha1.JobPhase, bool) {
 	if len(status.Steps) == 0 {
 		return "", false
@@ -456,9 +430,13 @@ func terminalJobPhase(status v1alpha1.JobStatus) (v1alpha1.JobPhase, bool) {
 	return "", false
 }
 
-func applyFinalizeJobs(workflowRun *v1alpha1.WorkflowRun, jobNames []string) {
-	for _, jobName := range jobNames {
-		status := workflowRun.Status.Jobs[jobName]
+func deriveWorkflowRunStatus(resources *workflowRunResources) {
+	projectTerminalChildRuns(resources)
+	workflowRun := resources.workflowRun
+	for jobName, status := range workflowRun.Status.Jobs {
+		if status.Phase != v1alpha1.JobRunning {
+			continue
+		}
 		phase, ok := terminalJobPhase(status)
 		if !ok {
 			continue
@@ -480,31 +458,7 @@ func jobReadyToStart(status v1alpha1.JobStatus, jobs map[string]v1alpha1.JobStat
 	return true
 }
 
-func childRunsNeedObservation(resources *workflowRunResources) bool {
-	workflowRun := resources.workflowRun
-	for _, run := range resources.childRuns {
-		stepPhase, terminal := terminalRunStepPhase(run.Status.Phase)
-		if !terminal {
-			continue
-		}
-		jobStatus, ok := workflowRun.Status.Jobs[run.Labels[v1alpha1.WorkflowJobLabel]]
-		if !ok {
-			continue
-		}
-		for _, step := range jobStatus.Steps {
-			if step.Name != run.Labels[v1alpha1.WorkflowStepLabel] {
-				continue
-			}
-			if (step.RunName == "" || step.RunName == run.Name) && (step.RunName != run.Name || step.Phase != stepPhase) {
-				return true
-			}
-			break
-		}
-	}
-	return false
-}
-
-func applyObserveChildRuns(resources *workflowRunResources) {
+func projectTerminalChildRuns(resources *workflowRunResources) {
 	workflowRun := resources.workflowRun
 	keys := make([]string, 0, len(resources.childRuns))
 	for key := range resources.childRuns {

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"strings"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 )
@@ -153,7 +155,7 @@ func TestWorkflowRunReconcilerStartsAllIndependentReadyJobs(t *testing.T) {
 
 func TestPlanWorkflowRunSeparatesCurrentStateFromAction(t *testing.T) {
 	empty := &v1alpha1.WorkflowRun{}
-	plan := planWorkflowRun(&workflowRunResources{workflowRun: empty})
+	plan := calculateWorkflowRunPlan(&workflowRunResources{workflowRun: empty})
 	if plan.state != workflowRunStateEmpty || plan.action != workflowRunActionInitialize {
 		t.Fatalf("empty plan = %#v, want Empty + Initialize", plan)
 	}
@@ -167,13 +169,13 @@ func TestPlanWorkflowRunSeparatesCurrentStateFromAction(t *testing.T) {
 			Jobs:  resolvedJobStatuses(map[string]v1alpha1.JobSpec{"build": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}}}}),
 		},
 	}
-	plan = planWorkflowRun(&workflowRunResources{workflowRun: pending})
+	plan = calculateWorkflowRunPlan(&workflowRunResources{workflowRun: pending})
 	if plan.state != workflowRunStatePending || plan.action != workflowRunActionStartRunnableSteps || len(plan.targets) != 1 || plan.targets[0] != (workflowRunStepTarget{jobName: "build", stepIndex: 0}) {
 		t.Fatalf("pending plan = %#v, want Pending + StartRunnableSteps(build[0])", plan)
 	}
 }
 
-func TestPlanWorkflowRunObservesChildRunsBeforeStartingReadyJobs(t *testing.T) {
+func TestCalculateWorkflowRunPlanProjectsStatusBeforeStartingReadyJobs(t *testing.T) {
 	workflowRun := &v1alpha1.WorkflowRun{
 		ObjectMeta: metav1.ObjectMeta{UID: "workflowrun-uid"},
 		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
@@ -189,12 +191,16 @@ func TestPlanWorkflowRunObservesChildRunsBeforeStartingReadyJobs(t *testing.T) {
 		},
 	}
 	buildRun := workflowChildRun(workflowRun, "build", "compile", "build-run", v1alpha1.RunSucceeded)
-	plan := planWorkflowRun(&workflowRunResources{
+	plan := calculateWorkflowRunPlan(&workflowRunResources{
 		workflowRun: workflowRun,
 		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): buildRun},
 	})
-	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionObserveChildRuns {
-		t.Fatalf("plan = %#v, want Running + ObserveChildRuns", plan)
+	want := []workflowRunStepTarget{{jobName: "lint", stepIndex: 0}}
+	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableSteps || !slices.Equal(plan.targets, want) {
+		t.Fatalf("plan = %#v, want Running + StartRunnableSteps(%#v)", plan, want)
+	}
+	if workflowRun.Status.Jobs["build"].Phase != v1alpha1.JobSucceeded {
+		t.Fatalf("build status = %#v, want derived succeeded job", workflowRun.Status.Jobs["build"])
 	}
 }
 
@@ -213,14 +219,14 @@ func TestPlanWorkflowRunStartsAllRunnableSteps(t *testing.T) {
 		},
 	}
 
-	plan := planWorkflowRun(&workflowRunResources{workflowRun: workflowRun})
+	plan := calculateWorkflowRunPlan(&workflowRunResources{workflowRun: workflowRun})
 	want := []workflowRunStepTarget{{jobName: "build", stepIndex: 1}, {jobName: "lint", stepIndex: 0}}
 	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableSteps || !slices.Equal(plan.targets, want) {
 		t.Fatalf("plan = %#v, want Running + StartRunnableSteps(%#v)", plan, want)
 	}
 }
 
-func TestPlanWorkflowRunFinalizesTerminalJobsBeforeStartingReadyJobs(t *testing.T) {
+func TestCalculateWorkflowRunPlanFinalizesJobsBeforeStartingReadyJobs(t *testing.T) {
 	workflowRun := &v1alpha1.WorkflowRun{
 		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
 			"build": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}}},
@@ -235,9 +241,13 @@ func TestPlanWorkflowRunFinalizesTerminalJobsBeforeStartingReadyJobs(t *testing.
 		},
 	}
 
-	plan := planWorkflowRun(&workflowRunResources{workflowRun: workflowRun})
-	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionFinalizeJobs || len(plan.jobs) != 1 || plan.jobs[0] != "build" {
-		t.Fatalf("plan = %#v, want Running + FinalizeJobs(build)", plan)
+	plan := calculateWorkflowRunPlan(&workflowRunResources{workflowRun: workflowRun})
+	want := []workflowRunStepTarget{{jobName: "lint", stepIndex: 0}}
+	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableSteps || !slices.Equal(plan.targets, want) {
+		t.Fatalf("plan = %#v, want Running + StartRunnableSteps(%#v)", plan, want)
+	}
+	if workflowRun.Status.Jobs["build"].Phase != v1alpha1.JobSucceeded {
+		t.Fatalf("build status = %#v, want derived succeeded job", workflowRun.Status.Jobs["build"])
 	}
 }
 
@@ -465,8 +475,12 @@ func TestWorkflowRunReconcilerObservesTerminalChildRuns(t *testing.T) {
 			if step.Phase != test.stepPhase || step.RunName != run.Name {
 				t.Fatalf("step = %#v, want %s %s", step, test.stepPhase, run.Name)
 			}
-			if updated.Status.Jobs["build"].Phase != v1alpha1.JobRunning || updated.Status.Phase != v1alpha1.WorkflowRunning {
-				t.Fatalf("status = %#v, want job and workflow to remain running", updated.Status)
+			wantJobPhase := v1alpha1.JobFailed
+			if test.stepPhase == v1alpha1.StepSucceeded {
+				wantJobPhase = v1alpha1.JobSucceeded
+			}
+			if updated.Status.Jobs["build"].Phase != wantJobPhase || updated.Status.Phase != v1alpha1.WorkflowRunning {
+				t.Fatalf("status = %#v, want derived terminal job and running workflow", updated.Status)
 			}
 		})
 	}
@@ -513,10 +527,8 @@ func TestWorkflowRunReconcilerCreatesNextStepAfterObservedSuccess(t *testing.T) 
 	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
 	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(workflowRun)}
 
-	// Observation is one durable transition. The following reconcile starts both
-	// the build next step and the independent lint first step.
-	reconcileWorkflowRun(t, reconciler, req, 1)
-	assertChildRunCount(t, c, workflowRun.Namespace, 1)
+	// Status projection and action planning happen in the same reconciliation,
+	// so the next build step and independent lint job start immediately.
 	reconcileWorkflowRun(t, reconciler, req, 1)
 	assertChildRunCount(t, c, workflowRun.Namespace, 3)
 
@@ -563,6 +575,54 @@ func TestWorkflowRunReconcilerCreatesNextStepAfterObservedSuccess(t *testing.T) 
 	}
 }
 
+func TestWorkflowRunReconcilerDoesNotPatchDerivedStatusWhenActionFails(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", UID: "workflowrun-uid"},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"build": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}}},
+			"lint":  {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "check", Run: "make lint"}}},
+		}},
+		Status: v1alpha1.WorkflowRunStatus{
+			Phase: v1alpha1.WorkflowRunning,
+			Jobs: map[string]v1alpha1.JobStatus{
+				"build": {Phase: v1alpha1.JobRunning, Steps: []v1alpha1.StepStatus{{Name: "compile", Phase: v1alpha1.StepRunning, RunName: "compile-run"}}},
+				"lint":  {Phase: v1alpha1.JobPending, Steps: []v1alpha1.StepStatus{{Name: "check", Phase: v1alpha1.StepPending}}},
+			},
+		},
+	}
+	compileRun := workflowChildRun(workflowRun, "build", "compile", "compile-run", v1alpha1.RunSucceeded)
+	createErr := errors.New("create child run")
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(workflowRun, compileRun).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(context.Context, client.WithWatch, client.Object, ...client.CreateOption) error {
+				return createErr
+			},
+		}).
+		Build()
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(workflowRun)})
+	if !errors.Is(err, createErr) {
+		t.Fatalf("Reconcile error = %v, want %v", err, createErr)
+	}
+
+	var updated v1alpha1.WorkflowRun
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
+		t.Fatalf("get workflowrun: %v", err)
+	}
+	build := updated.Status.Jobs["build"]
+	if build.Phase != v1alpha1.JobRunning || build.Steps[0].Phase != v1alpha1.StepRunning {
+		t.Fatalf("build status = %#v, want persisted status unchanged", build)
+	}
+}
+
 func TestWorkflowRunReconcilerFinalizesJobAfterObservedTerminalStep(t *testing.T) {
 	for _, test := range []struct {
 		name     string
@@ -601,8 +661,8 @@ func TestWorkflowRunReconcilerFinalizesJobAfterObservedTerminalStep(t *testing.T
 			reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
 			req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(workflowRun)}
 
-			// Observation and job finalization are separate durable transitions.
-			reconcileWorkflowRun(t, reconciler, req, 2)
+			// Child observation and job aggregation are derived before planning.
+			reconcileWorkflowRun(t, reconciler, req, 1)
 
 			var updated v1alpha1.WorkflowRun
 			if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {


### PR DESCRIPTION
## Summary

- derive child Run and terminal job status during every WorkflowRun reconciliation
- reserve reconcile actions for external side effects and plan from the derived status
- patch status only after a successful action and only when desired status differs
- update the Workflow design and roadmap in English and Chinese

## Behavioral impact

A terminal child Run can now update its step/job status and make the next steps runnable in the same reconciliation. If the external action fails, the derived status is not persisted and is recomputed on retry.

## Validation

- `make test`
- `make test-integration`
- `make site-build`