### PR TITLE
test(controller): verify WorkflowRun restart recovery

### DIFF
--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -561,7 +561,8 @@ the implementation lands.
 14. Implement failed-dependency propagation to `JobSkipped`.
 15. Implement WorkflowRun terminal aggregation.
 16. Implement WorkflowRun cancellation propagation.
-17. Implement controller restart recovery for in-progress inline WorkflowRuns.
+17. Verify controller restart recovery for in-progress inline WorkflowRuns,
+    including child Run creation before status persistence.
 18. Implement job-level reusable Workflow calls.
 19. Implement step-level Action expansion.
 20. Implement expression evaluation and output propagation.
@@ -569,7 +570,7 @@ the implementation lands.
 22. Add E2E coverage for inline `WorkflowRun`, reusable Workflow calls, Action
    calls, validation failures, output propagation, and controller restart
    recovery from the status DAG edges.
-20. Update the final v0.x demos after the reusable model is implemented.
+23. Update the final v0.x demos after the reusable model is implemented.
 
 Current implementation status:
 
@@ -586,11 +587,13 @@ Current implementation status:
   values are not evaluated into child Runs until WorkflowRun execution lands.
 - Stale E2E stubs for the old Workflow execution model have been removed so
   E2E stays focused on behavior that should still pass during the migration.
-- Inline WorkflowRuns create first-step child Runs for ready inline jobs and
-  record the child Run name in ordered step status. Child Run result
-  observation and next-step creation are still follow-up work.
-- WorkflowRuns observe terminal child Run phases and copy them into the
-  matching step status. Next-step creation and job/WorkflowRun terminal
-  handling are still follow-up work.
+- Inline WorkflowRuns create first-step and next-step child Runs for runnable
+  jobs and record child Run names in ordered step status.
+- WorkflowRuns observe terminal child Run phases, copy them into matching step
+  status, and aggregate terminal job phases. WorkflowRun terminal handling is
+  still follow-up work.
+- Restart recovery is verified across the create-before-status-patch failure
+  window: a replacement controller discovers child Runs through durable labels,
+  repairs step status, and continues terminal observation without duplicates.
 - Old Workflow execution E2E coverage is skipped until WorkflowRun execution
   lands.

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -513,7 +513,8 @@ status:
 14. 实现到 `JobSkipped` 的 failed-dependency propagation。
 15. 实现 WorkflowRun terminal aggregation。
 16. 实现 WorkflowRun cancellation propagation。
-17. 实现 in-progress inline WorkflowRuns 的 controller restart recovery。
+17. 验证 in-progress inline WorkflowRuns 的 controller restart recovery，包括 child Run
+    已创建但 status 尚未持久化的故障窗口。
 18. 实现 job-level reusable Workflow calls。
 19. 实现 step-level Action expansion。
 20. 实现 expression evaluation 和 output propagation。
@@ -521,7 +522,7 @@ status:
 22. 增加 E2E 覆盖 inline `WorkflowRun`、reusable Workflow calls、Action calls、
    validation failures、output propagation，以及从 status DAG edges 进行 controller
    restart recovery。
-20. reusable model 实现后，更新最终 v0.x demos。
+23. reusable model 实现后，更新最终 v0.x demos。
 
 当前实现状态：
 
@@ -537,9 +538,11 @@ status:
   WorkflowRun execution 实现后再用于 child Runs。
 - 旧 Workflow execution model 的 stale E2E stubs 已删除，保证迁移期间 E2E 聚焦于
   仍应保持 passing 的行为。
-- Inline WorkflowRuns 会为 ready inline jobs 创建 first-step child Runs，并将 child
-  Run name 记录到有序 step status 中。Child Run result observation 和 next-step
-  creation 仍是后续工作。
-- WorkflowRuns 会观察 terminal child Run phases，并复制到匹配的 step status。
-  Next-step creation 和 job/WorkflowRun terminal handling 仍是后续工作。
+- Inline WorkflowRuns 会为 runnable jobs 创建 first-step 和 next-step child Runs，并将
+  child Run names 记录到有序 step status 中。
+- WorkflowRuns 会观察 terminal child Run phases、复制到匹配的 step status，并聚合
+  terminal job phases。WorkflowRun terminal handling 仍是后续工作。
+- Restart recovery 已覆盖 create-before-status-patch 故障窗口：replacement controller
+  通过 durable labels 发现 child Runs、修复 step status，并继续观察 terminal state，且
+  不会重复创建 Runs。
 - 旧 Workflow execution E2E coverage 暂时 skip，等待 WorkflowRun execution 实现后恢复。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -225,7 +225,8 @@ wiring from accumulating avoidable conflicts.
   - implement failed-dependency propagation to `JobSkipped`;
   - implement WorkflowRun terminal aggregation;
   - implement WorkflowRun cancellation propagation;
-  - implement controller restart recovery for in-progress inline WorkflowRuns;
+  - [x] verify controller restart recovery for in-progress inline WorkflowRuns,
+    including child Run creation before status persistence;
   - implement job-level reusable Workflow calls;
   - implement step-level Action expansion;
   - implement expression evaluation for `inputs`, `steps`, and `jobs` contexts;

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -193,7 +193,8 @@ controller wiring 累积不必要的冲突。
   - 实现到 `JobSkipped` 的 failed-dependency propagation；
   - 实现 WorkflowRun terminal aggregation；
   - 实现 WorkflowRun cancellation propagation；
