### PR TITLE
feat(workflow): add reusable execution API prerequisites

### DIFF
--- a/api/v1alpha1/workflow_types.go
+++ b/api/v1alpha1/workflow_types.go
@@ -2,42 +2,6 @@ package v1alpha1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// WorkflowPhase is the lifecycle phase of a WorkflowRun execution.
-// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed;Cancelled
-type WorkflowPhase string
-
-const (
-	WorkflowPending   WorkflowPhase = "Pending"
-	WorkflowRunning   WorkflowPhase = "Running"
-	WorkflowSucceeded WorkflowPhase = "Succeeded"
-	WorkflowFailed    WorkflowPhase = "Failed"
-	WorkflowCancelled WorkflowPhase = "Cancelled"
-)
-
-// JobPhase is the lifecycle phase of a job within a workflow.
-// +kubebuilder:validation:Enum=Pending;Waiting;Running;Succeeded;Failed;Skipped
-type JobPhase string
-
-const (
-	JobPending   JobPhase = "Pending"
-	JobWaiting   JobPhase = "Waiting"
-	JobRunning   JobPhase = "Running"
-	JobSucceeded JobPhase = "Succeeded"
-	JobFailed    JobPhase = "Failed"
-	JobSkipped   JobPhase = "Skipped"
-)
-
-// StepPhase is the lifecycle phase of a step within a job.
-// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed
-type StepPhase string
-
-const (
-	StepPending   StepPhase = "Pending"
-	StepRunning   StepPhase = "Running"
-	StepSucceeded StepPhase = "Succeeded"
-	StepFailed    StepPhase = "Failed"
-)
-
 // +kubebuilder:object:generate=true
 // WorkflowInputSpec defines one reusable Workflow input.
 type WorkflowInputSpec struct {
@@ -183,48 +147,6 @@ type WorkflowStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
-}
-
-// +kubebuilder:object:generate=true
-// JobStatus tracks the status of a job.
-type JobStatus struct {
-	// Phase is the current phase of the job.
-	Phase JobPhase `json:"phase"`
-
-	// Pre is the resolved list of predecessor jobs that must complete before
-	// this job can start.
-	// +optional
-	// +kubebuilder:validation:MaxItems=64
-	// +kubebuilder:validation:items:MaxLength=63
-	Pre []string `json:"pre,omitempty"`
-
-	// Steps tracks each step in the original job step order.
-	// +optional
-	// +kubebuilder:validation:MaxItems=128
-	Steps []StepStatus `json:"steps,omitempty"`
-}
-
-// +kubebuilder:object:generate=true
-// StepStatus tracks the status of a step.
-type StepStatus struct {
-	// Name is the step name.
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MinLength=1
-	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern=`^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$`
-	Name string `json:"name"`
-
-	// Phase is the current phase of the step.
-	Phase StepPhase `json:"phase"`
-
-	// RunName is the name of the Run CRD created for this step.
-	// +optional
-	RunName string `json:"runName,omitempty"`
-
-	// Outputs is key-value pairs exposed by this step.
-	// +optional
-	// +kubebuilder:validation:MaxProperties=64
-	Outputs map[string]string `json:"outputs,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/workflowrun_types.go
+++ b/api/v1alpha1/workflowrun_types.go
@@ -2,6 +2,42 @@ package v1alpha1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+// WorkflowPhase is the lifecycle phase of a WorkflowRun execution.
+// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed;Cancelled
+type WorkflowPhase string
+
+const (
+	WorkflowPending   WorkflowPhase = "Pending"
+	WorkflowRunning   WorkflowPhase = "Running"
+	WorkflowSucceeded WorkflowPhase = "Succeeded"
+	WorkflowFailed    WorkflowPhase = "Failed"
+	WorkflowCancelled WorkflowPhase = "Cancelled"
+)
+
+// JobPhase is the lifecycle phase of a job within a WorkflowRun.
+// +kubebuilder:validation:Enum=Pending;Waiting;Running;Succeeded;Failed;Skipped
+type JobPhase string
+
+const (
+	JobPending   JobPhase = "Pending"
+	JobWaiting   JobPhase = "Waiting"
+	JobRunning   JobPhase = "Running"
+	JobSucceeded JobPhase = "Succeeded"
+	JobFailed    JobPhase = "Failed"
+	JobSkipped   JobPhase = "Skipped"
+)
+
+// StepPhase is the lifecycle phase of a step within a WorkflowRun job.
+// +kubebuilder:validation:Enum=Pending;Running;Succeeded;Failed
+type StepPhase string
+
+const (
+	StepPending   StepPhase = "Pending"
+	StepRunning   StepPhase = "Running"
+	StepSucceeded StepPhase = "Succeeded"
+	StepFailed    StepPhase = "Failed"
+)
+
 const (
 	// WorkflowRunAcceptedCondition reports whether the WorkflowRun was accepted by the controller.
 	WorkflowRunAcceptedCondition = "Accepted"
@@ -12,6 +48,16 @@ const (
 	WorkflowJobLabel = "kruntimes.io/workflow-job"
 	// WorkflowStepLabel identifies the workflow step that owns a child Run.
 	WorkflowStepLabel = "kruntimes.io/workflow-step"
+
+	// WorkflowRootRunUIDLabel identifies the root WorkflowRun that owns a
+	// nested child WorkflowRun or Run.
+	WorkflowRootRunUIDLabel = "kruntimes.io/root-workflowrun-uid"
+	// WorkflowSnapshotNameAnnotation identifies the immutable ControllerRevision
+	// snapshot used by a WorkflowRun execution tree.
+	WorkflowSnapshotNameAnnotation = "kruntimes.io/workflow-snapshot-name"
+	// WorkflowCallPathAnnotation identifies a namespace-local reusable Workflow
+	// call path within a snapshot execution tree.
+	WorkflowCallPathAnnotation = "kruntimes.io/workflow-call-path"
 )
 
 // +kubebuilder:object:generate=true
@@ -19,6 +65,8 @@ const (
 // +kubebuilder:validation:XValidation:rule="has(self.jobs) != has(self.uses)",message="exactly one of jobs or uses must be set"
 // +kubebuilder:validation:XValidation:rule="!has(self.with) || has(self.uses)",message="with can only be set when uses is set"
 // +kubebuilder:validation:XValidation:rule="!has(self.jobs) || self.jobs.all(name, !has(self.jobs[name].needs) || self.jobs[name].needs.all(need, need in self.jobs && need != name))",message="each dependency must name another job in this WorkflowRun"
+// +kubebuilder:validation:XValidation:rule="has(self.jobs) == has(oldSelf.jobs) && (!has(self.jobs) || self.jobs == oldSelf.jobs) && has(self.uses) == has(oldSelf.uses) && (!has(self.uses) || self.uses == oldSelf.uses) && has(self.with) == has(oldSelf.with) && (!has(self.with) || self.with == oldSelf.with)",message="jobs, uses, and with are immutable after WorkflowRun creation"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.cancelRequested) || !oldSelf.cancelRequested || (has(self.cancelRequested) && self.cancelRequested)",message="cancelRequested may not transition from true to false"
 type WorkflowRunSpec struct {
 	// Jobs is a map of inline job names to job specs. Jobs run in parallel
 	// unless constrained by needs; the map order is not significant.
@@ -60,6 +108,12 @@ type WorkflowRunStatus struct {
 	// +kubebuilder:validation:MaxProperties=64
 	Jobs map[string]JobStatus `json:"jobs,omitempty"`
 
+	// SnapshotName is the name of the immutable ControllerRevision index that
+	// captures the WorkflowRun's resolved execution definitions.
+	// +optional
+	// +kubebuilder:validation:MaxLength=253
+	SnapshotName string `json:"snapshotName,omitempty"`
+
 	// Message is a human-readable status or error message.
 	// +optional
 	// +kubebuilder:validation:MaxLength=4096
@@ -71,6 +125,54 @@ type WorkflowRunStatus struct {
 	// +listType=map
 	// +listMapKey=type
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// +kubebuilder:object:generate=true
+// JobStatus tracks the execution status of a WorkflowRun job.
+type JobStatus struct {
+	// Phase is the current phase of the job.
+	Phase JobPhase `json:"phase"`
+
+	// Pre is the resolved list of predecessor jobs that must complete before
+	// this job can start.
+	// +optional
+	// +kubebuilder:validation:MaxItems=64
+	// +kubebuilder:validation:items:MaxLength=63
+	Pre []string `json:"pre,omitempty"`
+
+	// WorkflowRunName is the child WorkflowRun created for a job-level reusable
+	// Workflow call. It is empty for inline jobs.
+	// +optional
+	// +kubebuilder:validation:MaxLength=253
+	WorkflowRunName string `json:"workflowRunName,omitempty"`
+
+	// Steps tracks each step in the original job step order.
+	// +optional
+	// +kubebuilder:validation:MaxItems=128
+	Steps []StepStatus `json:"steps,omitempty"`
+}
+
+// +kubebuilder:object:generate=true
+// StepStatus tracks the execution status of a WorkflowRun step.
+type StepStatus struct {
+	// Name is the step name.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern=`^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$`
+	Name string `json:"name"`
+
+	// Phase is the current phase of the step.
+	Phase StepPhase `json:"phase"`
+
+	// RunName is the name of the Run CRD created for this step.
+	// +optional
+	RunName string `json:"runName,omitempty"`
+
+	// Outputs is key-value pairs exposed by this step.
+	// +optional
+	// +kubebuilder:validation:MaxProperties=64
+	Outputs map[string]string `json:"outputs,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/charts/kruntimes/crds/kruntimes.io_workflowruns.yaml
+++ b/charts/kruntimes/crds/kruntimes.io_workflowruns.yaml
@@ -187,6 +187,14 @@ spec:
             - message: each dependency must name another job in this WorkflowRun
               rule: '!has(self.jobs) || self.jobs.all(name, !has(self.jobs[name].needs)
                 || self.jobs[name].needs.all(need, need in self.jobs && need != name))'
