### PR TITLE
docs(run): define workspace and affinity API

### DIFF
--- a/docs/design/_index.md
+++ b/docs/design/_index.md
@@ -9,5 +9,6 @@ implemented.
 
 - [Function Mode and Agent Sandboxes](function-mode/)
 - [Workflow Data Sharing](workflow-data-sharing/)
+- [Run Workspace References and Affinity](run-workspace-affinity/)
 - [Workflow Reuse](workflow-reuse/)
 - [Dashboard](dashboard/)

--- a/docs/design/_index.zh.md
+++ b/docs/design/_index.zh.md
@@ -7,5 +7,6 @@
 
 - [Function Mode 和 Agent Sandboxes](function-mode/)
 - [Workflow Data Sharing](workflow-data-sharing/)
+- [Run Workspace 引用与 Affinity](run-workspace-affinity/)
 - [Workflow Reuse](workflow-reuse/)
 - [Dashboard](dashboard/)

--- a/docs/design/run-workspace-affinity.md
+++ b/docs/design/run-workspace-affinity.md
@@ -1,0 +1,237 @@
+# Run Workspace References and Affinity
+
+Status: **Proposed for review**
+
+This document fixes the API shape for the next Workflow data-sharing
+prerequisite: a generic Run workspace reference and Run-to-Run affinity. It
+does not implement workspace binding, scheduler placement, or runtimed file
+preparation. Those are separate, reviewable implementation PRs.
+
+## Scope
+
+`PersistentWorkspace` is a namespace-scoped resource with a Runtime binding and
+lifecycle. A Run needs a small, typed reference to use one. Later Runs also need
+a familiar way to require or prefer the same Runtime Pod as another Run, without
+exposing an opaque scheduler-specific sticky key.
+
+The API must remain useful outside Workflows. A user can create a
+`PersistentWorkspace` and one or more Runs directly; a Workflow controller is
+only one future consumer.
+
+## Run Workspace Reference
+
+`Run.spec.workspace` is an optional typed local reference:
+
+```go
+type RunWorkspaceReference struct {
+    Name     string `json:"name"`
+    Kind     string `json:"kind,omitempty"`
+    APIGroup string `json:"apiGroup,omitempty"`
+}
+
+type RunSpec struct {
+    // Existing fields omitted.
+    Workspace *RunWorkspaceReference `json:"workspace,omitempty"`
+}
+```
+
+The initial served values are deliberately narrow:
+
+| Field | Required | Default | Initial accepted value |
+| --- | --- | --- | --- |
+| `name` | Yes | None | A DNS-1123 subdomain name in the Run namespace. |
+| `kind` | No | `PersistentWorkspace` | `PersistentWorkspace`. |
+| `apiGroup` | No | `kruntimes.io/v1alpha1` | `kruntimes.io/v1alpha1`. |
+
+`apiGroup` preserves the compact reference form proposed for the experimental
+API. It identifies the currently served group/version, not an arbitrary remote
+resource. A future general workspace-provider API can introduce versioned
+reference semantics through a reviewed API change rather than silently making
+these fields mean something broader.
+
+The reference is always namespace-local. It has no `namespace` field, and the
+API rejects unsupported kind/group combinations. A Run cannot refer to a
+workspace in another namespace, even if its creator has permission to read it.
+
+For example, these forms are equivalent in the initial API:
+
+```yaml
+spec:
+  workspace:
+    name: ci-build-workspace
+```
+
+```yaml
+spec:
+  workspace:
+    name: ci-build-workspace
+    kind: PersistentWorkspace
+    apiGroup: kruntimes.io/v1alpha1
+```
+
+The Run reference only expresses intent. It does **not** copy workspace status,
+bind a workspace, or implicitly select a Runtime Pod. The PersistentWorkspace
+controller remains the owner of binding and lifecycle. The scheduler and
+runtimed follow-up PRs must reject incompatible Runtime bindings and honor a
+bound workspace's placement without learning any Workflow concepts.
+
+## Run Affinity API
+
+Run affinity follows Kubernetes affinity's familiar required/preferred model
+and label-selector vocabulary, but it deliberately does not reuse
+`corev1.Affinity`. Kubernetes uses that type to choose a Node for a new Pod;
+kruntimes chooses an existing ready Runtime Pod for a Run. Reusing it would
+present unsupported Node and Pod semantics as functional API surface.
+
+```go
+type RunAffinity struct {
+    RunAffinity     *RunAffinityRules `json:"runAffinity,omitempty"`
+    RunAntiAffinity *RunAffinityRules `json:"runAntiAffinity,omitempty"`
+}
+
+type RunAffinityRules struct {
+    RequiredDuringSchedulingIgnoredDuringExecution []RunAffinityTerm `json:"requiredDuringSchedulingIgnoredDuringExecution,omitempty"`
+    PreferredDuringSchedulingIgnoredDuringExecution []WeightedRunAffinityTerm `json:"preferredDuringSchedulingIgnoredDuringExecution,omitempty"`
+}
+
+type WeightedRunAffinityTerm struct {
+    Weight          int32           `json:"weight"`
+    RunAffinityTerm RunAffinityTerm `json:"runAffinityTerm"`
+}
+
+type RunAffinityTerm struct {
+    LabelSelector *metav1.LabelSelector `json:"labelSelector"`
+    TopologyKey   string                `json:"topologyKey"`
+}
+
+type RunSpec struct {
+    // Existing fields omitted.
+    Affinity *RunAffinity `json:"affinity,omitempty"`
+}
+```
+
+The field names intentionally mirror Kubernetes:
+
+- `requiredDuringSchedulingIgnoredDuringExecution` is a hard scheduling
+  constraint. A candidate that does not satisfy every term is ineligible; the
+  Run remains `Pending` if no candidate is eligible.
+- `preferredDuringSchedulingIgnoredDuringExecution` is a soft scoring hint.
+  It never lets a candidate violate required rules or Runtime capacity.
+- `runAffinity` requires a matching active Run to share the requested topology.
+- `runAntiAffinity` requires matching active Runs to be absent from that
+  topology.
+
+The initial API supports exactly one topology key:
+
+```text
+kruntimes.io/runtime-pod
+```
+
+For this key, topology equality means equality of the assigned Runtime Pod
+name. It is the direct, understandable constraint required by a
+`RuntimePodLocal` PersistentWorkspace. The scheduler need not interpret a
+node, zone, or a Kubernetes Pod's affinity to evaluate it.
+
+Every term matches labels on namespace-local `Run` objects. In the first
+version, a Run is an *active affinity target* only while its phase is
+`Scheduled`, `Running`, or `Ready` and it has an assigned Runtime Pod. Pending
+and terminal Runs do not constrain another Run. The Run being scheduled never
+matches itself because it has no assignment yet.
+
+Example: require a later build step to run on the Runtime Pod selected for a
+previous step.
+
+```yaml
+apiVersion: kruntimes.io/v1alpha1
+kind: Run
+metadata:
+  name: ci-build-test
+  labels:
+    workflows.kruntimes.io/workflow: ci-data-sharing-demo
+    workflows.kruntimes.io/job: build
+spec:
+  runtime: bash
+  workspace:
+    name: ci-build-workspace
+  affinity:
+    runAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              workflows.kruntimes.io/workflow: ci-data-sharing-demo
+              workflows.kruntimes.io/job: build
+          topologyKey: kruntimes.io/runtime-pod
+  mode:
+    task: {}
+```
+
+The Workflow controller will use a more selective label set in its generated
+Runs so that a job cannot accidentally match an unrelated Run with copied user
+labels. The generic API itself intentionally permits any caller-owned labels.
+
+## Validation and Transition Rules
+
+The initial CRD validation is intentionally mechanical and bounded:
+
+- `workspace.name` has Kubernetes object-name length and format validation.
+- `workspace.kind`, when present, must be `PersistentWorkspace`.
+- `workspace.apiGroup`, when present, must be `kruntimes.io/v1alpha1`.
+- every affinity term requires a non-empty `labelSelector` and the only
+  supported `topologyKey`.
+- required and preferred term lists each have a small bounded maximum; preferred
+  weights are integers from 1 through 100.
+
+As with other execution inputs, `workspace` and `affinity` are immutable after
+Run creation. Changing either after assignment could make a Running Run observe
+a different shared-data boundary or placement requirement. This is an
+experimental API validation change and requires regenerated CRDs and integration
+tests in the API skeleton PR.
+
+The initial API intentionally does not offer cross-namespace selectors,
+namespace selectors, Node affinity, arbitrary topologies, topology spread, or
+a direct `podName`/sticky-key field. Each expands the scheduler's trust and
+RBAC surface and needs its own design review.
+
+## Scheduler Contract
+
+The API skeleton only declares and validates fields. The placement PR follows
+these rules:
+
+1. Load candidate ready Runtime Pods using the existing Runtime and capacity
+   filtering.
+2. Load active affinity target Runs from the same namespace.
+3. Remove candidates that violate required Run affinity or anti-affinity.
+4. Score remaining candidates by preferred terms, then use the existing
+   least-loaded strategy as the deterministic tie breaker.
+5. If no candidate remains, leave the Run `Pending`; do not mark it `Failed`.
+
+The scheduler remains Workflow-agnostic. It neither creates workspaces nor
+interprets job or step labels. It evaluates generic Run labels and the declared
+affinity terms only.
+
+## Interaction with PersistentWorkspace
+
+`PersistentWorkspace.spec.runtime` must equal `Run.spec.runtime` before a Run
+can use that workspace. For `RuntimePodLocal`, after the workspace is bound the
+scheduler must allow only its `status.boundPod`; it may express that internal
+constraint directly rather than requiring a controller to manufacture an
+affinity target Run. The public affinity API remains useful for direct users and
+for later steps that must follow another active Run.
+
+A missing, pending, lost, or incompatible workspace is not a terminal Run
+failure at scheduling time. The later workspace-aware reconciliation design must
+provide a clear condition and requeue behavior. Its exact failure/retry policy
+is intentionally outside this API PR.
+
+## Implementation Sequence
+
+1. Add the Go API types, deepcopy generation, CRD schemas, and validation
+   integration tests only.
+2. Add scheduler candidate filtering and scoring with focused unit and
+   integration coverage.
+3. Add PersistentWorkspace binding and Run workspace admission/preparation in
+   the controller and runtimed.
+4. Add Workflow controller composition and end-to-end data-sharing coverage.
+
+Steps 2 through 4 must remain separate PRs so each preserves the scheduler and
+runtimed component boundary.

