### PR TITLE
docs(function): define lifecycle and invoke dataplane

### DIFF
--- a/docs/design/_index.md
+++ b/docs/design/_index.md
@@ -8,6 +8,7 @@ implemented.
 ## Documents
 
 - [Function Mode and Agent Sandboxes](function-mode/)
+- [Function Mode Lifecycle and Invoke Dataplane](function-mode-lifecycle/)
 - [Workflow Data Sharing](workflow-data-sharing/)
 - [Workflow Reuse](workflow-reuse/)
 - [Dashboard](dashboard/)

--- a/docs/design/_index.zh.md
+++ b/docs/design/_index.zh.md
@@ -6,6 +6,7 @@
 ## 文档列表
 
 - [Function Mode 和 Agent Sandboxes](function-mode/)
+- [Function Mode 生命周期与 Invoke Dataplane](function-mode-lifecycle/)
 - [Workflow Data Sharing](workflow-data-sharing/)
 - [Workflow Reuse](workflow-reuse/)
 - [Dashboard](dashboard/)

--- a/docs/design/function-mode-lifecycle.md
+++ b/docs/design/function-mode-lifecycle.md
@@ -1,0 +1,388 @@
+# Function Mode Lifecycle and Invoke Dataplane
+
+Status: **Proposed for review**
+
+This document refines the function-mode target in
+[Function Mode and Agent Sandboxes](../function-mode/). It defines the Run
+lifecycle, status API, gateway boundary, recovery behavior, and invocation
+semantics that must be reviewed before implementation.
+
+## Problem
+
+The existing design establishes a function-mode Run and a Runtime gateway, but
+it leaves several correctness and security questions unresolved:
+
+- whether `Ready` is a terminal phase and how generic Run controllers classify
+  it;
+- what happens when registration fails or the assigned Runtime Pod disappears;
+- how cancellation, deletion, total timeout, and idle timeout release capacity;
+- how an invoke request reaches the owning runtimed without a Kubernetes API
+  lookup on the hot path;
+- how callers are authenticated and authorized;
+- whether a transport retry may execute an invocation twice;
+- how invocation concurrency, payloads, outputs, artifacts, and logs remain
+  bounded;
+- which state belongs in Run status and which state remains in the dataplane.
+
+Adding only a `Ready` phase and an endpoint field would leave these behaviors
+undefined and make later compatibility harder.
+
+## Control Plane and Dataplane
+
+Kubernetes remains the durable lifecycle control plane:
+
+- a function-mode `Run` declares source, Runtime, handler, timeouts, and retry
+  policy;
+- the scheduler assigns Runtime capacity exactly as it does for task Runs;
+- runtimed prepares and registers the function, updates bounded Run status, and
+  releases the reservation;
+- controllers recover or terminate the Run when its Runtime Pod disappears.
+
+Invocation is a dataplane operation:
+
+- clients invoke through the Runtime gateway Service;
+- runtimed routes from an in-memory ownership/readiness cache;
+- the owning runtimed calls its local Runtime Server;
+- individual invocations do not create Kubernetes objects and do not append
+  history to Run status.
+
+Scheduler and Runtime Server remain unaware of agents, sandboxes, Workflows,
+and SDK sessions.
+
+## Run Status API
+
+The Run phase enum gains `Ready`:
+
+```go
+const RunReady RunPhase = "Ready"
+```
+
+`Ready` is active and non-terminal. Generic phase helpers, capacity accounting,
+stale-pod recovery, cancellation, metrics, CLI waits, TTL cleanup, and completed
+Run GC must all classify it explicitly. Only `Succeeded`, `Failed`, `Timeout`,
+and `Cancelled` remain terminal.
+
+Function-mode status gains one stable endpoint reference:
+
+```go
+type RunEndpointProtocol string
+
+const RunEndpointProtocolHTTPS RunEndpointProtocol = "HTTPS"
+
+type RunEndpoint struct {
+    Protocol RunEndpointProtocol `json:"protocol"`
+    URL      string              `json:"url"`
+    CABundle []byte              `json:"caBundle,omitempty"`
+}
+
+type RunStatus struct {
+    // Existing fields omitted.
+    AssignedPodUID string       `json:"assignedPodUID,omitempty"`
+    Endpoint       *RunEndpoint `json:"endpoint,omitempty"`
+}
+```
+
+`assignedPodUID` disambiguates Pod-name reuse and is set and cleared with
+`assignedPod`. The endpoint URL is limited to 2048 bytes and the PEM CA bundle
+to 16 KiB. These bounds are part of CRD validation.
+
+The first public invoke protocol is HTTPS. Runtime Server communication remains
+internal gRPC and is not exposed through this field. `caBundle` contains a
+bounded PEM trust bundle when the Runtime gateway uses the controller-managed
+CA; it is omitted when the certificate chains to a trust root configured by
+the client. Supporting another public protocol requires a later API review.
+
+The endpoint path includes namespace, Run name, and immutable Run UID so a
+deleted Run name cannot address a newly created Run accidentally:
+
+```yaml
+status:
+  phase: Ready
+  assignedPod: runtime-python-7f587b4668-njcks
+  endpoint:
+    protocol: HTTPS
+    url: https://python-gateway.kruntimes-demo.svc.cluster.local/v1/namespaces/kruntimes-demo/runs/kube-diagnose-agent/2c24c1f0-9f8f-4f80-82d5-3dd16a12d1e6/invoke
+    caBundle: <base64-encoded-PEM>
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: FunctionRegistered
+```
+
+`Ready=True` means the assigned runtimed has registered the Run UID with the
+local Runtime Server and can accept invokes. During scheduling, registration,
+retry, cancellation, and terminal phases it is false with a specific reason.
+The endpoint may remain stable while a Run is temporarily unavailable during
+recovery; clients must use phase or the Ready condition, not endpoint presence,
+as the readiness signal.
+
+Opaque Runtime Server registration IDs, ownership-cache entries, invocation
+counters, and invocation history do not belong in Run status. The Run UID is
+the stable registration identity across runtimed and Runtime Server.
+
+## Spec Transition Rules
+
+Execution inputs must not change after creation. CRD transition validation
+should make `runtime`, `source`, `mode`, `env`, `timeout`, and `retryPolicy`
+immutable for both task and function Runs. Otherwise a reconciler can observe a
+different program or execution mode after assignment.
+
+`cancelRequested` may transition only from false to true. The existing
+`ttlSecondsAfterFinished` field may remain mutable because it controls retention
+after execution rather than execution behavior.
+
+These are breaking validation changes to the experimental API and require
+review before the CRD is regenerated.
+
+## Lifecycle State Machine
+
+The normal function lifecycle is:
+
+```text
+Pending -> Scheduled -> Running (preparing/registering) -> Ready
+```
+
+`Run.status.startTime` is set when runtimed claims the Run. `attempt` counts
+registration attempts, including the initial attempt, using the existing
+shared retry engine.
+
+Terminal transitions are:
+
+- cancellation before assignment ends as `Cancelled` in the scheduler;
+- cancellation after assignment makes the owning runtimed unregister, clean
+  local state, release capacity, and then set `Cancelled`;
+- a registration error retries according to `retryPolicy`; exhaustion ends as
+  `Failed`;
+- assigned Runtime Pod loss makes the Run unavailable and enters fenced stale
+  recovery; after the old assignment is fenced, a new attempt may register on
+  another ready Pod, while exhaustion ends as `Failed`;
+- `spec.timeout`, when set, is the maximum reservation lifetime from
+  `startTime`; expiry unregisters and ends as `Timeout`;
+- `mode.function.idleTimeoutSeconds`, when set, expires one registration epoch
+  after no completed or in-flight invocation activity and ends as `Timeout`
+  with reason `IdleTimeout`.
+
+Invocation-level handler errors, request timeouts, and rejected concurrency do
+not change Run phase and do not consume Run retry attempts. They are results of
+one invocation, not failures of the registered function lifecycle. A fatal
+Runtime Server error that invalidates registration makes the Run not ready and
+enters registration recovery.
+
+The Runtime Server owns the precise last-activity clock for a registration
+epoch and exposes it through `FunctionStatus`; it is not checkpointed on every
+invoke to etcd. If the Runtime Server process recovers its registration, it
+also recovers that clock. If the Runtime Pod is replaced, registration creates
+a new epoch and resets the idle timer. This avoids early expiry and avoids a
+high-frequency Run status write path.
+
+## Ownership Epoch and Fencing
+
+Run UID is the stable external function identity. Each registration is fenced
+by an ownership epoch made from `status.attempt`, `assignedPod`, and
+`assignedPodUID`. runtimed and Runtime Server lifecycle calls carry Run UID and
+attempt; a local gateway invokes only when its active epoch matches the newest
+cache entry.
+
+Pod readiness or a stale heartbeat alone is not proof that an old function has
+stopped. Recovery first makes the old assignment unreachable through the
+gateway Service and confirms one of these fences:
+
+- the exact assigned Pod UID no longer exists;
+- the Pod is deleting and has been removed from Service endpoints; or
+- the old owning runtimed acknowledged unregister for that epoch.
+
+Only then may shared retry clear assignment and schedule a new attempt. Peer
+requests carry the expected Run UID and attempt and are rejected on mismatch.
+This prevents normal recovery from routing to two epochs at once. kruntimes
+still does not promise exactly-once invocation when a network fails after
+dispatch; that separate ambiguity is defined by the invoke contract below.
+
+## Cleanup and Finalization
+
+Before registering a function, runtimed adds the
+`kruntimes.io/function-cleanup` finalizer. A deleting function Run is reconciled
+even though normal execution creation has stopped:
+
+1. stop accepting new invokes;
+2. wait for or cancel bounded in-flight invokes;
+3. call `UnregisterFunction` idempotently;
+4. remove function-local workspace and retained invocation state;
+5. release the active capacity entry;
+6. remove the finalizer.
+
+If the assigned Pod no longer exists, the stale-recovery controller may remove
+the finalizer after confirming that the Pod-local registration cannot still be
+serving. PersistentWorkspace and ArtifactStore cleanup remain owned by their
+existing controllers and policies; the function finalizer must not delete
+shared persistent data implicitly.
+
+Cancellation keeps the Run object and records a terminal status. Deletion is a
+separate user request and uses the finalizer path. Both operations are
+idempotent across controller and runtimed restarts.
+
+## Runtime Gateway Service
+
+The Runtime controller creates one ClusterIP gateway Service for each Runtime.
+The Service is owned by the Runtime and selects all ready Runtime Pods in that
+pool on a dedicated runtimed gateway port. The controller also manages a
+Runtime-scoped CA and serving certificate Secret mounted only into runtimed.
+Certificates cover the gateway Service DNS name. Rotation publishes an
+overlapping old/new CA bundle before replacing serving certificates, then
+removes the retired CA after all Runtime Pods have rolled.
+
+```text
+Runtime gateway Service
+  -> any runtimed in the Runtime pool
+     -> owning runtimed, directly or through one peer proxy hop
+        -> local Runtime Server
+```
+
+Every runtimed maintains a watch-backed cache for all function Runs assigned to
+its Runtime and namespace:
+
+```text
+Run namespace/name/UID -> assigned Pod address -> lifecycle readiness
+```
+
+The cache is populated asynchronously from informer events. The invoke handler
+must not synchronously read Runs or Pods from the Kubernetes API. Requests are
+handled as follows:
+
+- UID or current-object mismatch: `404 Not Found`;
+- known Run but not ready, recovering, or terminating: `503 Service Unavailable`;
+- local owner: invoke the local Runtime Server;
+- remote owner: proxy once to the owning Pod's gateway port;
+- stale or unreachable owner: `503 Service Unavailable` and enqueue recovery;
+- local concurrency limit reached: `429 Too Many Requests`.
+
+The peer request retains the original caller credential and is authorized by
+the owner too. Peer connections use TLS and verify the same Runtime-scoped CA;
+when connecting to an owning Pod address, the client verifies against the
+gateway Service DNS name carried by the shared serving certificate. A hop
+marker prevents proxy loops. Service routing and cache recovery must tolerate a
+request reaching a Pod whose watch cache has not yet observed the newest
+assignment.
+
+## Authentication and Authorization
+
+The initial gateway is HTTPS and ClusterIP-only; it does not claim to be an
+Internet ingress. Plaintext HTTP is not supported because every client request
+carries a Kubernetes bearer token. The receiving runtimed uses that token to
+submit a `SelfSubjectAccessReview` and requires the caller to be allowed to
+`get` the exact Run being invoked. The token must be valid for the Kubernetes
+API audience.
+
+Authorization decisions may be cached for at most 30 seconds and never beyond
+the token's known expiry. Cache keys use a token digest plus Run namespace,
+name, and UID; raw tokens are never logged or stored in Run status. A proxied
+request forwards the original token and the owner repeats or reuses the same
+bounded authorization decision.
+
+This introduces Kubernetes API traffic on authorization cache misses, but not
+for ownership or readiness routing. It preserves namespace RBAC without
+granting a custom Runtime service account broad Secret access or TokenReview
+privileges.
+
+External exposure requires a separately reviewed authenticated ingress or
+gateway. NetworkPolicy should restrict direct gateway access to expected agent
+and platform namespaces even when Kubernetes authorization is enabled.
+
+## Invoke Contract
+
+The first HTTPS request is deliberately bounded:
+
+```http
+POST /v1/namespaces/{namespace}/runs/{name}/{uid}/invoke
+Authorization: Bearer <kubernetes-token>
+Content-Type: application/json
+X-Kruntime-Invocation-ID: <caller-generated-id>
+```
+
+Initial limits are:
+
+- request body: 1 MiB;
+- invocation ID: 128 bytes;
+- outputs: the same key/count/value limits as bounded Run outputs;
+- artifact references: the same count and metadata limits as Run artifact
+  references;
+- one in-flight invocation per function Run in v0.x;
+- no unbounded server-side queue.
+
+The Runtime gateway never automatically retries an invocation after dispatch
+to an owner or Runtime Server. A connection failure may have an unknown
+execution outcome. The SDK also defaults to no execution retry. A future
+deduplication or idempotency contract may use the caller-generated invocation
+ID, but v0.x does not promise exactly-once execution.
+
+Successful and failed responses include the invocation ID. Structured runtimed
+logs include Runtime, Run UID, and invocation ID. Invocation stdout/stderr is
+exposed through log collection or a bounded response field defined by the
+Runtime Server contract; it is never appended to `Run.status.message`.
+
+## Runtime Server Boundary
+
+The internal gRPC API gains idempotent lifecycle operations keyed by Run UID:
+
+- `RegisterFunction`: register working directory, handler, and environment;
+- `FunctionStatus`: report registered/readiness state, fatal errors, in-flight
+  count, and last activity for the current registration epoch;
+- `InvokeFunction`: execute one bounded request with an invocation ID and
+  timeout;
+- `UnregisterFunction`: stop new work and release the registration.
+
+Registering the same Run UID and attempt with the same immutable configuration
+succeeds idempotently. Registering that epoch with different configuration
+fails. Unregistering an absent epoch succeeds. Exact protobuf fields and
+Bash/Python adapter behavior are a separate implementation PR, but they must
+preserve these semantics.
+
+## Capacity and Concurrency
+
+Runtime `runs` capacity controls how many task executions or registered
+function Runs may occupy one Runtime Pod. A Ready function Run continues to
+consume one unit until terminal cleanup or deletion releases it.
+
+Invocation concurrency is not scheduler capacity. In v0.x, runtimed and the
+Runtime Server allow one in-flight invocation per function Run and reject an
+overlapping request with `429`. A later design may add per-function and
+Runtime-wide invocation concurrency or queue controls without teaching the
+scheduler about individual invokes.
+
+Agent sandbox deployments should continue to use Runtime `runs: "1"` when they
+need exclusive Pod and workspace ownership. The SDK may validate or warn about
+that deployment choice, but it must not change scheduler semantics.
+
+## Component Boundaries
+
+| Component | Responsibility |
+| --- | --- |
+| Runtime controller | Reconcile the Runtime-owned gateway Service and ports. |
+| Scheduler | Assign generic Run capacity; treat Ready as active and non-terminal. |
+| runtimed | Register/unregister, own lifecycle status, maintain routing caches, authorize and proxy invokes, enforce local limits, and clean local state. |
+| Runtime Server | Hold registration and activity state, execute invokes, and expose idempotent local lifecycle APIs. |
+| stale recovery | Detect lost owning Pods, release impossible local cleanup, and enter shared Run retry/exhaustion semantics. |
+| SDK and `krt` | Watch readiness, discover endpoint, supply credentials, invoke without implicit execution retries, and expose typed errors. |
+
+Workflow controllers remain unaware of function registration and invocation.
+They may create function Runs later, but they use only the public Run API.
+
+## Implementation Plan
+
+1. Add API prerequisites: `Ready`, assigned Pod UID, endpoint status,
+   transition validation, finalizer constant, generated CRDs, and generic
+   phase-classification tests.
+2. Add Runtime gateway Service reconciliation and Helm/RBAC coverage.
+3. Add Runtime-scoped gateway TLS certificate reconciliation, CA publication,
+   rotation, and pod rollout behavior.
+4. Add Runtime Server register/status/invoke/unregister protobuf APIs and
+   built-in Bash/Python adapters.
+5. Add runtimed registration lifecycle, finalization, shared retry integration,
+   timeout handling, and restart recovery.
+6. Add the HTTPS gateway, watch-backed routing cache, local/peer dispatch,
+   SelfSubjectAccessReview authorization, limits, and metrics.
+7. Add `krt invoke`, then the Go and Python sandbox SDK connection layer.
+8. Add E2E coverage for registration, TLS rotation, authorization, local and
+   proxied invoke,
+   concurrency rejection, cancellation, deletion, idle/lifetime timeout,
+   Runtime Pod loss, and retry exhaustion.
+9. Complete the agent sandbox demo only after the supported path passes E2E.

