### PR TITLE
docs(workflow): define job-level reuse execution

### DIFF
--- a/docs/design/_index.md
+++ b/docs/design/_index.md
@@ -10,4 +10,5 @@ implemented.
 - [Function Mode and Agent Sandboxes](function-mode/)
 - [Workflow Data Sharing](workflow-data-sharing/)
 - [Workflow Reuse](workflow-reuse/)
+- [Job-Level Reusable Workflow Execution](workflow-job-reuse/)
 - [Dashboard](dashboard/)

--- a/docs/design/_index.zh.md
+++ b/docs/design/_index.zh.md
@@ -8,4 +8,5 @@
 - [Function Mode 和 Agent Sandboxes](function-mode/)
 - [Workflow Data Sharing](workflow-data-sharing/)
 - [Workflow Reuse](workflow-reuse/)
+- [Job-Level Reusable Workflow Execution](workflow-job-reuse/)
 - [Dashboard](dashboard/)

--- a/docs/design/workflow-job-reuse.md
+++ b/docs/design/workflow-job-reuse.md
@@ -3,7 +3,7 @@
 Status: **Proposed for review**
 
 This document refines the job-level `uses` model introduced in
-[Workflow Reuse](workflow-reuse.md). It defines an execution boundary that is
+[Workflow Reuse](../workflow-reuse/). It defines an execution boundary that is
 deterministic across controller restarts and reusable `Workflow` updates.
 
 ## Problem
@@ -128,25 +128,30 @@ initializing `status.jobs` or creating any child, the controller recursively
 resolves the complete namespace-local Workflow call tree and writes an
 immutable execution snapshot.
 
-The snapshot is stored outside status in WorkflowRun-owned, immutable
-ConfigMaps:
+The snapshot is stored outside status in WorkflowRun-owned `ControllerRevision`
+objects. Kubernetes API validation makes a successfully created revision's
+`data` immutable:
 
-- a small index ConfigMap maps stable call paths to definition snapshots;
-- definition ConfigMaps contain normalized Workflow inputs, outputs, and jobs;
+- a small index ControllerRevision maps stable call paths to definition
+  revisions;
+- definition ControllerRevisions contain normalized Workflow inputs, outputs,
+  and jobs in their JSON `data` fields;
 - every entry records source name, UID, generation, and resource version;
 - call nodes retain unevaluated `with` expressions for later evaluation in the
   caller context;
-- ConfigMaps contain no runtime results or secret material;
+- revision data contains no runtime results or secret material;
 - owner references provide garbage collection with the root WorkflowRun.
 
 Snapshot names are deterministic and content-addressed. Creation is idempotent:
 after a partial failure, reconciliation verifies and reuses matching immutable
-ConfigMaps before creating missing entries. Unreferenced partial snapshots are
-deleted before the WorkflowRun is accepted.
+ControllerRevision data before creating missing entries. The controller does
+not rely on mutable revision labels or annotations for correctness.
+Unreferenced partial revisions are deleted before the WorkflowRun is accepted.
 
-`WorkflowRun.status.snapshotName` records the index ConfigMap name. Status does
-not copy full job specs, scripts, or environment values. If a snapshot cannot
-fit Kubernetes object limits, resolution fails before execution.
+`WorkflowRun.status.snapshotName` records the index ControllerRevision name.
+Status does not copy full job specs, scripts, or environment values. If a
+snapshot cannot fit ControllerRevision object limits, resolution fails before
+execution.
 
 Once `snapshotName` is persisted, all reconciliation reads the snapshot rather
 than current `Workflow` objects. A child WorkflowRun inherits the root snapshot
@@ -166,7 +171,7 @@ Snapshot resolution happens before any execution child is created:
 4. Record each definition version and call path in the snapshot.
 5. Reject missing definitions, invalid inputs, unsupported shapes, and direct
    or indirect Workflow call cycles.
-6. Persist immutable snapshot ConfigMaps.
+6. Persist immutable snapshot ControllerRevisions.
 7. Initialize lightweight status from the snapshot and set `Accepted=True`.
 
 Initial safety limits are a maximum call depth of 8 and at most 64 reusable
@@ -180,7 +185,7 @@ The controller keeps the existing load/calculate/apply/patch structure.
 
 Loaded resources add:
 
-- the root snapshot index and definition ConfigMaps;
+- the root snapshot index and definition ControllerRevisions;
 - direct child WorkflowRuns owned by the reconciled WorkflowRun;
 - direct child Runs for inline jobs.
 
@@ -234,7 +239,7 @@ Implementation requires review of these API and operational changes:
   one-way cancellation;
 - reject `runs-on`, `steps`, and caller-defined `outputs` on a `uses` job;
 - reserve snapshot/call-path labels and annotations;
-- grant the WorkflowRun controller namespace-scoped ConfigMap
+- grant the WorkflowRun controller namespace-scoped `apps` ControllerRevision
   get/list/watch/create/delete permissions;
 - watch owned child WorkflowRuns as well as child Runs.
 
@@ -261,7 +266,7 @@ Status should remain lightweight execution state, not an execution-spec store.
 ## Implementation Plan
 
 1. API prerequisites: status references, transition validation, reserved
-   metadata, generated CRDs, and ConfigMap/child-WorkflowRun RBAC.
+   metadata, generated CRDs, and ControllerRevision/child-WorkflowRun RBAC.
 2. Snapshot storage and recursive resolver with version capture, limits, input
    validation, and cross-Workflow cycle detection.
 3. Execute top-level `spec.uses` from the immutable snapshot, fixing the current