+            - message: jobs, uses, and with are immutable after WorkflowRun creation
+              rule: has(self.jobs) == has(oldSelf.jobs) && (!has(self.jobs) || self.jobs
+                == oldSelf.jobs) && has(self.uses) == has(oldSelf.uses) && (!has(self.uses)
+                || self.uses == oldSelf.uses) && has(self.with) == has(oldSelf.with)
+                && (!has(self.with) || self.with == oldSelf.with)
+            - message: cancelRequested may not transition from true to false
+              rule: '!has(oldSelf.cancelRequested) || !oldSelf.cancelRequested ||
+                (has(self.cancelRequested) && self.cancelRequested)'
           status:
             description: WorkflowRunStatus defines the observed state of a WorkflowRun.
             properties:
@@ -254,7 +262,8 @@ spec:
                 x-kubernetes-list-type: map
               jobs:
                 additionalProperties:
-                  description: JobStatus tracks the status of a job.
+                  description: JobStatus tracks the execution status of a WorkflowRun
+                    job.
                   properties:
                     phase:
                       description: Phase is the current phase of the job.
@@ -279,7 +288,8 @@ spec:
                       description: Steps tracks each step in the original job step
                         order.
                       items:
-                        description: StepStatus tracks the status of a step.
+                        description: StepStatus tracks the execution status of a WorkflowRun
+                          step.
                         properties:
                           name:
                             description: Name is the step name.