--- a/docs/design/function-mode-lifecycle.zh.md
+++ b/docs/design/function-mode-lifecycle.zh.md
@@ -1,0 +1,334 @@
+# Function Mode 生命周期与 Invoke Dataplane
+
+状态：**提案，等待 review**
+
+本文细化 [Function Mode 和 Agent Sandboxes](../function-mode/) 中的 function-mode 目标，
+定义实现前必须 review 的 Run lifecycle、status API、gateway boundary、recovery behavior 和
+invocation semantics。
+
+## 问题
+
+现有设计确定了 function-mode Run 和 Runtime gateway，但仍有若干 correctness 与 security
+问题没有明确：
+
+- `Ready` 是否为 terminal phase，以及通用 Run controllers 如何对它分类；
+- registration 失败或 assigned Runtime Pod 丢失后如何处理；
+- cancellation、deletion、total timeout 和 idle timeout 如何释放 capacity；
+- invoke request 如何在热路径不查询 Kubernetes API 的情况下到达 owning runtimed；
+- caller 如何完成 authentication 和 authorization；
+- transport retry 是否可能导致 invocation 被执行两次；
+- invocation concurrency、payload、outputs、artifacts 和 logs 如何保持有界；
+- 哪些状态属于 Run status，哪些应留在 dataplane。
+
+只增加 `Ready` phase 和 endpoint 字段会让这些行为继续保持未定义，并增加后续兼容成本。
+
+## Control Plane 与 Dataplane
+
+Kubernetes 仍是持久化 lifecycle control plane：
+
+- function-mode `Run` 声明 source、Runtime、handler、timeouts 和 retry policy；
+- scheduler 与 task Run 一样分配 Runtime capacity；
+- runtimed 准备并注册 function、更新有界 Run status，并释放 reservation；
+- Runtime Pod 丢失后由 controllers 恢复或终止 Run。
+
+Invocation 是 dataplane operation：
+
+- client 通过 Runtime gateway Service invoke；
+- runtimed 使用内存中的 ownership/readiness cache 路由；
+- owning runtimed 调用本地 Runtime Server；
+- 单次 invocation 不创建 Kubernetes object，也不向 Run status 追加 history。
+
+Scheduler 和 Runtime Server 继续不感知 agent、sandbox、Workflow 或 SDK session。
+
+## Run Status API
+
+Run phase enum 增加 `Ready`：
+
+```go
+const RunReady RunPhase = "Ready"
+```
+
+`Ready` 是 active、non-terminal phase。通用 phase helpers、capacity accounting、
+stale-pod recovery、cancellation、metrics、CLI waits、TTL cleanup 和 completed Run GC 都必须
+显式识别它。只有 `Succeeded`、`Failed`、`Timeout` 和 `Cancelled` 保持 terminal。
+
+Function-mode status 增加一个稳定 endpoint reference：
+
+```go
+type RunEndpointProtocol string
+
+const RunEndpointProtocolHTTPS RunEndpointProtocol = "HTTPS"
+
+type RunEndpoint struct {
+    Protocol RunEndpointProtocol `json:"protocol"`
+    URL      string              `json:"url"`
+    CABundle []byte              `json:"caBundle,omitempty"`
+}
+
+type RunStatus struct {
+    // 省略已有字段。
+    AssignedPodUID string       `json:"assignedPodUID,omitempty"`
+    Endpoint       *RunEndpoint `json:"endpoint,omitempty"`
+}
+```
+
+`assignedPodUID` 用于区分 Pod name reuse，并与 `assignedPod` 一起设置和清除。endpoint URL
+限制为 2048 bytes，PEM CA bundle 限制为 16 KiB；这些 bounds 属于 CRD validation。
+
+第一版 public invoke protocol 是 HTTPS。Runtime Server communication 继续使用内部 gRPC，
+不会通过该字段暴露。当 Runtime gateway 使用 controller-managed CA 时，`caBundle` 包含有界
+PEM trust bundle；certificate 链到 client 已配置的 trust root 时可省略。支持其他 public
+protocol 需要后续 API review。
+
+endpoint path 包含 namespace、Run name 和 immutable Run UID，避免被删除的 Run name
+意外指向后续新建 Run：
+
+```yaml
+status:
+  phase: Ready
+  assignedPod: runtime-python-7f587b4668-njcks
+  endpoint:
+    protocol: HTTPS
+    url: https://python-gateway.kruntimes-demo.svc.cluster.local/v1/namespaces/kruntimes-demo/runs/kube-diagnose-agent/2c24c1f0-9f8f-4f80-82d5-3dd16a12d1e6/invoke
+    caBundle: <base64-encoded-PEM>
+  conditions:
+    - type: Ready
+      status: "True"
+      reason: FunctionRegistered
+```
+
+`Ready=True` 表示 assigned runtimed 已使用 Run UID 在本地 Runtime Server 完成注册，并可
+接受 invokes。在 scheduling、registration、retry、cancellation 和 terminal phases 中，它为
+false，并带有明确 reason。Run recovery 期间 endpoint 可以保持稳定；client 必须使用 phase
+或 Ready condition 判断 readiness，不能只检查 endpoint 是否存在。
+
+Opaque Runtime Server registration IDs、ownership-cache entries、invocation counters 和
+invocation history 不属于 Run status。Run UID 是 runtimed 与 Runtime Server 之间的稳定
+registration identity。
+
+## Spec Transition Rules
+
+Execution inputs 创建后不能变化。CRD transition validation 应使 `runtime`、`source`、`mode`、
+`env`、`timeout` 和 `retryPolicy` 对 task 和 function Runs 都不可变。否则 reconciler 可能在
+assignment 后观察到不同 program 或 execution mode。
+
+`cancelRequested` 只能从 false 变为 true。已有 `ttlSecondsAfterFinished` 可以保持 mutable，
+因为它控制 execution 结束后的 retention，而不是 execution behavior。
+
+这些是 experimental API 的 breaking validation changes，必须在重新生成 CRD 前完成 review。
+
+## Lifecycle State Machine
+
+正常 function lifecycle 为：
+
+```text
+Pending -> Scheduled -> Running (preparing/registering) -> Ready
+```
+
+runtimed claim Run 时设置 `Run.status.startTime`。`attempt` 使用已有 shared retry engine 统计
+registration attempts，并包含首次 attempt。
+
+Terminal transitions：
+
+- assignment 前 cancellation 由 scheduler 结束为 `Cancelled`；
+- assignment 后 cancellation 由 owning runtimed unregister、清理本地状态、释放 capacity，
+  然后设置为 `Cancelled`；
+- registration error 按 `retryPolicy` 重试，耗尽后进入 `Failed`；
+- assigned Runtime Pod 丢失会让 Run unavailable，并进入带 fencing 的 stale recovery；旧
+  assignment 被 fence 后，新 attempt 可以在另一个 ready Pod 上注册，耗尽后进入 `Failed`；
+- `spec.timeout` 在设置时表示从 `startTime` 开始计算的最大 reservation lifetime；过期后
+  unregister 并进入 `Timeout`；
+- `mode.function.idleTimeoutSeconds` 在一个 registration epoch 内没有 completed 或 in-flight
+  invocation activity 后过期，并以 reason `IdleTimeout` 进入 `Timeout`。
+
+Invocation-level handler error、request timeout 和 concurrency rejection 不改变 Run phase，
+也不消耗 Run retry attempt。它们是单次 invocation 的结果，不是 registered function lifecycle
+失败。会使 registration 失效的 fatal Runtime Server error 会让 Run not ready 并进入
+registration recovery。
+
+Runtime Server 负责当前 registration epoch 的精确 last-activity clock，并通过
+`FunctionStatus` 暴露；不会每次 invoke 都 checkpoint 到 etcd。如果 Runtime Server process
+恢复 registration，也会恢复该 clock。如果 Runtime Pod 被替换，新 registration 会创建新
+epoch 并重置 idle timer。这样既避免提前过期，也不会形成高频 Run status write path。
+
+## Ownership Epoch 与 Fencing
+
+Run UID 是稳定的 external function identity。每次 registration 使用由 `status.attempt`、
+`assignedPod` 和 `assignedPodUID` 组成的 ownership epoch 进行 fencing。runtimed 和 Runtime
+Server lifecycle calls 携带 Run UID 与 attempt；local gateway 仅在 active epoch 与最新 cache
+entry 匹配时 invoke。
+
+Pod readiness 或 stale heartbeat 本身不能证明旧 function 已停止。Recovery 会先使旧
+assignment 无法再通过 gateway Service 到达，并确认以下任一 fence：
+
+- 精确 assigned Pod UID 已不存在；
+- Pod 正在 deleting，且已从 Service endpoints 移除；
+- old owning runtimed 已确认 unregister 对应 epoch。
+
+只有满足 fence 后，shared retry 才能清除 assignment 并调度新 attempt。Peer request 携带
+expected Run UID 和 attempt，mismatch 时被拒绝。这可以防止正常 recovery 同时向两个 epoch
+routing。网络在 dispatch 后失败时，kruntimes 仍不承诺 exactly-once invocation；这一独立
+ambiguity 由后面的 invoke contract 定义。
+
+## Cleanup 与 Finalization
+
+注册 function 前，runtimed 增加 `kruntimes.io/function-cleanup` finalizer。Function Run 进入
+deleting 后，即使正常 execution creation 已停止，仍需 reconcile：
+
+1. 停止接受新 invokes；
+2. 等待或取消有界的 in-flight invokes；
+3. 幂等调用 `UnregisterFunction`；
+4. 删除 function-local workspace 和 retained invocation state；
+5. 释放 active capacity entry；
+6. 移除 finalizer。
+
+如果 assigned Pod 已不存在，stale-recovery controller 可在确认 Pod-local registration 不可能
+继续 serving 后移除 finalizer。PersistentWorkspace 和 ArtifactStore cleanup 仍由已有
+controllers 与 policies 负责；function finalizer 不得隐式删除 shared persistent data。
+
+Cancellation 保留 Run object 并记录 terminal status。Deletion 是独立的 user request，使用
+finalizer path。两种操作在 controller 和 runtimed restart 后都必须保持幂等。
+
+## Runtime Gateway Service
+
+Runtime controller 为每个 Runtime 创建一个 ClusterIP gateway Service。Service 由 Runtime
+owner，并通过专用 runtimed gateway port 选择该 pool 中所有 ready Runtime Pods。Controller
+同时管理 Runtime-scoped CA 和只挂载到 runtimed 的 serving certificate Secret。Certificate
+覆盖 gateway Service DNS name。Rotation 会先发布同时包含 old/new CA 的 bundle，再替换
+serving certificates，并在所有 Runtime Pods 完成 rollout 后删除 retired CA。
+
+```text
+Runtime gateway Service
+  -> Runtime pool 中任意 runtimed
+     -> owning runtimed（直接到达或经过一次 peer proxy）
+        -> local Runtime Server
+```
+
+每个 runtimed 为其 Runtime 和 namespace 中所有 assigned function Runs 维护 watch-backed
+cache：
+
+```text
+Run namespace/name/UID -> assigned Pod address -> lifecycle readiness
+```
+
+cache 由 informer events 异步填充。invoke handler 不得同步从 Kubernetes API 读取 Run 或
+Pod。请求处理规则：
+
+- UID 或 current-object 不匹配：`404 Not Found`；
+- Run 已知但 not ready、recovering 或 terminating：`503 Service Unavailable`；
+- local owner：调用本地 Runtime Server；
+- remote owner：最多 proxy 一次到 owning Pod gateway port；
+- owner stale 或 unreachable：返回 `503 Service Unavailable` 并 enqueue recovery；
+- 达到 local concurrency limit：`429 Too Many Requests`。
+
+peer request 保留原 caller credential，并由 owner 再次 authorization。Peer connection 使用
+TLS 并验证相同 Runtime-scoped CA；连接 owning Pod address 时，client 使用 shared serving
+certificate 中的 gateway Service DNS name 完成校验。hop marker 防止 proxy loop。Service
+routing 和 cache recovery 必须容忍请求落到尚未通过 watch cache 观察到最新 assignment 的
+Pod。
+
+## Authentication 与 Authorization
+
+第一版 gateway 使用 HTTPS 且仅为 ClusterIP，不声称自己是 Internet ingress。由于每个
+client request 都携带 Kubernetes bearer token，因此不支持 plaintext HTTP。接收请求的
+runtimed 使用该 token 提交 `SelfSubjectAccessReview`，并要求 caller 有权 `get` 被 invoke 的
+精确 Run。Token 必须对 Kubernetes API audience 有效。
+
+Authorization decision 最多缓存 30 秒，并且不能超过 token 已知 expiry。cache key 使用 token
+digest 加 Run namespace、name 和 UID；raw token 不记录到日志或 Run status。Proxy request
+转发原 token，owner 重复执行或复用同样有界的 authorization decision。
+
+这会在 authorization cache miss 时产生 Kubernetes API traffic，但 ownership/readiness
+routing 不查询 API。它能保留 namespace RBAC，并避免为 custom Runtime service account
+授予广泛 Secret access 或 TokenReview 权限。
+
+External exposure 需要单独 review 的 authenticated ingress 或 gateway。即使开启 Kubernetes
+authorization，也应通过 NetworkPolicy 将 direct gateway access 限制到预期 agent 和 platform
+namespaces。
+
+## Invoke Contract
+
+第一版 HTTPS request 明确保持有界：
+
+```http
+POST /v1/namespaces/{namespace}/runs/{name}/{uid}/invoke
+Authorization: Bearer <kubernetes-token>
+Content-Type: application/json
+X-Kruntime-Invocation-ID: <caller-generated-id>
+```
+
+初始限制：
+
+- request body：1 MiB；
+- invocation ID：128 bytes；
+- outputs：使用 bounded Run outputs 相同的 key/count/value limits；
+- artifact references：使用 Run artifact references 相同的 count 和 metadata limits；
+- v0.x 中每个 function Run 只允许一个 in-flight invocation；
+- 不提供无界 server-side queue。
+
+Runtime gateway 在 dispatch 到 owner 或 Runtime Server 后绝不自动 retry invocation。连接失败
+可能代表 unknown execution outcome。SDK 也默认不 retry execution。未来 deduplication 或
+idempotency contract 可以使用 caller-generated invocation ID，但 v0.x 不承诺 exactly-once。
+
+成功和失败 response 都包含 invocation ID。Structured runtimed logs 包含 Runtime、Run UID 和
+invocation ID。Invocation stdout/stderr 通过 log collection 或 Runtime Server contract 定义的
+bounded response field 暴露，绝不追加到 `Run.status.message`。
+
+## Runtime Server Boundary
+
+内部 gRPC API 增加以 Run UID 为 key 的幂等 lifecycle operations：
+
+- `RegisterFunction`：注册 working directory、handler 和 environment；
+- `FunctionStatus`：报告 registered/readiness state、fatal errors、in-flight count，以及当前
+  registration epoch 的 last activity；
+- `InvokeFunction`：使用 invocation ID 和 timeout 执行一次 bounded request；
+- `UnregisterFunction`：停止新请求并释放 registration。
+
+使用同一 immutable configuration 重复注册同一 Run UID 和 attempt 应幂等成功；使用不同
+configuration 注册同一 epoch 必须失败。Unregister 不存在的 epoch 应成功。具体 protobuf
+fields 和 Bash/Python adapter behavior 属于独立 implementation PR，但必须保持这些语义。
+
+## Capacity 与 Concurrency
+
+Runtime `runs` capacity 控制一个 Runtime Pod 可以承载多少个 task executions 或 registered
+function Runs。Ready function Run 在 terminal cleanup 或 deletion 释放前持续占用一个 unit。
+
+Invocation concurrency 不是 scheduler capacity。v0.x 中，runtimed 与 Runtime Server 对每个
+function Run 只允许一个 in-flight invocation，并对 overlap request 返回 `429`。后续设计可以
+增加 per-function 和 Runtime-wide invocation concurrency 或 queue controls，而不让 scheduler
+感知单次 invoke。
+
+需要 exclusive Pod 和 workspace ownership 的 agent sandbox deployment 应继续使用 Runtime
+`runs: "1"`。SDK 可以 validation 或 warning 这一部署选择，但不能改变 scheduler semantics。
+
+## Component Boundaries
+
+| Component | Responsibility |
+| --- | --- |
+| Runtime controller | Reconcile Runtime-owned gateway Service 和 ports。 |
+| Scheduler | 分配通用 Run capacity；把 Ready 视为 active、non-terminal。 |
+| runtimed | Register/unregister、维护 lifecycle status 和 routing cache、authorize/proxy invokes、执行 local limits，并清理本地状态。 |
+| Runtime Server | 保存 registration/activity state、执行 invokes，并暴露幂等 local lifecycle APIs。 |
+| stale recovery | 检测 owning Pod 丢失、释放已经不可能执行的 local cleanup，并进入 shared Run retry/exhaustion semantics。 |
+| SDK 和 `krt` | Watch readiness、发现 endpoint、提供 credential、在不隐式 retry execution 的情况下 invoke，并暴露 typed errors。 |
+
+Workflow controllers 不感知 function registration 和 invocation。后续它们可以创建 function
+Runs，但只使用 public Run API。
+
+## Implementation Plan
+
+1. 增加 API prerequisites：`Ready`、assigned Pod UID、endpoint status、transition validation、
+   finalizer constant、generated CRDs 和通用 phase-classification tests。
+2. 增加 Runtime gateway Service reconciliation 以及 Helm/RBAC coverage。
+3. 增加 Runtime-scoped gateway TLS certificate reconciliation、CA publication、rotation 和
+   pod rollout behavior。
+4. 增加 Runtime Server register/status/invoke/unregister protobuf APIs 和内置 Bash/Python
+   adapters。
+5. 增加 runtimed registration lifecycle、finalization、shared retry integration、timeout handling
+   和 restart recovery。
+6. 增加 HTTPS gateway、watch-backed routing cache、local/peer dispatch、
+   SelfSubjectAccessReview authorization、limits 和 metrics。
+7. 增加 `krt invoke`，然后增加 Go/Python sandbox SDK connection layer。
+8. 增加覆盖 registration、TLS rotation、authorization、local/proxied invoke、concurrency rejection、
+   cancellation、deletion、idle/lifetime timeout、Runtime Pod loss 和 retry exhaustion 的 E2E。
+9. 只有 supported path 通过 E2E 后，才完成 agent sandbox demo。