--- a/docs/design/workflow-job-reuse.md
+++ b/docs/design/workflow-job-reuse.md
@@ -1,0 +1,274 @@
+# Job-Level Reusable Workflow Execution
+
+Status: **Proposed for review**
+
+This document refines the job-level `uses` model introduced in
+[Workflow Reuse](workflow-reuse.md). It defines an execution boundary that is
+deterministic across controller restarts and reusable `Workflow` updates.
+
+## Problem
+
+The existing design says that a job-level reusable Workflow call expands into
+a nested job group, but it does not define:
+
+- how caller `needs` edges connect to callee roots and leaves;
+- how nested jobs appear in `WorkflowRun.status.jobs`;
+- how nested execution paths fit Kubernetes label limits;
+- how cancellation, failure, outputs, and restart recovery cross the call
+  boundary;
+- how an accepted WorkflowRun avoids observing later changes to a referenced
+  `Workflow`.
+
+The last point is already an implementation gap for top-level
+`WorkflowRun.spec.uses`: the controller initializes status from the referenced
+definition, but execution still reads `WorkflowRun.spec.jobs`, which is empty
+for that shape.
+
+## Decision
+
+A job-level reusable Workflow call is represented by a child `WorkflowRun`.
+The caller job remains one logical dependency and output node. The called
+Workflow's jobs remain local to the child WorkflowRun instead of being flattened
+into the parent status map.
+
+This choice adds one Kubernetes object and controller transition per call. That
+cost is outside the hot Run scheduling path and buys explicit ownership,
+bounded names, local status, recursive cancellation, and independent
+workspace/artifact boundaries.
+
+The first implementation remains namespace-local and does not add a new public
+invocation CRD.
+
+## User Model
+
+The API shape remains direct:
+
+```yaml
+apiVersion: kruntimes.io/v1alpha1
+kind: WorkflowRun
+metadata:
+  name: release
+spec:
+  jobs:
+    build:
+      runs-on: bash
+      steps:
+        - name: package
+          run: make package
+    deploy:
+      needs: [build]
+      uses: deploy-workflow
+      with:
+        environment: staging
+    notify:
+      needs: [deploy]
+      runs-on: bash
+      steps:
+        - name: send
+          run: send-notification
+```
+
+`deploy` behaves as one caller job:
+
+- it starts only after `build` succeeds;
+- its child WorkflowRun may execute multiple jobs in parallel;
+- it succeeds only when the child WorkflowRun succeeds;
+- `notify` waits for the complete child WorkflowRun, not one internal leaf;
+- called Workflow outputs become outputs of the `deploy` job;
+- called jobs do not share a workspace with caller jobs.
+
+This follows the useful part of the
+[GitHub Actions reusable-workflow model](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows):
+reusable Workflows are called at job level, while their declared outputs are
+consumed through the caller job. The kruntimes implementation remains
+Kubernetes-native and namespace-local.
+
+## Parent and Child Status
+
+`JobStatus` gains an optional `workflowRunName`, symmetric with
+`StepStatus.runName`:
+
+```yaml
+status:
+  jobs:
+    deploy:
+      phase: Running
+      pre: [build]
+      workflowRunName: release-deploy-7f6d98c04a
+```
+
+A call job has `workflowRunName` and no step statuses. The child WorkflowRun
+contains its own local `status.jobs` map. Nested names therefore never need to
+be encoded into a parent map key or a child Run label.
+
+The child WorkflowRun has a controller owner reference to its parent. Its name
+is deterministic from the parent UID and caller job name. Reserved labels and
+annotations identify the root WorkflowRun UID, snapshot, and call path for
+recovery and diagnostics.
+
+The parent controller watches owned child WorkflowRuns and projects state as
+follows:
+
+| Child WorkflowRun | Caller job |
+| --- | --- |
+| `Pending` or `Running` | `Running` |
+| `Succeeded` | `Succeeded` |
+| `Failed` | `Failed` |
+| `Cancelled` outside parent cancellation | `Failed` |
+
+During parent cancellation, the controller requests cancellation on active
+child WorkflowRuns and direct child Runs. The parent becomes `Cancelled` only
+after both kinds of children settle. Jobs that never started retain their
+existing `Pending` or `Waiting` phase.
+
+## Immutable Execution Snapshot
+
+Accepted executions must not read mutable `Workflow` definitions again. Before
+initializing `status.jobs` or creating any child, the controller recursively
+resolves the complete namespace-local Workflow call tree and writes an
+immutable execution snapshot.
+
+The snapshot is stored outside status in WorkflowRun-owned, immutable
+ConfigMaps:
+
+- a small index ConfigMap maps stable call paths to definition snapshots;
+- definition ConfigMaps contain normalized Workflow inputs, outputs, and jobs;
+- every entry records source name, UID, generation, and resource version;
+- call nodes retain unevaluated `with` expressions for later evaluation in the
+  caller context;
+- ConfigMaps contain no runtime results or secret material;
+- owner references provide garbage collection with the root WorkflowRun.
+
+Snapshot names are deterministic and content-addressed. Creation is idempotent:
+after a partial failure, reconciliation verifies and reuses matching immutable
+ConfigMaps before creating missing entries. Unreferenced partial snapshots are
+deleted before the WorkflowRun is accepted.
+
+`WorkflowRun.status.snapshotName` records the index ConfigMap name. Status does
+not copy full job specs, scripts, or environment values. If a snapshot cannot
+fit Kubernetes object limits, resolution fails before execution.
+
+Once `snapshotName` is persisted, all reconciliation reads the snapshot rather
+than current `Workflow` objects. A child WorkflowRun inherits the root snapshot
+and a call-path annotation, so nested calls use the same immutable tree.
+
+The root WorkflowRun spec is also execution input. After creation, `jobs`,
+`uses`, and `with` are immutable. `cancelRequested` may transition from false to
+true but not back to false. These rules require CRD transition validation.
+
+## Resolution and Cycle Detection
+
+Snapshot resolution happens before any execution child is created:
+
+1. Select inline root jobs or resolve top-level `spec.uses`.
+2. Validate and bind literal top-level inputs.
+3. Recursively resolve every job-level `uses` in the same namespace.
+4. Record each definition version and call path in the snapshot.
+5. Reject missing definitions, invalid inputs, unsupported shapes, and direct
+   or indirect Workflow call cycles.
+6. Persist immutable snapshot ConfigMaps.
+7. Initialize lightweight status from the snapshot and set `Accepted=True`.
+
+Initial safety limits are a maximum call depth of 8 and at most 64 reusable
+Workflow call nodes per root execution. Exceeding either limit rejects the
+WorkflowRun before child creation. These bounds prevent accidental recursive
+expansion even when the graph is acyclic.
+
+## Reconciliation
+
+The controller keeps the existing load/calculate/apply/patch structure.
+
+Loaded resources add:
+
+- the root snapshot index and definition ConfigMaps;
+- direct child WorkflowRuns owned by the reconciled WorkflowRun;
+- direct child Runs for inline jobs.
+
+Planning can produce one of two runnable target kinds:
+
+- an inline step target creates or reuses a child Run;
+- a reusable call target creates or reuses a child WorkflowRun.
+
+One reconcile may start all currently ready targets in parallel, but at most
+one target per caller job. Created child identities are recorded in desired
+status before the single status patch. Deterministic names and owner watches
+repair create-before-status-patch failures after restart.
+
+Top-level `spec.uses` does not create a wrapper child WorkflowRun. The root
+WorkflowRun initializes and executes the root jobs from its immutable snapshot.
+Only job-level calls create child WorkflowRuns.
+
+## Job Shape and Outputs
+
+A call job supports `needs`, `uses`, and `with`. It does not support `runs-on`,
+`steps`, or caller-defined `outputs` in v0.x. The called Workflow selects
+runtimes for its own jobs and exposes outputs through `Workflow.spec.outputs`.
+
+Input expressions are evaluated only when the call job becomes runnable, using
+the caller's completed dependency outputs. The resulting concrete values are
+placed in the child WorkflowRun's immutable `with` map. Secret inputs remain
+out of scope until a separate secret-handling design is reviewed.
+
+Output evaluation remains part of the existing expression/output propagation
+story. This design only fixes the boundary: child Workflow outputs are promoted
+to caller job outputs, and downstream jobs access them through the normal jobs
+context.
+
+## Component Boundaries
+
+- The WorkflowRun controller owns resolution, snapshots, child WorkflowRuns,
+  child Runs, status projection, and cancellation propagation.
+- The Workflow and Action controllers continue to validate definitions only.
+- Scheduler and runtimed continue to see only independent Runs and remain
+  unaware of Workflow calls and snapshots.
+- PersistentWorkspace and ArtifactStore behavior remains attached to the
+  called jobs, not to the synthetic caller job.
+
+## API and RBAC Changes
+
+Implementation requires review of these API and operational changes:
+
+- add `WorkflowRun.status.snapshotName`;
+- add `JobStatus.workflowRunName`;
+- add WorkflowRun spec transition validation for immutable execution inputs and
+  one-way cancellation;
+- reject `runs-on`, `steps`, and caller-defined `outputs` on a `uses` job;
+- reserve snapshot/call-path labels and annotations;
+- grant the WorkflowRun controller namespace-scoped ConfigMap
+  get/list/watch/create/delete permissions;
+- watch owned child WorkflowRuns as well as child Runs.
+
+## Rejected Alternatives
+
+### Flatten callee jobs into parent status
+
+Flattening avoids child WorkflowRun objects, but it requires synthetic caller
+nodes, rewrites external dependency edges to callee roots and leaves, leaks
+nested paths into labels, and mixes independent workspace/artifact boundaries
+in one status map. It also makes nested cancellation and output aggregation
+harder to explain.
+
+### Read the current Workflow on every reconcile
+
+This is simple but changes an in-progress execution when a reusable definition
+is edited. It cannot provide deterministic retries or restart recovery.
+
+### Copy resolved definitions into WorkflowRun status
+
+This makes status large and may duplicate scripts and environment values.
+Status should remain lightweight execution state, not an execution-spec store.
+
+## Implementation Plan
+
+1. API prerequisites: status references, transition validation, reserved
+   metadata, generated CRDs, and ConfigMap/child-WorkflowRun RBAC.
+2. Snapshot storage and recursive resolver with version capture, limits, input
+   validation, and cross-Workflow cycle detection.
+3. Execute top-level `spec.uses` from the immutable snapshot, fixing the current
+   status-only resolution gap.
+4. Create and observe child WorkflowRuns for ready job-level calls, including
+   dependency and terminal propagation.
+5. Add restart, mutation, nested-call, cancellation, and invalid-graph tests.
+6. Integrate expression inputs and child Workflow outputs in the existing
+   output propagation work.
+7. Add E2E coverage, then update the final workflow demo.