@@ -312,6 +322,12 @@ spec:
                         type: object
                       maxItems: 128
                       type: array
+                    workflowRunName:
+                      description: |-
+                        WorkflowRunName is the child WorkflowRun created for a job-level reusable
+                        Workflow call. It is empty for inline jobs.
+                      maxLength: 253
+                      type: string
                   required:
                   - phase
                   type: object
@@ -332,6 +348,12 @@ spec:
                 - Succeeded
                 - Failed
                 - Cancelled
+                type: string
+              snapshotName:
+                description: |-
+                  SnapshotName is the name of the immutable ControllerRevision index that
+                  captures the WorkflowRun's resolved execution definitions.
+                maxLength: 253
                 type: string
             required:
             - phase

--- a/charts/kruntimes/templates/controller-rbac.yaml
+++ b/charts/kruntimes/templates/controller-rbac.yaml
@@ -114,6 +114,16 @@ rules:
   - apiGroups:
       - apps
     resources:
+      - controllerrevisions
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+  - apiGroups:
+      - apps
+    resources:
       - deployments
     verbs:
       - get

--- a/docs/api.md
+++ b/docs/api.md
@@ -199,14 +199,19 @@ Current spec shape:
 | `spec.jobs` | Inline jobs to execute. Exactly one of `spec.jobs` or `spec.uses` must be set. |
 | `spec.uses` | Namespace-local reusable Workflow name to execute. Exactly one of `spec.jobs` or `spec.uses` must be set. |
 | `spec.with` | String inputs passed to the reusable Workflow named by `spec.uses`. |
-| `spec.cancelRequested` | Requests cancellation. The controller stops creating child Runs, sets `cancelRequested` on every active child Run, and waits for them to settle. |
+| `spec.cancelRequested` | Requests cancellation. It may transition only from `false` to `true`. The controller stops creating child Runs, sets `cancelRequested` on every active child Run, and waits for them to settle. |
+
+After creation, `spec.jobs`, `spec.uses`, and `spec.with` are immutable execution
+inputs. This prevents an accepted WorkflowRun from observing a different
+definition while it is running.
 
 Current status fields:
 
 | Field | Description |
 | --- | --- |
 | `status.phase` | `Pending`, `Running`, `Succeeded`, `Failed`, or `Cancelled`. After all jobs settle, the controller sets `Failed` if any job failed and `Succeeded` otherwise. A cancellation request results in `Cancelled` after active child Runs settle. |