--- a/docs/design/function-mode.md
+++ b/docs/design/function-mode.md
@@ -124,13 +124,18 @@ status:
   phase: Ready
   assignedPod: runtime-python-7f587b4668-njcks
   endpoint:
-    protocol: HTTP
-    url: http://python-runtime-gateway.kruntimes-demo.svc.cluster.local/v1/runs/kube-diagnose-agent/invoke
+    protocol: HTTPS
+    url: https://python-gateway.kruntimes-demo.svc.cluster.local/v1/namespaces/kruntimes-demo/runs/kube-diagnose-agent/2c24c1f0-9f8f-4f80-82d5-3dd16a12d1e6/invoke
+    caBundle: <base64-encoded-PEM>
   conditions:
     - type: Ready
       status: "True"
       reason: FunctionRegistered
 ```
+
+The exact phase, endpoint, retry, timeout, cleanup, routing, authorization, and
+invocation semantics are defined in
+[Function Mode Lifecycle and Invoke Dataplane](../function-mode-lifecycle/).
 
 `Ready` is not terminal for function-mode Runs. Deletion, cancellation, failed
 registration, or idle timeout ends the reservation.
@@ -203,6 +208,9 @@ function mode keeps `handler` under `mode.function`.
 
 ## Runtime Gateway
 
+The detailed gateway routing and authorization contract is defined in
+[Function Mode Lifecycle and Invoke Dataplane](../function-mode-lifecycle/).
+
 Each Runtime should get a gateway Service:
 
 ```text