--- a/docs/design/workflow-job-reuse.zh.md
+++ b/docs/design/workflow-job-reuse.zh.md
@@ -1,0 +1,243 @@
+# Job-Level Reusable Workflow Execution
+
+状态：**提案，等待 review**
+
+本文细化 [Workflow Reuse](workflow-reuse.md) 中的 job-level `uses` 模型，定义一个在
+controller restart 和 reusable `Workflow` 更新后仍保持确定性的 execution boundary。
+
+## 问题
+
+现有设计提出将 job-level reusable Workflow call 展开为 nested job group，但没有定义：
+
+- caller `needs` 如何连接 callee roots 和 leaves；
+- nested jobs 如何出现在 `WorkflowRun.status.jobs`；
+- nested execution path 如何满足 Kubernetes label 长度限制；
+- cancellation、failure、outputs 和 restart recovery 如何跨越 call boundary；
+- 已 accepted 的 WorkflowRun 如何避免观察到 referenced `Workflow` 的后续修改。
+
+最后一点已经造成 top-level `WorkflowRun.spec.uses` 的实现缺口：controller 会根据 referenced
+definition 初始化 status，但执行仍读取 `WorkflowRun.spec.jobs`；对于该 shape，此字段为空。
+
+## 决策
+
+job-level reusable Workflow call 使用 child `WorkflowRun` 表示。caller job 仍是一个逻辑
+dependency 和 output 节点。called Workflow 的 jobs 保留在 child WorkflowRun 的本地状态中，
+而不是扁平化到 parent status map。
+
+该方案会为每次 call 增加一个 Kubernetes object 和 controller transition。这些开销不在 Run
+调度热路径上，换来明确的 ownership、有界命名、本地 status、递归 cancellation，以及独立的
+workspace/artifact boundary。
+
+第一版保持 namespace-local，不增加新的 public invocation CRD。
+
+## 用户模型
+
+API 保持直接：
+
+```yaml
+apiVersion: kruntimes.io/v1alpha1
+kind: WorkflowRun
+metadata:
+  name: release
+spec:
+  jobs:
+    build:
+      runs-on: bash
+      steps:
+        - name: package
+          run: make package
+    deploy:
+      needs: [build]
+      uses: deploy-workflow
+      with:
+        environment: staging
+    notify:
+      needs: [deploy]
+      runs-on: bash
+      steps:
+        - name: send
+          run: send-notification
+```
+
+`deploy` 表现为一个 caller job：
+
+- 只有 `build` 成功后才启动；
+- child WorkflowRun 内可以并行执行多个 jobs；
+- 只有 child WorkflowRun succeeded 时它才 succeeded；
+- `notify` 等待完整 child WorkflowRun，而不是某个内部 leaf；
+- called Workflow outputs 成为 `deploy` job outputs；
+- called jobs 不与 caller jobs 共享 workspace。
+
+该语义保留了
+[GitHub Actions reusable-workflow model](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows)
+中有价值的部分：reusable Workflow 在 job level 调用，并通过 caller job 使用其 outputs。
+kruntimes 的实现仍保持 Kubernetes-native 和 namespace-local。
+
+## Parent 和 Child Status
+
+`JobStatus` 增加可选 `workflowRunName`，与 `StepStatus.runName` 对称：
+
+```yaml
+status:
+  jobs:
+    deploy:
+      phase: Running
+      pre: [build]
+      workflowRunName: release-deploy-7f6d98c04a
+```
+
+call job 有 `workflowRunName`，没有 step statuses。child WorkflowRun 包含自己的本地
+`status.jobs` map。因此 nested names 不需要编码到 parent map key 或 child Run label 中。
+
+child WorkflowRun 使用 controller owner reference 指向 parent。其名称由 parent UID 和 caller
+job name 确定性生成。保留的 labels 和 annotations 会记录 root WorkflowRun UID、snapshot 和
+call path，用于 recovery 和诊断。
+
+parent controller watch owned child WorkflowRuns，并按如下规则投影状态：
+
+| Child WorkflowRun | Caller job |
+| --- | --- |
+| `Pending` 或 `Running` | `Running` |
+| `Succeeded` | `Succeeded` |
+| `Failed` | `Failed` |
+| 非 parent cancellation 导致的 `Cancelled` | `Failed` |
+
+parent cancellation 期间，controller 会请求取消 active child WorkflowRuns 和 direct child
+Runs。两类 children 都 settled 后，parent 才进入 `Cancelled`。从未启动的 jobs 保持原有
+`Pending` 或 `Waiting` phase。
+
+## Immutable Execution Snapshot
+
+accepted execution 不能再次读取 mutable `Workflow` definitions。在初始化 `status.jobs` 或
+创建任何 child 前，controller 会递归解析完整的 namespace-local Workflow call tree，并写入
+immutable execution snapshot。
+
+snapshot 不放在 status 中，而是存储在由 WorkflowRun owner 的 immutable ConfigMaps 中：
+
+- 一个较小的 index ConfigMap 将稳定 call paths 映射到 definition snapshots；
+- definition ConfigMaps 包含 normalized Workflow inputs、outputs 和 jobs；
+- 每个 entry 记录 source name、UID、generation 和 resource version；
+- call nodes 保留尚未求值的 `with` expressions，后续在 caller context 中求值；
+- ConfigMaps 不包含 runtime results 或 secret material；
+- owner references 使其随 root WorkflowRun 被 garbage collection。
+
+Snapshot names 使用确定性的 content-addressed 方式生成。创建过程保持幂等：发生部分失败后，
+reconcile 会先校验并复用匹配的 immutable ConfigMaps，再创建缺失 entries。WorkflowRun
+accepted 前会删除未被引用的 partial snapshots。
+
+`WorkflowRun.status.snapshotName` 记录 index ConfigMap 名称。Status 不复制完整 job specs、
+scripts 或 environment values。如果 snapshot 无法满足 Kubernetes object size limits，resolution
+会在执行前失败。
+
+一旦 `snapshotName` 持久化，后续 reconcile 只读取 snapshot，不再读取当前 `Workflow`
+objects。child WorkflowRun 继承 root snapshot 和 call-path annotation，因此 nested calls 使用
+同一份 immutable tree。
+
+root WorkflowRun spec 也是 execution input。创建后，`jobs`、`uses` 和 `with` 不可修改；
+`cancelRequested` 只允许从 false 变成 true，不能恢复为 false。这些规则需要 CRD transition
+validation。
+
+## Resolution 和 Cycle Detection
+
+snapshot resolution 在创建任何 execution child 前完成：
+
+1. 选择 inline root jobs，或者解析 top-level `spec.uses`。
+2. 校验并绑定 literal top-level inputs。
+3. 递归解析同 namespace 中的所有 job-level `uses`。
+4. 将每个 definition version 和 call path 记录到 snapshot。
+5. 拒绝 missing definitions、invalid inputs、unsupported shapes，以及直接或间接 Workflow
+   call cycles。
+6. 持久化 immutable snapshot ConfigMaps。
+7. 根据 snapshot 初始化轻量 status，并设置 `Accepted=True`。
+
+初始安全限制为最大 call depth 8，以及每个 root execution 最多 64 个 reusable Workflow call
+nodes。超过任一限制都会在创建 child 前拒绝 WorkflowRun。即使 graph 无环，这些限制也能防止
+意外递归扩张。
+
+## Reconciliation
+
+controller 保持现有 load/calculate/apply/patch 结构。
+
+加载的资源增加：
+
+- root snapshot index 和 definition ConfigMaps；
+- reconciled WorkflowRun owner 的 direct child WorkflowRuns；
+- inline jobs 对应的 direct child Runs。
+
+plan 可以产生两类 runnable target：
+
+- inline step target 创建或复用 child Run；
+- reusable call target 创建或复用 child WorkflowRun。
+
+一次 reconcile 可以并行启动所有当前 ready targets，但每个 caller job 最多一个 target。创建的
+child identities 会在单次 status patch 前记录到 desired status。确定性名称和 owner watches
+能够在 restart 后修复 create-before-status-patch failure。
+
+top-level `spec.uses` 不创建 wrapper child WorkflowRun。root WorkflowRun 会根据 immutable
+snapshot 初始化并执行 root jobs。只有 job-level calls 创建 child WorkflowRuns。
+
+## Job Shape 和 Outputs
+
+call job 支持 `needs`、`uses` 和 `with`。v0.x 不支持 `runs-on`、`steps` 或 caller-defined
+`outputs`。called Workflow 为其内部 jobs 选择 runtimes，并通过 `Workflow.spec.outputs` 暴露
+outputs。
+
+input expressions 只在 call job ready 时求值，并使用 caller 已完成 dependency outputs。求值后
+的具体值放入 child WorkflowRun 的 immutable `with` map。Secret inputs 继续保持 out of scope，
+直到单独的 secret-handling design 完成 review。
+
+output evaluation 仍属于现有 expression/output propagation story。本文只确定 boundary：child
+Workflow outputs 会提升为 caller job outputs，downstream jobs 通过普通 jobs context 访问。
+
+## Component Boundaries
+
+- WorkflowRun controller 负责 resolution、snapshots、child WorkflowRuns、child Runs、status
+  projection 和 cancellation propagation。
+- Workflow 和 Action controllers 继续只校验 definitions。
+- Scheduler 和 runtimed 继续只看到独立 Runs，不感知 Workflow calls 和 snapshots。
+- PersistentWorkspace 和 ArtifactStore 行为属于 called jobs，不属于 synthetic caller job。
+
+## API 和 RBAC Changes
+
+实现前需要 review 以下 API 和运维变更：
+
+- 增加 `WorkflowRun.status.snapshotName`；
+- 增加 `JobStatus.workflowRunName`；
+- 增加 WorkflowRun spec transition validation，保证 execution inputs immutable 且 cancellation
+  单向变化；
+- 拒绝在 `uses` job 中设置 `runs-on`、`steps` 和 caller-defined `outputs`；
+- 保留 snapshot/call-path labels 和 annotations；
+- 授予 WorkflowRun controller namespace-scoped ConfigMap
+  get/list/watch/create/delete permissions；
+- 除 child Runs 外，watch owned child WorkflowRuns。
+
+## Rejected Alternatives
+
+### 将 callee jobs 扁平化到 parent status
+
+扁平化可以避免 child WorkflowRun objects，但需要 synthetic caller nodes、将 external dependency
+edges 重写到 callee roots 和 leaves、把 nested paths 泄漏到 labels，并在一个 status map 中混合
+独立的 workspace/artifact boundaries。Nested cancellation 和 output aggregation 也更难解释。
+
+### 每次 reconcile 都读取当前 Workflow
+
+该方案简单，但 reusable definition 被修改时会改变 in-progress execution，无法提供确定性的
+retry 或 restart recovery。
+
+### 将 resolved definitions 复制到 WorkflowRun status
+
+这会扩大 status，并可能复制 scripts 和 environment values。Status 应保持轻量 execution state，
+而不是 execution-spec store。
+
+## Implementation Plan
+
+1. API prerequisites：status references、transition validation、reserved metadata、generated
+   CRDs，以及 ConfigMap/child-WorkflowRun RBAC。
+2. Snapshot storage 和 recursive resolver：version capture、limits、input validation，以及
+   cross-Workflow cycle detection。
+3. 从 immutable snapshot 执行 top-level `spec.uses`，修复当前只初始化 status 的缺口。
+4. 为 ready job-level calls 创建并观察 child WorkflowRuns，包括 dependency 和 terminal
+   propagation。
+5. 增加 restart、mutation、nested-call、cancellation 和 invalid-graph tests。
+6. 在现有 output propagation work 中集成 expression inputs 和 child Workflow outputs。
+7. 增加 E2E coverage，然后更新最终 workflow demo。