--- a/docs/design/run-workspace-affinity.zh.md
+++ b/docs/design/run-workspace-affinity.zh.md
@@ -1,0 +1,207 @@
+# Run Workspace 引用与 Affinity
+
+状态：**等待 review 的提案**
+
+本文固定 Workflow data sharing 下一项前置能力的 API shape：通用的 Run workspace
+引用，以及 Run-to-Run affinity。本文不实现 workspace binding、scheduler placement 或
+runtimed 文件准备；它们将分别通过可 review 的实现 PR 完成。
+
+## 范围
+
+`PersistentWorkspace` 是带有 Runtime binding 与生命周期的 namespace-scoped 资源。Run 需要
+一个小型 typed reference 才能使用它。后续 Run 还需要一种熟悉的方式，要求或偏好与另一 Run
+位于同一个 Runtime Pod，而不是暴露不透明、scheduler-specific 的 sticky key。
+
+此 API 也必须能在 Workflow 外使用。用户可以直接创建 `PersistentWorkspace` 和一个或多个
+Run；Workflow controller 只是未来的一个 consumer。
+
+## Run Workspace Reference
+
+`Run.spec.workspace` 是可选的 typed local reference：
+
+```go
+type RunWorkspaceReference struct {
+    Name     string `json:"name"`
+    Kind     string `json:"kind,omitempty"`
+    APIGroup string `json:"apiGroup,omitempty"`
+}
+
+type RunSpec struct {
+    // Existing fields omitted.
+    Workspace *RunWorkspaceReference `json:"workspace,omitempty"`
+}
+```
+
+第一版只接受以下窄范围值：
+
+| 字段 | 必填 | 默认值 | 第一版接受的值 |
+| --- | --- | --- | --- |
+| `name` | 是 | 无 | Run 所在 namespace 内的 DNS-1123 subdomain name。 |
+| `kind` | 否 | `PersistentWorkspace` | `PersistentWorkspace`。 |
+| `apiGroup` | 否 | `kruntimes.io/v1alpha1` | `kruntimes.io/v1alpha1`。 |
+
+`apiGroup` 保留实验性 API 中提出的紧凑 reference 形式。它标识当前 served 的 group/version，
+而不是任意 remote resource。未来若需要通用 workspace-provider API，应通过经过 review 的 API
+change 引入 versioned reference semantics，而不是悄悄扩大这些字段的含义。
+
+该引用始终只作用于本 namespace。它没有 `namespace` 字段，API 也会拒绝不支持的
+kind/group 组合。即便创建者拥有读取权限，Run 也不能引用其他 namespace 的 workspace。
+
+第一版中，下列两种形式等价：
+
+```yaml
+spec:
+  workspace:
+    name: ci-build-workspace
+```
+
+```yaml
+spec:
+  workspace:
+    name: ci-build-workspace
+    kind: PersistentWorkspace
+    apiGroup: kruntimes.io/v1alpha1
+```
+
+Run reference 只表达 intent。它不会复制 workspace status、bind workspace 或隐式选择 Runtime
+Pod。PersistentWorkspace controller 仍拥有 binding 与 lifecycle。后续 scheduler 和 runtimed
+PR 必须拒绝不兼容的 Runtime binding，并遵守已 bound workspace 的 placement，同时不能理解任何
+Workflow 概念。
+
+## Run Affinity API
+
+Run affinity 使用 Kubernetes 中熟悉的 required/preferred 模型与 label selector 词汇，但不会
+直接复用 `corev1.Affinity`。Kubernetes 用该类型为新 Pod 选择 Node；kruntimes 是为 Run 从已有
+的 ready Runtime Pod 中选择一个。直接复用会把当前并未实现的 Node/Pod 语义变成表面 API。
+
+```go
+type RunAffinity struct {
+    RunAffinity     *RunAffinityRules `json:"runAffinity,omitempty"`
+    RunAntiAffinity *RunAffinityRules `json:"runAntiAffinity,omitempty"`
+}
+
+type RunAffinityRules struct {
+    RequiredDuringSchedulingIgnoredDuringExecution []RunAffinityTerm `json:"requiredDuringSchedulingIgnoredDuringExecution,omitempty"`
+    PreferredDuringSchedulingIgnoredDuringExecution []WeightedRunAffinityTerm `json:"preferredDuringSchedulingIgnoredDuringExecution,omitempty"`
+}
+
+type WeightedRunAffinityTerm struct {
+    Weight          int32           `json:"weight"`
+    RunAffinityTerm RunAffinityTerm `json:"runAffinityTerm"`
+}
+
+type RunAffinityTerm struct {
+    LabelSelector *metav1.LabelSelector `json:"labelSelector"`
+    TopologyKey   string                `json:"topologyKey"`
+}
+
+type RunSpec struct {
+    // Existing fields omitted.
+    Affinity *RunAffinity `json:"affinity,omitempty"`
+}
+```
+
+字段名有意贴近 Kubernetes：
+
+- `requiredDuringSchedulingIgnoredDuringExecution` 是硬调度约束。不满足任一 term 的 candidate
+  不可用；若没有 eligible candidate，Run 继续保持 `Pending`。
+- `preferredDuringSchedulingIgnoredDuringExecution` 是软 scoring hint。它不能绕过 required
+  rules 或 Runtime capacity。
+- `runAffinity` 要求匹配的 active Run 位于请求的 topology。
+- `runAntiAffinity` 要求匹配的 active Run 不位于该 topology。
+
+初版只支持一个 topology key：
+
+```text
+kruntimes.io/runtime-pod
+```
+
+对该 key，topology equality 表示 assigned Runtime Pod name 相等。这是
+`RuntimePodLocal` PersistentWorkspace 所需要、直接且易理解的约束；scheduler 不需要解释 Node、
+zone 或 Kubernetes Pod affinity。
+
+所有 term 都匹配同 namespace `Run` objects 上的 labels。第一版中，一条 Run 只有在 phase 为
+`Scheduled`、`Running` 或 `Ready` 且已 assigned Runtime Pod 时才是 *active affinity target*。
+Pending 和 terminal Runs 不约束另一条 Run。当前正在调度的 Run 因为尚未 assigned，不会匹配自身。
+
+示例：要求后续 build step 运行在前一步选定的 Runtime Pod：
+
+```yaml
+apiVersion: kruntimes.io/v1alpha1
+kind: Run
+metadata:
+  name: ci-build-test
+  labels:
+    workflows.kruntimes.io/workflow: ci-data-sharing-demo
+    workflows.kruntimes.io/job: build
+spec:
+  runtime: bash
+  workspace:
+    name: ci-build-workspace
+  affinity:
+    runAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              workflows.kruntimes.io/workflow: ci-data-sharing-demo
+              workflows.kruntimes.io/job: build
+          topologyKey: kruntimes.io/runtime-pod
+  mode:
+    task: {}
+```
+
+Workflow controller 在生成的 Run 中会使用更有选择性的 label set，确保一个 job 不会因用户复制了
+不相关的 labels 而匹配无关 Run。通用 API 则有意允许任意 caller-owned labels。
+
+## Validation 与 Transition Rules
+
+第一版 CRD validation 保持机械且有边界：
+
+- `workspace.name` 使用 Kubernetes object name 的长度和格式 validation。
+- 若设置 `workspace.kind`，必须为 `PersistentWorkspace`。
+- 若设置 `workspace.apiGroup`，必须为 `kruntimes.io/v1alpha1`。
+- 每个 affinity term 都需要非空 `labelSelector`，且只能使用支持的 `topologyKey`。
+- required 与 preferred term lists 都有小型上限；preferred weight 是 1 到 100 的整数。
+
+与其他 execution inputs 相同，`workspace` 和 `affinity` 在 Run 创建后不可变。assignment 后修改
+其中任意一个，可能让 Running Run 观察到不同的 shared-data boundary 或 placement requirement。
+这是实验性 API validation change，API skeleton PR 必须重新生成 CRDs 并增加 integration tests。
+
+初版刻意不支持 cross-namespace selectors、namespace selectors、Node affinity、任意 topology、
+topology spread，或直接的 `podName`/sticky-key field。每项都会扩大 scheduler 的 trust 与 RBAC
+surface，需要独立 design review。
+
+## Scheduler Contract
+
+API skeleton 只声明和 validation fields。placement PR 需要遵守：
+
+1. 使用已有 Runtime 与 capacity filtering 获取 candidate ready Runtime Pods。
+2. 加载同 namespace 的 active affinity target Runs。
+3. 移除违反 required Run affinity 或 anti-affinity 的 candidates。
+4. 根据 preferred terms 对剩余 candidates 打分，再使用已有 least-loaded strategy 作为确定性
+   tie breaker。
+5. 若没有 candidate，保持 Run `Pending`，不能标记为 `Failed`。
+
+scheduler 仍保持 Workflow-agnostic。它不创建 workspace，也不理解 job 或 step labels；它只评估
+通用 Run labels 与声明的 affinity terms。
+
+## 与 PersistentWorkspace 的交互
+
+Run 使用 workspace 前，`PersistentWorkspace.spec.runtime` 必须等于 `Run.spec.runtime`。对于
+`RuntimePodLocal`，workspace bound 后 scheduler 必须只允许 `status.boundPod`；它可以直接表达此
+内部约束，而不要求 controller 伪造一条 affinity target Run。public affinity API 对直接用户以及
+需要跟随另一条 active Run 的后续 steps 仍有价值。
+
+missing、pending、lost 或 incompatible workspace 在调度时不是 terminal Run failure。后续
+workspace-aware reconciliation design 必须提供明确 condition 和 requeue behavior；精确的
+failure/retry policy 不属于本 API PR。
+
+## 实现顺序
+
+1. 只增加 Go API types、deepcopy generation、CRD schemas 与 validation integration tests。
+2. 增加 scheduler candidate filtering/scoring 及 focused unit/integration coverage。
+3. 在 controller 和 runtimed 中增加 PersistentWorkspace binding 与 Run workspace
+   admission/preparation。
+4. 增加 Workflow controller composition 和端到端 data-sharing coverage。
+
+步骤 2 到 4 必须保持为独立 PR，确保 scheduler 和 runtimed 的组件边界清晰。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -158,6 +158,8 @@ wiring from accumulating avoidable conflicts.
     fields while keeping the current emptyDir default behavior;
   - [x] add `PersistentWorkspace` API types, CRD validation, status, and
     controller skeleton;