@@ -217,7 +225,7 @@ invoke request to any runtimed in that Runtime pool, so each runtimed needs an
 ownership cache:
 
 ```text
-Run UID/name -> assigned Runtime Pod -> readiness -> function ID
+Run namespace/name/UID -> assigned Runtime Pod UID -> attempt -> readiness
 ```
 
 Invoke behavior:
@@ -232,10 +240,13 @@ Invoke behavior:
 
 Runtime Servers need a function-mode contract in addition to one-shot execute:
 
-- `RegisterFunction`: prepare code and return a function ID.
+- `RegisterFunction`: prepare code for a Run UID and ownership attempt.
 - `InvokeFunction`: run a request against a registered function.
 - `UnregisterFunction`: release runtime-local state.
 - `FunctionStatus`: report readiness and runtime-local errors.
+
+The idempotency, fencing, timeout, and bounded invoke semantics are defined in
+[Function Mode Lifecycle and Invoke Dataplane](../function-mode-lifecycle/).
 
 Invoke responses should contain bounded structured data:
 

--- a/docs/design/function-mode.zh.md
+++ b/docs/design/function-mode.zh.md
@@ -61,8 +61,7 @@ type FunctionMode struct {
 }
 ```
 
-`mode.task` 和 `mode.function` 必须且只能设置一个。为了兼容现有 one-shot Runs，如果
-`mode` 为空，Run 默认使用 task mode。
+`mode.task` 和 `mode.function` 必须且只能设置一个；`mode` 是 required，不能省略。
 
 One-shot task Runs 仍然是默认模式。`entrypoint` 和 `args` 属于 task mode，因为它们描述
 如何启动一次性进程：
@@ -117,13 +116,17 @@ status:
   phase: Ready
   assignedPod: runtime-python-7f587b4668-njcks
   endpoint:
-    protocol: HTTP
-    url: http://python-runtime-gateway.kruntimes-demo.svc.cluster.local/v1/runs/kube-diagnose-agent/invoke
+    protocol: HTTPS
+    url: https://python-gateway.kruntimes-demo.svc.cluster.local/v1/namespaces/kruntimes-demo/runs/kube-diagnose-agent/2c24c1f0-9f8f-4f80-82d5-3dd16a12d1e6/invoke
+    caBundle: <base64-encoded-PEM>
   conditions:
     - type: Ready
       status: "True"
       reason: FunctionRegistered
 ```