--- a/docs/design/workflow-job-reuse.zh.md
+++ b/docs/design/workflow-job-reuse.zh.md
@@ -2,7 +2,7 @@
 
 状态：**提案，等待 review**
 
-本文细化 [Workflow Reuse](workflow-reuse.md) 中的 job-level `uses` 模型，定义一个在
+本文细化 [Workflow Reuse](../workflow-reuse/) 中的 job-level `uses` 模型，定义一个在
 controller restart 和 reusable `Workflow` 更新后仍保持确定性的 execution boundary。
 
 ## 问题
@@ -112,22 +112,25 @@ accepted execution 不能再次读取 mutable `Workflow` definitions。在初始
 创建任何 child 前，controller 会递归解析完整的 namespace-local Workflow call tree，并写入
 immutable execution snapshot。
 
-snapshot 不放在 status 中，而是存储在由 WorkflowRun owner 的 immutable ConfigMaps 中：
+snapshot 不放在 status 中，而是存储在由 WorkflowRun owner 的 `ControllerRevision`
+objects 中。Kubernetes API validation 会使已成功创建 revision 的 `data` 不可变：
 
-- 一个较小的 index ConfigMap 将稳定 call paths 映射到 definition snapshots；
-- definition ConfigMaps 包含 normalized Workflow inputs、outputs 和 jobs；
+- 一个较小的 index ControllerRevision 将稳定 call paths 映射到 definition revisions；
+- definition ControllerRevisions 在 JSON `data` fields 中包含 normalized Workflow inputs、
+  outputs 和 jobs；
 - 每个 entry 记录 source name、UID、generation 和 resource version；
 - call nodes 保留尚未求值的 `with` expressions，后续在 caller context 中求值；