-| `status.jobs` | Lightweight resolved job status keyed by job name. Each job records `pre` and ordered step statuses. |
+| `status.jobs` | Lightweight resolved job status keyed by job name. Each job records `pre`, ordered step statuses, and, for a reusable call, its child `workflowRunName`. |
+| `status.snapshotName` | Immutable ControllerRevision index for the resolved execution tree. The snapshot resolver is tracked in the roadmap. |
 | `status.conditions` | Lifecycle conditions. The skeleton controller records `Accepted=True`. |
 
 Job phases are `Pending`, `Waiting`, `Running`, `Succeeded`, `Failed`, and

--- a/docs/api.zh.md
+++ b/docs/api.zh.md
@@ -192,14 +192,18 @@ dependency cycle 的 inline 和 resolved reusable Workflow job graph。rejection
 | `spec.jobs` | Inline jobs。`spec.jobs` 和 `spec.uses` 必须且只能设置一个。 |
 | `spec.uses` | 要执行的 namespace-local reusable Workflow 名称。`spec.jobs` 和 `spec.uses` 必须且只能设置一个。 |
 | `spec.with` | 传给 `spec.uses` 引用的 reusable Workflow 的 string inputs。 |
-| `spec.cancelRequested` | 请求取消 WorkflowRun。controller 会停止创建 child Runs，为所有 active child Runs 设置 `cancelRequested`，并等待它们 settled。 |
+| `spec.cancelRequested` | 请求取消 WorkflowRun。它只能从 `false` 变为 `true`。controller 会停止创建 child Runs，为所有 active child Runs 设置 `cancelRequested`，并等待它们 settled。 |
+
+创建后，`spec.jobs`、`spec.uses` 与 `spec.with` 都是 immutable execution inputs。这样可防止
+已 accepted 的 WorkflowRun 在运行中观察到不同 definition。
 
 当前 status 字段：
 
 | Field | Description |
 | --- | --- |
 | `status.phase` | `Pending`、`Running`、`Succeeded`、`Failed` 或 `Cancelled`。所有 jobs settled 后，任一 job failed 则 controller 设置为 `Failed`，否则设置为 `Succeeded`。收到 cancellation request 后，active child Runs settled 时设置为 `Cancelled`。 |
-| `status.jobs` | 按 job name 记录轻量 resolved job status。每个 job 记录 `pre` 和有序 step statuses。 |
+| `status.jobs` | 按 job name 记录轻量 resolved job status。每个 job 记录 `pre`、有序 step statuses，以及 reusable call 对应的 child `workflowRunName`。 |
+| `status.snapshotName` | resolved execution tree 的 immutable ControllerRevision index。snapshot resolver 仍在 roadmap 中跟踪。 |
 | `status.conditions` | Lifecycle conditions。skeleton controller 会记录 `Accepted=True`。 |
 
 Job phases 包括 `Pending`、`Waiting`、`Running`、`Succeeded`、`Failed` 和 `Skipped`。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -257,8 +257,8 @@ wiring from accumulating avoidable conflicts.
     including child Run creation before status persistence;
   - [ ] implement job-level reusable Workflow calls through the reviewed
     [execution-boundary design](design/workflow-job-reuse.md):
-    - [ ] review and approve the child WorkflowRun and immutable snapshot model;
-    - [ ] add status references, spec transition validation, reserved metadata,
+    - [x] review and approve the child WorkflowRun and immutable snapshot model;
+    - [x] add status references, spec transition validation, reserved metadata,
       generated CRDs, and controller RBAC prerequisites;
     - [ ] add immutable ControllerRevision snapshot storage and recursive resolution with version
       capture, call limits, input validation, and cycle detection;

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -222,8 +222,8 @@ controller wiring 累积不必要的冲突。
   - [ ] 按照完成 review 的
     [execution-boundary design](design/workflow-job-reuse.md) 实现 job-level reusable
     Workflow calls：