+
+具体 phase、endpoint、retry、timeout、cleanup、routing、authorization 和 invocation 语义见
+[Function Mode 生命周期与 Invoke Dataplane](../function-mode-lifecycle/)。
 
 对于 function-mode Runs，`Ready` 不是 terminal。删除、取消、注册失败或 idle timeout 会结束
 reservation。
@@ -190,6 +193,9 @@ Top-level `handler`、`entrypoint` 和 `args` 不属于目标 Run API。Task mod
 
 ## Runtime Gateway
 
+详细 gateway routing 和 authorization contract 见
+[Function Mode 生命周期与 Invoke Dataplane](../function-mode-lifecycle/)。
+
 每个 Runtime 应该有一个 gateway Service：
 
 ```text
@@ -203,7 +209,7 @@ Service 地址是稳定的。Kubernetes Service 负载均衡可能把 invoke req
 pool 中的任意 runtimed，因此每个 runtimed 都需要 ownership cache：
 
 ```text
-Run UID/name -> assigned Runtime Pod -> readiness -> function ID
+Run namespace/name/UID -> assigned Runtime Pod UID -> attempt -> readiness
 ```
 
 Invoke 行为：
@@ -218,10 +224,13 @@ Invoke 行为：
 
 除了 one-shot execute，Runtime Server 还需要 function-mode contract：
 
-- `RegisterFunction`：准备代码并返回 function ID。
+- `RegisterFunction`：为 Run UID 和 ownership attempt 准备代码。
 - `InvokeFunction`：针对已注册 function 执行一次 request。
 - `UnregisterFunction`：释放 runtime-local state。
 - `FunctionStatus`：报告 readiness 和 runtime-local errors。
+
+幂等、fencing、timeout 和 bounded invoke 语义见
+[Function Mode 生命周期与 Invoke Dataplane](../function-mode-lifecycle/)。
 
 Invoke response 应包含有界结构化数据：
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -93,13 +93,30 @@ wiring from accumulating avoidable conflicts.
   - [x] remove top-level `entrypoint`, `args`, and `handler` before API
     stabilization;
   - [x] migrate CLI creation and high-level user docs to use `spec.mode.task`;
-  - add function-mode ready status, endpoint status, and dataplane lifecycle
-    fields;
+  - [ ] review and approve the
+    [function lifecycle and invoke dataplane design](design/function-mode-lifecycle.md);
+  - [ ] add `Ready` phase, assigned Pod UID, endpoint status, immutable
+    execution-input transitions, the function cleanup finalizer constant,
+    generated CRDs, and generic phase-classification tests;
+  - [ ] implement registration lifecycle, shared retry integration,
+    reservation/idle timeout, finalization, and restart recovery;
 - [ ] Runtime gateway invoke path: create one gateway Service per Runtime, use
   that Service as the stable Run invoke endpoint, route requests to the
   runtimed that owns the assigned Runtime Pod, and rely on runtimed's in-memory
   ownership/readiness cache instead of synchronous Kubernetes API reads on the
   invoke path.
+  Initial implementation TODO:
+  - [ ] reconcile a Runtime-owned ClusterIP gateway Service and dedicated
+    runtimed gateway port;
+  - [ ] reconcile Runtime-scoped TLS serving certificates and bounded CA
+    publication, rotation, and Runtime Pod rollout;
+  - [ ] implement watch-backed ownership/readiness caches and bounded local or
+    single-hop peer routing;
+  - [ ] fence registration epochs before stale-pod reassignment and reject
+    mismatched Run UID, attempt, or assigned Pod UID;
+  - [ ] authorize callers through Kubernetes SelfSubjectAccessReview with a
+    bounded decision cache;
+  - [ ] enforce TLS, request, response, concurrency, and proxy-loop limits;
 - [x] Function-mode API cleanup: remove top-level `Run.spec.handler`,
   `Run.spec.entrypoint`, and `Run.spec.args`; keep handler under
   `Run.spec.mode.function.handler` and task input under `Run.spec.mode.task`.
@@ -107,6 +124,12 @@ wiring from accumulating avoidable conflicts.
   unregister APIs; define bounded invoke request inputs, response outputs,
   artifact references, and log access without writing high-frequency invocation
   history into Run status.
+  Initial implementation TODO:
+  - [ ] add idempotent register/status/invoke/unregister protobuf operations
+    keyed by Run UID;
+  - [ ] implement built-in Bash and Python function adapters;
+  - [ ] add bounded invocation outputs/artifact references and structured logs
+    keyed by Run UID and invocation ID;
 - [ ] Function-mode reliability and isolation: cover function registration,
   ready status, local and proxied invoke, repeated invocation, artifact reuse,
   idle timeout, explicit release, runtime pod restart recovery, cleanup, service

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -84,17 +84,38 @@ controller wiring 累积不必要的冲突。
     和 runtime helpers；
   - [x] 在 API 稳定前删除 top-level 的 `entrypoint`、`args` 和 `handler`；
   - [x] 将 CLI 创建和高层用户文档迁移为使用 `spec.mode.task`；
-  - 增加 function-mode ready status、endpoint status 和 dataplane lifecycle 字段；
+  - [ ] review 并确认
+    [function lifecycle 和 invoke dataplane 设计](design/function-mode-lifecycle.md)；
+  - [ ] 增加 `Ready` phase、assigned Pod UID、endpoint status、immutable execution-input
+    transitions、function cleanup finalizer constant、generated CRDs 和通用
+    phase-classification tests；
+  - [ ] 实现 registration lifecycle、shared retry integration、reservation/idle timeout、
+    finalization 和 restart recovery；
 - [ ] Runtime gateway invoke path：为每个 Runtime 创建一个 gateway Service，把这个
   Service 作为稳定的 Run invoke endpoint，将请求路由到拥有 assigned Runtime Pod 的
   runtimed，并在 invoke path 上依赖 runtimed 的内存 ownership/readiness cache，而不是
   同步读取 Kubernetes API。
+  初始实现 TODO：
+  - [ ] reconcile Runtime-owned ClusterIP gateway Service 和专用 runtimed gateway port；
+  - [ ] reconcile Runtime-scoped TLS serving certificates，以及有界 CA publication、
+    rotation 和 Runtime Pod rollout；
+  - [ ] 实现 watch-backed ownership/readiness caches，以及有界 local 或 single-hop peer
+    routing；
+  - [ ] 在 stale-pod reassignment 前 fence registration epoch，并拒绝 Run UID、attempt 或
+    assigned Pod UID mismatch；
+  - [ ] 通过 Kubernetes SelfSubjectAccessReview 和有界 decision cache authorize caller；
+  - [ ] 执行 TLS、request、response、concurrency 和 proxy-loop limits；
 - [x] Function-mode API cleanup：删除 top-level `Run.spec.handler`、
   `Run.spec.entrypoint` 和 `Run.spec.args`；handler 放在
   `Run.spec.mode.function.handler` 下，task input 放在 `Run.spec.mode.task` 下。
 - [ ] Function-mode runtime contract：增加 runtime-server register、invoke 和
   unregister APIs；定义有界 invoke request inputs、response outputs、artifact
   references 和 log access，同时避免把高频 invocation history 写入 Run status。
+  初始实现 TODO：
+  - [ ] 增加以 Run UID 为 key 的幂等 register/status/invoke/unregister protobuf operations；
+  - [ ] 实现内置 Bash 和 Python function adapters；
+  - [ ] 增加有界 invocation outputs/artifact references，以及以 Run UID 和 invocation ID
+    为 key 的 structured logs；
 - [ ] Function-mode reliability and isolation：覆盖 function registration、ready
   status、local/proxied invoke、多次 invocation、artifact reuse、idle timeout、
   explicit release、runtime pod restart recovery、cleanup、service account 选择、


### PR DESCRIPTION
## Summary

- define the lifecycle and bounded status API for function-mode Runs
- define assignment epoch fencing, retry, timeout, cancellation, and deletion semantics
- define a Runtime-owned HTTPS gateway Service, TLS rotation, routing cache, and peer dispatch
- define Kubernetes-native caller authorization through SelfSubjectAccessReview
- define Runtime Server lifecycle contracts, invocation limits, and at-least-once invocation boundaries
- split roadmap implementation into reviewable API, gateway, runtime-contract, lifecycle, SDK, and E2E work

## Decisions requiring review

- add non-terminal `RunReady`, `status.assignedPodUID`, and `status.endpoint`
- make Run execution inputs immutable after creation; allow only one-way cancellation
- expose a Runtime-scoped HTTPS endpoint with a bounded CA bundle
- use Run UID plus attempt and Pod UID as the registration/fencing identity
- do not reassign after only a stale heartbeat; fence the old assignment first
- use Kubernetes bearer tokens and `SelfSubjectAccessReview` for ClusterIP gateway authorization
- permit one in-flight invocation per function Run in v0.x; never automatically retry a dispatched invocation
- use a function cleanup finalizer for deletion and local unregistration

This PR is design-only. No API, CRD, or runtime implementation starts until review is complete.

## Validation

- `make site-build`
- rendered English and Chinese sibling design links