-- ConfigMaps 不包含 runtime results 或 secret material；
+- revision data 不包含 runtime results 或 secret material；
 - owner references 使其随 root WorkflowRun 被 garbage collection。
 
 Snapshot names 使用确定性的 content-addressed 方式生成。创建过程保持幂等：发生部分失败后，
-reconcile 会先校验并复用匹配的 immutable ConfigMaps，再创建缺失 entries。WorkflowRun
-accepted 前会删除未被引用的 partial snapshots。
+reconcile 会先校验并复用匹配的 immutable ControllerRevision data，再创建缺失 entries。
+Controller 不依赖 mutable revision labels 或 annotations 保证 correctness。WorkflowRun accepted
+前会删除未被引用的 partial revisions。
 
-`WorkflowRun.status.snapshotName` 记录 index ConfigMap 名称。Status 不复制完整 job specs、
-scripts 或 environment values。如果 snapshot 无法满足 Kubernetes object size limits，resolution
-会在执行前失败。
+`WorkflowRun.status.snapshotName` 记录 index ControllerRevision 名称。Status 不复制完整 job
+specs、scripts 或 environment values。如果 snapshot 无法满足 ControllerRevision object limits，
+resolution 会在执行前失败。
 
 一旦 `snapshotName` 持久化，后续 reconcile 只读取 snapshot，不再读取当前 `Workflow`
 objects。child WorkflowRun 继承 root snapshot 和 call-path annotation，因此 nested calls 使用