-    - [ ] review 并批准 child WorkflowRun 和 immutable snapshot model；
-    - [ ] 增加 status references、spec transition validation、reserved metadata、generated
+    - [x] review 并批准 child WorkflowRun 和 immutable snapshot model；
+    - [x] 增加 status references、spec transition validation、reserved metadata、generated
       CRDs 和 controller RBAC prerequisites；
     - [ ] 增加 immutable ControllerRevision snapshot storage 和 recursive resolution，包括 version capture、
       call limits、input validation 和 cycle detection；

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -83,6 +83,7 @@ type WorkflowRunReconciler struct {
 // +kubebuilder:rbac:groups=kruntimes.io,resources=workflowruns/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=kruntimes.io,resources=workflows,verbs=get;list;watch
 // +kubebuilder:rbac:groups=kruntimes.io,resources=runs,verbs=get;list;watch;create;patch
+// +kubebuilder:rbac:groups=apps,resources=controllerrevisions,verbs=get;list;watch;create;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 
 func (r *WorkflowRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -709,6 +709,74 @@ func TestCRDValidationAllowsWorkflowRunTerminalAPI(t *testing.T) {
 	}
 }
 
+func TestCRDValidationAllowsWorkflowRunSnapshotAndCallStatus(t *testing.T) {
+	ctx := context.Background()
+	ns := testNamespace(t, "test-workflowrun-snapshot-status-")
+
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: ns.Name},
+		Spec: v1alpha1.WorkflowRunSpec{
+			Jobs: map[string]v1alpha1.JobSpec{
+				"deploy": {Uses: "deploy-workflow"},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, workflowRun); err != nil {
+		t.Fatalf("create workflowrun: %v", err)
+	}
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(workflowRun), workflowRun); err != nil {
+		t.Fatalf("get workflowrun: %v", err)
+	}
+	workflowRun.Status.Phase = v1alpha1.WorkflowPending
+	workflowRun.Status.SnapshotName = "release-snapshot-a1b2c3d4"
+	workflowRun.Status.Jobs = map[string]v1alpha1.JobStatus{
+		"deploy": {Phase: v1alpha1.JobRunning, WorkflowRunName: "release-deploy-a1b2c3d4"},
+	}
+	if err := k8sClient.Status().Update(ctx, workflowRun); err != nil {
+		t.Fatalf("update workflowrun snapshot status: %v", err)
+	}
+}
+
+func TestCRDValidationWorkflowRunExecutionInputsAreImmutable(t *testing.T) {
+	ctx := context.Background()
+	ns := testNamespace(t, "test-workflowrun-immutable-inputs-")
+
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: ns.Name},
+		Spec: v1alpha1.WorkflowRunSpec{
+			Jobs: map[string]v1alpha1.JobSpec{
+				"build": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}}},
+			},
+		},
+	}
+	if err := k8sClient.Create(ctx, workflowRun); err != nil {
+		t.Fatalf("create workflowrun: %v", err)
+	}
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(workflowRun), workflowRun); err != nil {
+		t.Fatalf("get workflowrun: %v", err)
+	}
+	workflowRun.Spec.Jobs["build"] = v1alpha1.JobSpec{RunsOn: "python", Steps: []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}}}
+	if err := k8sClient.Update(ctx, workflowRun); !apierrors.IsInvalid(err) {
+		t.Fatalf("mutating workflowrun jobs error = %v, want Invalid", err)
+	}
+
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(workflowRun), workflowRun); err != nil {
+		t.Fatalf("get workflowrun after rejected update: %v", err)
+	}
+	workflowRun.Spec.CancelRequested = true
+	if err := k8sClient.Update(ctx, workflowRun); err != nil {
+		t.Fatalf("request workflowrun cancellation: %v", err)
+	}
+
+	if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(workflowRun), workflowRun); err != nil {
+		t.Fatalf("get cancelled workflowrun: %v", err)
+	}
+	workflowRun.Spec.CancelRequested = false
+	if err := k8sClient.Update(ctx, workflowRun); !apierrors.IsInvalid(err) {
+		t.Fatalf("clearing workflowrun cancellation error = %v, want Invalid", err)
+	}
+}
+
 func TestCRDValidationAllowsWorkflowRunUses(t *testing.T) {
 	ctx := context.Background()
 	ns := testNamespace(t, "test-workflowrun-uses-validation-")


### PR DESCRIPTION
## Summary
- add immutable WorkflowRun execution inputs and one-way cancellation validation
- add snapshot and child WorkflowRun status references plus reserved metadata constants
- grant the controller ControllerRevision permissions and document the API in English and Chinese

This intentionally establishes the reviewed API boundary only. Recursive snapshot resolution and child WorkflowRun reconciliation remain separate roadmap work.