-  - 实现 in-progress inline WorkflowRuns 的 controller restart recovery；
+  - [x] 验证 in-progress inline WorkflowRuns 的 controller restart recovery，包括
+    child Run 已创建但 status 尚未持久化的故障窗口；
   - 实现 job-level reusable Workflow calls；
   - 实现 step-level Action expansion；
   - 实现 `inputs`、`steps` 和 `jobs` contexts 的 expression evaluation；

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -623,6 +623,103 @@ func TestWorkflowRunReconcilerDoesNotPatchDerivedStatusWhenActionFails(t *testin
 	}
 }
 
+func TestWorkflowRunReconcilerRecoversAfterRestartAcrossStatusPatchFailure(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", UID: "workflowrun-uid"},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"build": {
+				RunsOn: "bash",
+				Steps: []v1alpha1.StepSpec{
+					{Name: "compile", Run: "make build"},
+					{Name: "package", Run: "make package"},
+				},
+			},
+		}},
+		Status: v1alpha1.WorkflowRunStatus{
+			Phase: v1alpha1.WorkflowRunning,
+			Jobs: map[string]v1alpha1.JobStatus{
+				"build": {Phase: v1alpha1.JobRunning, Steps: []v1alpha1.StepStatus{
+					{Name: "compile", Phase: v1alpha1.StepSucceeded, RunName: "compile-run"},
+					{Name: "package", Phase: v1alpha1.StepPending},
+				}},
+			},
+		},
+	}
+	compileRun := workflowChildRun(workflowRun, "build", "compile", "compile-run", v1alpha1.RunSucceeded)
+	statusErr := errors.New("patch workflowrun status")
+	failStatusPatch := true
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(workflowRun, compileRun).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}, &v1alpha1.Run{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(ctx context.Context, underlying client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				if subResourceName == "status" && failStatusPatch {
+					return statusErr
+				}
+				return underlying.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(workflowRun)}
+
+	firstController := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	if _, err := firstController.Reconcile(context.Background(), req); !errors.Is(err, statusErr) {
+		t.Fatalf("first Reconcile error = %v, want %v", err, statusErr)
+	}
+	assertChildRunCount(t, c, workflowRun.Namespace, 2)
+
+	var persisted v1alpha1.WorkflowRun
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &persisted); err != nil {
+		t.Fatalf("get workflowrun after failed status patch: %v", err)
+	}
+	if step := persisted.Status.Jobs["build"].Steps[1]; step.RunName != "" || step.Phase != v1alpha1.StepPending {
+		t.Fatalf("persisted package step = %#v, want pending without runName", step)
+	}
+
+	// A replacement controller discovers the already-created Run by labels and
+	// repairs status instead of creating a duplicate.
+	failStatusPatch = false
+	restartedController := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	reconcileWorkflowRun(t, restartedController, req, 1)
+	assertChildRunCount(t, c, workflowRun.Namespace, 2)
+
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &persisted); err != nil {
+		t.Fatalf("get recovered workflowrun: %v", err)
+	}
+	packageStep := persisted.Status.Jobs["build"].Steps[1]
+	if packageStep.RunName == "" || packageStep.Phase != v1alpha1.StepRunning {
+		t.Fatalf("recovered package step = %#v, want running with existing runName", packageStep)
+	}
+
+	var packageRun v1alpha1.Run
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: workflowRun.Namespace, Name: packageStep.RunName}, &packageRun); err != nil {
+		t.Fatalf("get recovered package run: %v", err)
+	}
+	packageRun.Status.Phase = v1alpha1.RunSucceeded
+	if err := c.Status().Update(context.Background(), &packageRun); err != nil {
+		t.Fatalf("complete package run: %v", err)
+	}
+
+	// Another replacement controller derives terminal step and job state from
+	// the durable child Run without relying on process-local memory.
+	terminalController := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	reconcileWorkflowRun(t, terminalController, req, 1)
+	assertChildRunCount(t, c, workflowRun.Namespace, 2)
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &persisted); err != nil {
+		t.Fatalf("get terminal workflowrun: %v", err)
+	}
+	build := persisted.Status.Jobs["build"]
+	if build.Phase != v1alpha1.JobSucceeded || build.Steps[1].Phase != v1alpha1.StepSucceeded {
+		t.Fatalf("recovered build status = %#v, want succeeded", build)
+	}
+}
+
 func TestWorkflowRunReconcilerFinalizesJobAfterObservedTerminalStep(t *testing.T) {
 	for _, test := range []struct {
 		name     string


### PR DESCRIPTION
## Summary

- simulate child Run creation succeeding while the WorkflowRun status patch fails
- replace reconciler instances and verify label-based Run recovery repairs status without duplicate Runs
- verify another replacement reconciler continues terminal child observation and job aggregation
- update the English and Chinese design/roadmap with the proven restart contract

No production recovery loop is added: WorkflowRun reconciliation is already stateless and reconstructs its view from persisted WorkflowRun status plus labeled child Runs.

## Validation

- `make test`
- `make test-integration`
- `make site-build`