@@ -147,7 +150,7 @@ snapshot resolution 在创建任何 execution child 前完成：
 4. 将每个 definition version 和 call path 记录到 snapshot。
 5. 拒绝 missing definitions、invalid inputs、unsupported shapes，以及直接或间接 Workflow
    call cycles。
-6. 持久化 immutable snapshot ConfigMaps。
+6. 持久化 immutable snapshot ControllerRevisions。
 7. 根据 snapshot 初始化轻量 status，并设置 `Accepted=True`。
 
 初始安全限制为最大 call depth 8，以及每个 root execution 最多 64 个 reusable Workflow call
@@ -160,7 +163,7 @@ controller 保持现有 load/calculate/apply/patch 结构。
 
 加载的资源增加：
 
-- root snapshot index 和 definition ConfigMaps；
+- root snapshot index 和 definition ControllerRevisions；
 - reconciled WorkflowRun owner 的 direct child WorkflowRuns；
 - inline jobs 对应的 direct child Runs。
 
@@ -207,7 +210,7 @@ Workflow outputs 会提升为 caller job outputs，downstream jobs 通过普通 
   单向变化；
 - 拒绝在 `uses` job 中设置 `runs-on`、`steps` 和 caller-defined `outputs`；
 - 保留 snapshot/call-path labels 和 annotations；
-- 授予 WorkflowRun controller namespace-scoped ConfigMap
+- 授予 WorkflowRun controller namespace-scoped `apps` ControllerRevision
   get/list/watch/create/delete permissions；
 - 除 child Runs 外，watch owned child WorkflowRuns。
 
@@ -232,7 +235,7 @@ retry 或 restart recovery。
 ## Implementation Plan
 
 1. API prerequisites：status references、transition validation、reserved metadata、generated
-   CRDs，以及 ConfigMap/child-WorkflowRun RBAC。
+   CRDs，以及 ControllerRevision/child-WorkflowRun RBAC。
 2. Snapshot storage 和 recursive resolver：version capture、limits、input validation，以及
    cross-Workflow cycle detection。
 3. 从 immutable snapshot 执行 top-level `spec.uses`，修复当前只初始化 status 的缺口。

--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -143,7 +143,7 @@ Validation must enforce that job `uses` and job `steps` are mutually exclusive.
 Reusable Workflow jobs have their own job/workspace/artifact boundary. They
 communicate with callers through inputs, outputs, and artifacts. The concrete
 parent/child execution boundary and immutable snapshot model are defined in
-[Job-Level Reusable Workflow Execution](workflow-job-reuse.md).
+[Job-Level Reusable Workflow Execution](../workflow-job-reuse/).
 
 ## Action
 
@@ -277,7 +277,7 @@ Reference resolution should happen in this order:
 4. Represent each runnable reusable Workflow call as a child WorkflowRun with
    its own job/workspace/artifact boundary, using the immutable execution
    snapshot defined in