+  - [ ] review the dedicated Run workspace-reference and affinity API shape
+    before adding the API skeleton;
   - add Run fields for workspace reference and Kubernetes-style Run affinity;
   - update scheduler placement to respect required/preferred Run affinity while
     keeping no-capacity Runs Pending;

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -138,6 +138,7 @@ controller wiring 累积不必要的冲突。
     当前 emptyDir 默认行为；
   - [x] 增加 `PersistentWorkspace` API types、CRD validation、status 和 controller
     skeleton；
+  - [ ] review Run workspace reference 与 affinity 的专用 API shape，再增加 API skeleton；
   - 为 Run 增加 workspace reference 和 Kubernetes-style Run affinity 字段；
   - 更新 scheduler placement，使其支持 required/preferred Run affinity，同时在无 capacity
     时继续保持 Run Pending；


### PR DESCRIPTION
## Summary
- define the namespace-local `Run.spec.workspace` reference, initially limited to `PersistentWorkspace`
- define Kubernetes-familiar required/preferred Run affinity semantics over active Run labels
- constrain the initial topology to `kruntimes.io/runtime-pod`, avoiding unsupported Node scheduling semantics
- split API, scheduler, workspace, and Workflow work into reviewable roadmap tasks

## Decisions requiring review
- `workspace.name`, optional `kind`, and optional `apiGroup`, with defaults to `PersistentWorkspace` and `kruntimes.io/v1alpha1`
- `spec.affinity.runAffinity` and `spec.affinity.runAntiAffinity`, rather than reusing `corev1.Affinity`
- only namespace-local selectors and a single Runtime-Pod topology in the first version
- workspace and affinity immutable after Run creation

## Validation
- `make site-build`