-   [Job-Level Reusable Workflow Execution](workflow-job-reuse.md).
+   [Job-Level Reusable Workflow Execution](../workflow-job-reuse/).
 5. Resolve each step-level `uses` to a same-namespace `Action`.
 6. Expand Action steps inline inside the caller job context.
 7. Detect cycles before creating any child Runs.

--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -141,7 +141,9 @@ spec:
 Validation must enforce that job `uses` and job `steps` are mutually exclusive.
 
 Reusable Workflow jobs have their own job/workspace/artifact boundary. They
-communicate with callers through inputs, outputs, and artifacts.
+communicate with callers through inputs, outputs, and artifacts. The concrete
+parent/child execution boundary and immutable snapshot model are defined in
+[Job-Level Reusable Workflow Execution](workflow-job-reuse.md).
 
 ## Action
 
@@ -272,8 +274,10 @@ Reference resolution should happen in this order:
    namespace.
 2. Expand the referenced Workflow jobs into the WorkflowRun execution graph.
 3. Resolve each job-level `uses` to a same-namespace reusable `Workflow`.
-4. Expand reusable Workflow calls as nested job groups with their own
-   job/workspace/artifact boundary.
+4. Represent each runnable reusable Workflow call as a child WorkflowRun with
+   its own job/workspace/artifact boundary, using the immutable execution
+   snapshot defined in
+   [Job-Level Reusable Workflow Execution](workflow-job-reuse.md).
 5. Resolve each step-level `uses` to a same-namespace `Action`.
 6. Expand Action steps inline inside the caller job context.
 7. Detect cycles before creating any child Runs.
@@ -294,10 +298,10 @@ not rely on scheduler or runtimed to understand Workflow concepts.
 
 The first implementation should use a simple deterministic graph model:
 
-- every job has a stable execution path, such as `jobs.build` or
-  `jobs.release.jobs.build` for a job expanded from a reusable Workflow call;
+- every job has a stable execution path local to its owning WorkflowRun;
 - every step has a stable execution path, such as `jobs.build.steps.package`;
-- each child Run is labeled with the WorkflowRun name, job path, and step path;
+- each child Run is labeled with its owning WorkflowRun, local job, and local
+  step identity;
 - child Run names are generated deterministically enough for idempotent
   reconciliation, or are discovered through labels before creating new Runs;
 - the controller creates Runs only when all dependency jobs have succeeded;

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -136,7 +136,7 @@ Validation 必须保证 job `uses` 和 job `steps` 互斥。
 
 Reusable Workflow jobs 拥有自己的 job/workspace/artifact boundary。它们通过 inputs、
 outputs 和 artifacts 与 caller 通信。具体的 parent/child execution boundary 和 immutable
-snapshot model 见 [Job-Level Reusable Workflow Execution](workflow-job-reuse.md)。
+snapshot model 见 [Job-Level Reusable Workflow Execution](../workflow-job-reuse/)。
 
 ## Action
 
@@ -262,7 +262,7 @@ Reference resolution 应按以下顺序发生：
 1. 将 top-level `WorkflowRun.spec.uses` 解析到同 namespace 下的 `Workflow`。
 2. 将被引用 Workflow 的 jobs 展开到 WorkflowRun execution graph。
 3. 将每个 job-level `uses` 解析到同 namespace 下的 reusable `Workflow`。
-4. 使用 [Job-Level Reusable Workflow Execution](workflow-job-reuse.md) 定义的 immutable
+4. 使用 [Job-Level Reusable Workflow Execution](../workflow-job-reuse/) 定义的 immutable
    execution snapshot，把每个 runnable reusable Workflow call 表示为拥有独立
    job/workspace/artifact boundary 的 child WorkflowRun。
 5. 将每个 step-level `uses` 解析到同 namespace 下的 `Action`。

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -135,7 +135,8 @@ spec:
 Validation 必须保证 job `uses` 和 job `steps` 互斥。
 
 Reusable Workflow jobs 拥有自己的 job/workspace/artifact boundary。它们通过 inputs、
-outputs 和 artifacts 与 caller 通信。
+outputs 和 artifacts 与 caller 通信。具体的 parent/child execution boundary 和 immutable
+snapshot model 见 [Job-Level Reusable Workflow Execution](workflow-job-reuse.md)。
 
 ## Action
 
@@ -261,8 +262,9 @@ Reference resolution 应按以下顺序发生：
 1. 将 top-level `WorkflowRun.spec.uses` 解析到同 namespace 下的 `Workflow`。
 2. 将被引用 Workflow 的 jobs 展开到 WorkflowRun execution graph。
 3. 将每个 job-level `uses` 解析到同 namespace 下的 reusable `Workflow`。
-4. 将 reusable Workflow calls 展开为 nested job groups，并保持它们自己的
-   job/workspace/artifact boundary。
+4. 使用 [Job-Level Reusable Workflow Execution](workflow-job-reuse.md) 定义的 immutable
+   execution snapshot，把每个 runnable reusable Workflow call 表示为拥有独立
+   job/workspace/artifact boundary 的 child WorkflowRun。
 5. 将每个 step-level `uses` 解析到同 namespace 下的 `Action`。
 6. 将 Action steps inline 展开到 caller job context。
 7. 在创建任何 child Runs 之前检测 cycles。
@@ -282,10 +284,9 @@ runtimed 理解 Workflow 概念。
 
 第一版应使用简单、确定性的 graph 模型：
 
-- 每个 job 都有稳定的 execution path，例如 `jobs.build`，或从 reusable Workflow call
-  展开的 `jobs.release.jobs.build`；
+- 每个 job 都有相对于 owning WorkflowRun 的稳定 execution path；
 - 每个 step 都有稳定的 execution path，例如 `jobs.build.steps.package`；
-- 每个 child Run 都带有 WorkflowRun name、job path 和 step path labels；
+- 每个 child Run 都带有 owning WorkflowRun、local job 和 local step identity labels；
 - child Run names 要么足够确定以支持 idempotent reconciliation，要么在创建新 Runs 前
   通过 labels 发现已有 Runs；
 - controller 只在所有 dependency jobs 成功后创建 Runs；

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -234,7 +234,7 @@ wiring from accumulating avoidable conflicts.
     - [ ] review and approve the child WorkflowRun and immutable snapshot model;
     - [ ] add status references, spec transition validation, reserved metadata,
       generated CRDs, and controller RBAC prerequisites;
-    - [ ] add immutable snapshot storage and recursive resolution with version
+    - [ ] add immutable ControllerRevision snapshot storage and recursive resolution with version
       capture, call limits, input validation, and cycle detection;
     - [ ] execute top-level `WorkflowRun.spec.uses` from its snapshot instead of
       only initializing status;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -229,7 +229,19 @@ wiring from accumulating avoidable conflicts.
   - [x] implement WorkflowRun cancellation propagation;
   - [x] verify controller restart recovery for in-progress inline WorkflowRuns,
     including child Run creation before status persistence;
-  - implement job-level reusable Workflow calls;
+  - [ ] implement job-level reusable Workflow calls through the reviewed
+    [execution-boundary design](design/workflow-job-reuse.md):
+    - [ ] review and approve the child WorkflowRun and immutable snapshot model;
+    - [ ] add status references, spec transition validation, reserved metadata,
+      generated CRDs, and controller RBAC prerequisites;
+    - [ ] add immutable snapshot storage and recursive resolution with version
+      capture, call limits, input validation, and cycle detection;
+    - [ ] execute top-level `WorkflowRun.spec.uses` from its snapshot instead of
+      only initializing status;
+    - [ ] create and observe child WorkflowRuns for ready job-level calls;
+    - [ ] verify definition mutation isolation, restart recovery, nested calls,
+      cancellation, and invalid graphs;
+    - [ ] integrate call inputs and outputs with expression/output propagation;
   - implement step-level Action expansion;
   - implement expression evaluation for `inputs`, `steps`, and `jobs` contexts;
   - promote child Run outputs into WorkflowRun step/job/workflow outputs;

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -203,7 +203,7 @@ controller wiring 累积不必要的冲突。
     - [ ] review 并批准 child WorkflowRun 和 immutable snapshot model；
     - [ ] 增加 status references、spec transition validation、reserved metadata、generated
       CRDs 和 controller RBAC prerequisites；
-    - [ ] 增加 immutable snapshot storage 和 recursive resolution，包括 version capture、
+    - [ ] 增加 immutable ControllerRevision snapshot storage 和 recursive resolution，包括 version capture、
       call limits、input validation 和 cycle detection；
     - [ ] 从 snapshot 执行 top-level `WorkflowRun.spec.uses`，而不是只初始化 status；
     - [ ] 为 ready job-level calls 创建并观察 child WorkflowRuns；

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -197,7 +197,19 @@ controller wiring 累积不必要的冲突。
   - [x] 实现 WorkflowRun cancellation propagation；
   - [x] 验证 in-progress inline WorkflowRuns 的 controller restart recovery，包括
     child Run 已创建但 status 尚未持久化的故障窗口；
-  - 实现 job-level reusable Workflow calls；
+  - [ ] 按照完成 review 的
+    [execution-boundary design](design/workflow-job-reuse.md) 实现 job-level reusable
+    Workflow calls：
+    - [ ] review 并批准 child WorkflowRun 和 immutable snapshot model；
+    - [ ] 增加 status references、spec transition validation、reserved metadata、generated
+      CRDs 和 controller RBAC prerequisites；
+    - [ ] 增加 immutable snapshot storage 和 recursive resolution，包括 version capture、
+      call limits、input validation 和 cycle detection；
+    - [ ] 从 snapshot 执行 top-level `WorkflowRun.spec.uses`，而不是只初始化 status；
+    - [ ] 为 ready job-level calls 创建并观察 child WorkflowRuns；
+    - [ ] 验证 definition mutation isolation、restart recovery、nested calls、cancellation 和
+      invalid graphs；
+    - [ ] 将 call inputs 和 outputs 接入 expression/output propagation；
   - 实现 step-level Action expansion；
   - 实现 `inputs`、`steps` 和 `jobs` contexts 的 expression evaluation；
   - 将 child Run outputs 提升为 WorkflowRun step/job/workflow outputs；


### PR DESCRIPTION
## Summary

- define job-level reusable Workflow calls as child `WorkflowRun` executions
- define immutable, WorkflowRun-owned `ControllerRevision` snapshots so accepted executions do not observe later definition mutations
- specify parent/child status, cancellation, output, ownership, restart-recovery, and component boundaries
- document required API/RBAC changes and split implementation into reviewable roadmap tasks
- update the English and Chinese design indexes and workflow reuse design

## Decisions requiring review

- a reusable Workflow call remains one logical caller job and owns a child `WorkflowRun`
- top-level and nested calls execute from one immutable, recursively resolved snapshot
- snapshots are stored outside status in immutable `ControllerRevision.data`
- `WorkflowRun.status.snapshotName` and `JobStatus.workflowRunName` are added during the implementation phase
- execution inputs become immutable after creation; cancellation is a one-way transition
- v0.x limits call depth to 8 and call nodes to 64
- scheduler and runtimed remain unaware of Workflow semantics

This PR is design-only. API and controller implementation will start only after design review.

## Validation

- `make site-build`
