### PR TITLE
docs(workflow): define execution snapshot record

### DIFF
--- a/docs/design/workflow-job-reuse.md
+++ b/docs/design/workflow-job-reuse.md
@@ -128,6 +128,59 @@ initializing `status.jobs` or creating any child, the controller recursively
 resolves the complete namespace-local Workflow call tree and writes an
 immutable execution snapshot.
 
+### Snapshot Record Format
+
+The snapshot has two JSON record types in `ControllerRevision.data.raw`.
+They are controller-private records, not CRDs, and start with an explicit
+schema version so a future incompatible record format requires a reviewed
+migration rather than silently reinterpreting an accepted execution.
+
+```go
+type WorkflowExecutionSnapshotIndex struct {
+    SchemaVersion string                 `json:"schemaVersion"` // v1alpha1
+    Nodes         []WorkflowSnapshotNode `json:"nodes"`
+}
+
+type WorkflowSnapshotNode struct {
+    CallPath           string            `json:"callPath"`
+    DefinitionRevision string            `json:"definitionRevision"`
+    With               map[string]string `json:"with,omitempty"`
+}
+
+type WorkflowDefinitionSnapshot struct {
+    SchemaVersion string                 `json:"schemaVersion"` // v1alpha1
+    Source        WorkflowSnapshotSource `json:"source"`
+    Inputs        map[string]WorkflowInputSpec
+    Outputs       map[string]WorkflowOutputSpec
+    Jobs          map[string]JobSpec
+}
+
+type WorkflowSnapshotSource struct {
+    Kind            string `json:"kind"` // WorkflowRun or Workflow
+    Name            string `json:"name"`
+    UID             string `json:"uid"`
+    Generation      int64  `json:"generation"`
+    ResourceVersion string `json:"resourceVersion"`
+}
+```
+
+Every index contains a `root` node. An inline root has a `WorkflowRun`
+definition snapshot; a root `spec.uses` node and every nested call use a
+`Workflow` definition snapshot. A job-level call path appends
+`/jobs/<job-name>` to its caller path. Job names cannot contain `/`, so this is
+unambiguous and stable across reconciliation. `With` remains on the call node,
+where it can later be evaluated in the caller context; it is never merged into
+the callee definition.
+
+Definition revisions and the index name are content-addressed from canonical
+JSON plus the root WorkflowRun UID. The controller creates definition revisions
+first, then the index, and only then persists `status.snapshotName`. A restart
+therefore either finds a complete matching index or safely recreates missing
+immutable records. Before accepting the WorkflowRun, it deletes only
+root-owned definition revisions that are not referenced by the complete index.
+The resolver rejects a record that exceeds the Kubernetes object size limit
+before it creates an index or execution child.
+
 The snapshot is stored outside status in WorkflowRun-owned `ControllerRevision`
 objects. Kubernetes API validation makes a successfully created revision's
 `data` immutable:

--- a/docs/design/workflow-job-reuse.md
+++ b/docs/design/workflow-job-reuse.md
@@ -83,6 +83,67 @@ reusable Workflows are called at job level, while their declared outputs are
 consumed through the caller job. The kruntimes implementation remains
 Kubernetes-native and namespace-local.
 
+### Nested Reuse
+
+Reusable Workflows may call other reusable Workflows. For example,
+`deploy-workflow` can use `smoke-test` after it applies the deployment:
+
+```yaml
+apiVersion: kruntimes.io/v1alpha1
+kind: Workflow
+metadata:
+  name: deploy-workflow
+spec:
+  inputs:
+    environment: { type: string, required: true }
+  jobs:
+    apply:
+      runs-on: bash
+      steps:
+        - name: deploy
+          run: deploy
+    verify:
+      needs: [apply]
+      uses: smoke-test
+      with:
+        endpoint: https://staging.example.com
+---
+apiVersion: kruntimes.io/v1alpha1
+kind: Workflow
+metadata:
+  name: smoke-test
+spec:
+  inputs:
+    endpoint: { type: string, required: true }
+  jobs:
+    smoke:
+      runs-on: bash
+      steps:
+        - name: check
+          run: check-service
+```
+
+The accepted `release` execution resolves this tree before it starts work:
+
+```text
+root                         WorkflowRun release
+root/jobs/deploy             Workflow deploy-workflow
+root/jobs/deploy/jobs/verify Workflow smoke-test
+```
+
+The root controller creates and observes only the child WorkflowRun for
+`deploy`. That child executes `apply`, then creates and observes its own child
+WorkflowRun for `verify`. Each WorkflowRun has a local jobs status map; a
+parent call job succeeds only when its direct child WorkflowRun succeeds.
+Consequently, `release.status.jobs.deploy` cannot succeed until the nested
+`smoke-test` WorkflowRun has settled.
+
+Cancellation and failure follow the same direct-parent boundary. Cancelling
+`release` requests cancellation of its `deploy` child; that controller then
+requests cancellation of `verify`. Conversely, a failed `smoke-test` makes
+`verify` fail, then makes the `deploy` call fail in `release`. Controllers do
+not need to traverse arbitrary descendants during normal reconciliation.
+
 ## Parent and Child Status
 
 `JobStatus` gains an optional `workflowRunName`, symmetric with
@@ -128,83 +189,100 @@ initializing `status.jobs` or creating any child, the controller recursively
 resolves the complete namespace-local Workflow call tree and writes an
 immutable execution snapshot.
 
-### Snapshot Record Format
+### Snapshot Storage
 
-The snapshot has two JSON record types in `ControllerRevision.data.raw`.
-They are controller-private records, not CRDs, and start with an explicit
-schema version so a future incompatible record format requires a reviewed
-migration rather than silently reinterpreting an accepted execution.
+Each root WorkflowRun owns exactly one snapshot `ControllerRevision`.
+`ControllerRevision.data` is a small envelope around direct serialized public
+specs, not a second Workflow model:
 
-```go
-type WorkflowExecutionSnapshotIndex struct {
-    SchemaVersion string                 `json:"schemaVersion"` // v1alpha1
-    Nodes         []WorkflowSnapshotNode `json:"nodes"`
-}
+- `root.spec` is the exact accepted `WorkflowRun.spec` for an inline root, or
+  the resolved `Workflow.spec` for a root `spec.uses`;
+- `workflows[call-path]` is the exact `Workflow.spec` resolved for each
+  job-level call.
 
-type WorkflowSnapshotNode struct {
-    CallPath           string            `json:"callPath"`
-    DefinitionRevision string            `json:"definitionRevision"`
-    With               map[string]string `json:"with,omitempty"`
-}
+The root revision name is recorded in `WorkflowRun.status.snapshotName`. A
+nested child receives that name and its call path through reserved metadata,
+then reads its definition from the same snapshot. `with` remains in the stored
+caller `JobSpec`, exactly where the user wrote it; it is not copied into a
+controller-specific record.
 
-type WorkflowDefinitionSnapshot struct {
-    SchemaVersion string                 `json:"schemaVersion"` // v1alpha1
-    Source        WorkflowSnapshotSource `json:"source"`
-    Inputs        map[string]WorkflowInputSpec
-    Outputs       map[string]WorkflowOutputSpec
-    Jobs          map[string]JobSpec
-}
+For the `release` example above, the following is an abbreviated but complete
+shape of the snapshot ControllerRevision. Its name is illustrative: the
+controller derives it deterministically from the root WorkflowRun UID.
 
-type WorkflowSnapshotSource struct {
-    Kind            string `json:"kind"` // WorkflowRun or Workflow
-    Name            string `json:"name"`
-    UID             string `json:"uid"`
-    Generation      int64  `json:"generation"`
-    ResourceVersion string `json:"resourceVersion"`
-}
+```yaml
+# The root WorkflowRun owns the single snapshot revision.
+apiVersion: apps/v1
+kind: ControllerRevision
+metadata:
+  name: release-snapshot-root-8d91c3f4
+  namespace: default
+  labels:
+    kruntimes.io/root-workflowrun-uid: 7e4d41cb-69c8-4fa1-8e31-f9135512c22b
+  annotations:
+    kruntimes.io/workflow-call-path: root
+  ownerReferences:
+    - apiVersion: kruntimes.io/v1alpha1
+      kind: WorkflowRun
+      name: release
+      uid: 7e4d41cb-69c8-4fa1-8e31-f9135512c22b
+      controller: true
+      blockOwnerDeletion: true
+revision: 1
+data:
+  root:
+    kind: WorkflowRun
+    spec: # exact accepted WorkflowRun.spec
+      jobs:
+        build: { runs-on: bash, steps: [{ name: package, run: make package }] }
+        deploy: { needs: [build], uses: deploy-workflow, with: { environment: staging } }
+        notify: { needs: [deploy], runs-on: bash, steps: [{ name: send, run: send-notification }] }
+  workflows:
+    root/jobs/deploy: # exact Workflow.spec resolved for this call
+      inputs:
+        environment: { type: string, required: true }
+      jobs:
+        apply: { runs-on: bash, steps: [{ name: deploy, run: deploy }] }
+        verify: { needs: [apply], uses: smoke-test, with: { endpoint: https://staging.example.com } }
+    root/jobs/deploy/jobs/verify: # exact Workflow.spec resolved for the nested call
+      inputs:
+        endpoint: { type: string, required: true }
+      jobs:
+        smoke: { runs-on: bash, steps: [{ name: check, run: check-service }] }
 ```
 
-Every index contains a `root` node. An inline root has a `WorkflowRun`
-definition snapshot; a root `spec.uses` node and every nested call use a
-`Workflow` definition snapshot. A job-level call path appends
-`/jobs/<job-name>` to its caller path. Job names cannot contain `/`, so this is
-unambiguous and stable across reconciliation. `With` remains on the call node,
-where it can later be evaluated in the caller context; it is never merged into
-the callee definition.
+The root snapshot stores the direct `WorkflowRun.spec`, the resolved
+`Workflow.spec` for `root/jobs/deploy`, and the nested `Workflow.spec` for
+`root/jobs/deploy/jobs/verify`. When `deploy` becomes runnable, the controller
+evaluates its stored `with.environment` in the caller context and creates a
+child WorkflowRun with the same snapshot name and the `root/jobs/deploy` call
+path. That child later resolves `verify` from the same snapshot. Neither
+controller reads the current `deploy-workflow` or `smoke-test` object again.
 
-Definition revisions and the index name are content-addressed from canonical
-JSON plus the root WorkflowRun UID. The controller creates definition revisions
-first, then the index, and only then persists `status.snapshotName`. A restart
-therefore either finds a complete matching index or safely recreates missing
-immutable records. Before accepting the WorkflowRun, it deletes only
-root-owned definition revisions that are not referenced by the complete index.
-The resolver rejects a record that exceeds the Kubernetes object size limit
-before it creates an index or execution child.
+A job-level call path appends `/jobs/<job-name>` to its caller path. Job names
+cannot contain `/`, so this is unambiguous and stable across reconciliation.
+The path is a YAML/JSON map key in `ControllerRevision.data`, where `/` is
+valid; it is not a Kubernetes label, annotation, or object name. JSON Pointer
+would escape `/` as `~1`, but snapshot data is immutable and is never patched
+by path. The resolver rejects a stored spec that exceeds Kubernetes object size
+limits before it creates an execution child.
 
-The snapshot is stored outside status in WorkflowRun-owned `ControllerRevision`
-objects. Kubernetes API validation makes a successfully created revision's
-`data` immutable:
+The snapshot is stored outside status in a WorkflowRun-owned
+`ControllerRevision`. Kubernetes API validation makes a successfully created revision's
+`data` immutable. Revision metadata records the root WorkflowRun UID for
+lookup and garbage collection; child WorkflowRun metadata records its call path.
+Revision data contains no runtime results or secret material.
 
-- a small index ControllerRevision maps stable call paths to definition
-  revisions;
-- definition ControllerRevisions contain normalized Workflow inputs, outputs,
-  and jobs in their JSON `data` fields;
-- every entry records source name, UID, generation, and resource version;
-- call nodes retain unevaluated `with` expressions for later evaluation in the
-  caller context;
-- revision data contains no runtime results or secret material;
-- owner references provide garbage collection with the root WorkflowRun.
+Snapshot names are deterministic from the root UID. Creation is idempotent:
+after a partial failure, reconciliation verifies and reuses a matching
+immutable revision before accepting the WorkflowRun.
 
-Snapshot names are deterministic and content-addressed. Creation is idempotent:
-after a partial failure, reconciliation verifies and reuses matching immutable
-ControllerRevision data before creating missing entries. The controller does
-not rely on mutable revision labels or annotations for correctness.
-Unreferenced partial revisions are deleted before the WorkflowRun is accepted.
-
-`WorkflowRun.status.snapshotName` records the index ControllerRevision name.
+`WorkflowRun.status.snapshotName` records the root ControllerRevision name.
 Status does not copy full job specs, scripts, or environment values. If a
-snapshot cannot fit ControllerRevision object limits, resolution fails before
-execution.
+snapshot exceeds 1 MiB after serialization, resolution fails before execution.
+The explicit limit leaves headroom below etcd's commonly configured 1.5 MiB
+request limit; cluster operators may configure different API server or etcd
+limits.
 
 Once `snapshotName` is persisted, all reconciliation reads the snapshot rather
 than current `Workflow` objects. A child WorkflowRun inherits the root snapshot
@@ -221,7 +299,7 @@ Snapshot resolution happens before any execution child is created:
 1. Select inline root jobs or resolve top-level `spec.uses`.
 2. Validate and bind literal top-level inputs.
 3. Recursively resolve every job-level `uses` in the same namespace.
-4. Record each definition version and call path in the snapshot.
+4. Store the complete resolved tree in one immutable snapshot revision.
 5. Reject missing definitions, invalid inputs, unsupported shapes, and direct
    or indirect Workflow call cycles.
 6. Persist immutable snapshot ControllerRevisions.
@@ -238,7 +316,7 @@ The controller keeps the existing load/calculate/apply/patch structure.
 
 Loaded resources add:
 
-- the root snapshot index and definition ControllerRevisions;
+- the root snapshot ControllerRevision;
 - direct child WorkflowRuns owned by the reconciled WorkflowRun;
 - direct child Runs for inline jobs.
 

--- a/docs/design/workflow-job-reuse.zh.md
+++ b/docs/design/workflow-job-reuse.zh.md
@@ -73,6 +73,64 @@ spec:
 中有价值的部分：reusable Workflow 在 job level 调用，并通过 caller job 使用其 outputs。
 kruntimes 的实现仍保持 Kubernetes-native 和 namespace-local。
 
+### 嵌套 Reuse
+
+reusable Workflow 可以继续调用其他 reusable Workflow。例如，`deploy-workflow` 在完成部署后可以
+调用 `smoke-test`：
+
+```yaml
+apiVersion: kruntimes.io/v1alpha1
+kind: Workflow
+metadata:
+  name: deploy-workflow
+spec:
+  inputs:
+    environment: { type: string, required: true }
+  jobs:
+    apply:
+      runs-on: bash
+      steps:
+        - name: deploy
+          run: deploy
+    verify:
+      needs: [apply]
+      uses: smoke-test
+      with:
+        endpoint: https://staging.example.com
+---
+apiVersion: kruntimes.io/v1alpha1
+kind: Workflow
+metadata:
+  name: smoke-test
+spec:
+  inputs:
+    endpoint: { type: string, required: true }
+  jobs:
+    smoke:
+      runs-on: bash
+      steps:
+        - name: check
+          run: check-service
+```
+
+accepted 的 `release` execution 会在启动工作前解析整个调用树：
+
+```text
+root                         WorkflowRun release
+root/jobs/deploy             Workflow deploy-workflow
+root/jobs/deploy/jobs/verify Workflow smoke-test
+```
+
+root controller 只创建并观察 `deploy` 对应的 child WorkflowRun。该 child 执行 `apply` 后，会创建并
+观察 `verify` 对应的自己的 child WorkflowRun。每个 WorkflowRun 都有本地 jobs status map；parent
+call job 只有在其 direct child WorkflowRun succeeded 后才会 succeeded。因此，嵌套的
+`smoke-test` WorkflowRun settled 前，`release.status.jobs.deploy` 不会 succeeded。
+
+cancellation 和 failure 也遵循相同的 direct-parent boundary。取消 `release` 会请求取消它的
+`deploy` child；该 controller 随后请求取消 `verify`。反过来，`smoke-test` failed 会先让 `verify`
+failed，再让 `release` 中的 `deploy` call failed。controller 在正常 reconciliation 中不需要遍历任意
+depth 的 descendants。
+
 ## Parent 和 Child Status
 
 `JobStatus` 增加可选 `workflowRunName`，与 `StepStatus.runName` 对称：
@@ -112,72 +170,88 @@ accepted execution 不能再次读取 mutable `Workflow` definitions。在初始
 创建任何 child 前，controller 会递归解析完整的 namespace-local Workflow call tree，并写入
 immutable execution snapshot。
 
-### Snapshot Record 格式
+### Snapshot Storage
 
-snapshot 在 `ControllerRevision.data.raw` 中使用两种 JSON record。它们是
-controller-private record，而不是 CRD；record 显式包含 schema version，因此未来不兼容的格式
-变更必须经过 review 的 migration，不能静默地重新解释已经 accepted 的 execution。
+每个 root WorkflowRun 恰好 owner 一个 snapshot `ControllerRevision`。
+`ControllerRevision.data` 是对直接序列化的 public specs 的一个很小的 envelope，不引入第二套
+Workflow model：
 
-```go
-type WorkflowExecutionSnapshotIndex struct {
-    SchemaVersion string                 `json:"schemaVersion"` // v1alpha1
-    Nodes         []WorkflowSnapshotNode `json:"nodes"`
-}
+- inline root 的 `root.spec` 是 accepted 时完整的 `WorkflowRun.spec`；root `spec.uses` 则保存
+  解析到的 `Workflow.spec`；
+- `workflows[call-path]` 是每个 job-level call 解析到的完整 `Workflow.spec`。
 
-type WorkflowSnapshotNode struct {
-    CallPath           string            `json:"callPath"`
-    DefinitionRevision string            `json:"definitionRevision"`
-    With               map[string]string `json:"with,omitempty"`
-}
+root revision name 保存在 `WorkflowRun.status.snapshotName`。nested child 通过保留 metadata 接收
+该名称及自身的 call path，并从同一个 snapshot 读取 definition。`with` 保留在存储的 caller
+`JobSpec` 中，和用户提交的内容完全一致；不会复制到 controller-specific record。
 
-type WorkflowDefinitionSnapshot struct {
-    SchemaVersion string                 `json:"schemaVersion"` // v1alpha1
-    Source        WorkflowSnapshotSource `json:"source"`
-    Inputs        map[string]WorkflowInputSpec
-    Outputs       map[string]WorkflowOutputSpec
-    Jobs          map[string]JobSpec
-}
+以上面的 `release` 为例，下面展示 snapshot ControllerRevision 的完整结构（内容经过必要简化）。
+其名称仅用于示例：controller 会从 root WorkflowRun UID 确定性生成名称。
 
-type WorkflowSnapshotSource struct {
-    Kind            string `json:"kind"` // WorkflowRun 或 Workflow
-    Name            string `json:"name"`
-    UID             string `json:"uid"`
-    Generation      int64  `json:"generation"`
-    ResourceVersion string `json:"resourceVersion"`
-}
+```yaml
+# root WorkflowRun owns 唯一的 snapshot revision。
+apiVersion: apps/v1
+kind: ControllerRevision
+metadata:
+  name: release-snapshot-root-8d91c3f4
+  namespace: default
+  labels:
+    kruntimes.io/root-workflowrun-uid: 7e4d41cb-69c8-4fa1-8e31-f9135512c22b
+  annotations:
+    kruntimes.io/workflow-call-path: root
+  ownerReferences:
+    - apiVersion: kruntimes.io/v1alpha1
+      kind: WorkflowRun
+      name: release
+      uid: 7e4d41cb-69c8-4fa1-8e31-f9135512c22b
+      controller: true
+      blockOwnerDeletion: true
+revision: 1
+data:
+  root:
+    kind: WorkflowRun
+    spec: # accepted 时完整的 WorkflowRun.spec
+      jobs:
+        build: { runs-on: bash, steps: [{ name: package, run: make package }] }
+        deploy: { needs: [build], uses: deploy-workflow, with: { environment: staging } }
+        notify: { needs: [deploy], runs-on: bash, steps: [{ name: send, run: send-notification }] }
+  workflows:
+    root/jobs/deploy: # 此 call 解析到的完整 Workflow.spec
+      inputs:
+        environment: { type: string, required: true }
+      jobs:
+        apply: { runs-on: bash, steps: [{ name: deploy, run: deploy }] }
+        verify: { needs: [apply], uses: smoke-test, with: { endpoint: https://staging.example.com } }
+    root/jobs/deploy/jobs/verify: # nested call 解析到的完整 Workflow.spec
+      inputs:
+        endpoint: { type: string, required: true }
+      jobs:
+        smoke: { runs-on: bash, steps: [{ name: check, run: check-service }] }
 ```
 
-每个 index 都有一个 `root` node。inline root 使用 `WorkflowRun` definition snapshot；root
-`spec.uses` node 和每个 nested call 使用 `Workflow` definition snapshot。job-level call path
-在 caller path 后增加 `/jobs/<job-name>`。job name 不允许包含 `/`，因此它在 reconciliation
-间没有歧义且保持稳定。`With` 保留在 call node，以便之后在 caller context 中求值；它绝不会被
-合并到 callee definition。
+root snapshot 直接保存 `WorkflowRun.spec`、`root/jobs/deploy` 对应的解析后 `Workflow.spec`，以及
+`root/jobs/deploy/jobs/verify` 对应的 nested `Workflow.spec`。当 `deploy` runnable 时，controller
+在 caller context 中求值已存储的 `with.environment`，并使用相同的 snapshot name 与
+`root/jobs/deploy` call path 创建 child WorkflowRun。该 child 后续会从同一份 snapshot 解析
+`verify`。两个 controller 都不会再次读取当前的 `deploy-workflow` 或 `smoke-test` object。
 
-definition revision 和 index name 都从 canonical JSON 与 root WorkflowRun UID 进行
-content-address。controller 先创建 definition revisions，再创建 index，最后才持久化
-`status.snapshotName`。因此 restart 要么找到完整且匹配的 index，要么安全重建缺失的 immutable
-records。在接受 WorkflowRun 前，它只删除未被完整 index 引用的 root-owned definition revisions。
-resolver 会在创建 index 或 execution child 前拒绝超过 Kubernetes object size limit 的 record。
+job-level call path 在 caller path 后增加 `/jobs/<job-name>`。job name 不允许包含 `/`，因此它在
+reconciliation 间没有歧义且保持稳定。该 path 是 `ControllerRevision.data` 中的 YAML/JSON map key，
+`/` 在这里合法；它不是 Kubernetes label、annotation 或 object name。JSON Pointer 会将 `/` 转义为
+`~1`，但 snapshot data 不可变，controller 不会按 path patch 它。resolver 会在创建 execution child 前
+拒绝超过 Kubernetes object size limit 的存储 spec。
 
-snapshot 不放在 status 中，而是存储在由 WorkflowRun owner 的 `ControllerRevision`
-objects 中。Kubernetes API validation 会使已成功创建 revision 的 `data` 不可变：
+snapshot 不放在 status 中，而是存储在由 WorkflowRun owner 的一个 `ControllerRevision` 中。
+Kubernetes API validation 会使已成功创建 revision 的 `data` 不可变。revision metadata 记录 root
+WorkflowRun UID，用于 lookup 和 garbage collection；child WorkflowRun metadata 记录自身的 call
+path。revision data 不包含 runtime results 或 secret material。
 
-- 一个较小的 index ControllerRevision 将稳定 call paths 映射到 definition revisions；
-- definition ControllerRevisions 在 JSON `data` fields 中包含 normalized Workflow inputs、
-  outputs 和 jobs；
-- 每个 entry 记录 source name、UID、generation 和 resource version；
-- call nodes 保留尚未求值的 `with` expressions，后续在 caller context 中求值；
-- revision data 不包含 runtime results 或 secret material；
-- owner references 使其随 root WorkflowRun 被 garbage collection。
+Snapshot name 由 root UID 确定性生成。创建过程保持幂等：发生部分失败后，reconcile 会先校验并
+复用匹配的 immutable revision，再接受 WorkflowRun。
 
-Snapshot names 使用确定性的 content-addressed 方式生成。创建过程保持幂等：发生部分失败后，
-reconcile 会先校验并复用匹配的 immutable ControllerRevision data，再创建缺失 entries。
-Controller 不依赖 mutable revision labels 或 annotations 保证 correctness。WorkflowRun accepted
-前会删除未被引用的 partial revisions。
-
-`WorkflowRun.status.snapshotName` 记录 index ControllerRevision 名称。Status 不复制完整 job
-specs、scripts 或 environment values。如果 snapshot 无法满足 ControllerRevision object limits，
-resolution 会在执行前失败。
+`WorkflowRun.status.snapshotName` 记录 root ControllerRevision 名称。Status 不复制完整 job specs、
+scripts 或 environment values。如果 snapshot 序列化后超过 1 MiB，resolution 会在执行前失败。
+这个显式限制为 etcd 常见的 1.5 MiB request limit 留出余量；cluster operator 可以配置不同的 API
+server 或 etcd limits。
 
 一旦 `snapshotName` 持久化，后续 reconcile 只读取 snapshot，不再读取当前 `Workflow`
 objects。child WorkflowRun 继承 root snapshot 和 call-path annotation，因此 nested calls 使用
@@ -194,7 +268,7 @@ snapshot resolution 在创建任何 execution child 前完成：
 1. 选择 inline root jobs，或者解析 top-level `spec.uses`。
 2. 校验并绑定 literal top-level inputs。
 3. 递归解析同 namespace 中的所有 job-level `uses`。
-4. 将每个 definition version 和 call path 记录到 snapshot。
+4. 将完整的解析树存储到一个 immutable snapshot revision。
 5. 拒绝 missing definitions、invalid inputs、unsupported shapes，以及直接或间接 Workflow
    call cycles。
 6. 持久化 immutable snapshot ControllerRevisions。
@@ -210,7 +284,7 @@ controller 保持现有 load/calculate/apply/patch 结构。
 
 加载的资源增加：
 
-- root snapshot index 和 definition ControllerRevisions；
+- root snapshot ControllerRevision；
 - reconciled WorkflowRun owner 的 direct child WorkflowRuns；
 - inline jobs 对应的 direct child Runs。
 

--- a/docs/design/workflow-job-reuse.zh.md
+++ b/docs/design/workflow-job-reuse.zh.md
@@ -112,6 +112,53 @@ accepted execution 不能再次读取 mutable `Workflow` definitions。在初始
 创建任何 child 前，controller 会递归解析完整的 namespace-local Workflow call tree，并写入
 immutable execution snapshot。
 
+### Snapshot Record 格式
+
+snapshot 在 `ControllerRevision.data.raw` 中使用两种 JSON record。它们是
+controller-private record，而不是 CRD；record 显式包含 schema version，因此未来不兼容的格式
+变更必须经过 review 的 migration，不能静默地重新解释已经 accepted 的 execution。
+
+```go
+type WorkflowExecutionSnapshotIndex struct {
+    SchemaVersion string                 `json:"schemaVersion"` // v1alpha1
+    Nodes         []WorkflowSnapshotNode `json:"nodes"`
+}
+
+type WorkflowSnapshotNode struct {
+    CallPath           string            `json:"callPath"`
+    DefinitionRevision string            `json:"definitionRevision"`
+    With               map[string]string `json:"with,omitempty"`
+}
+
+type WorkflowDefinitionSnapshot struct {
+    SchemaVersion string                 `json:"schemaVersion"` // v1alpha1
+    Source        WorkflowSnapshotSource `json:"source"`
+    Inputs        map[string]WorkflowInputSpec
+    Outputs       map[string]WorkflowOutputSpec
+    Jobs          map[string]JobSpec
+}
+
+type WorkflowSnapshotSource struct {
+    Kind            string `json:"kind"` // WorkflowRun 或 Workflow
+    Name            string `json:"name"`
+    UID             string `json:"uid"`
+    Generation      int64  `json:"generation"`
+    ResourceVersion string `json:"resourceVersion"`
+}
+```
+
+每个 index 都有一个 `root` node。inline root 使用 `WorkflowRun` definition snapshot；root
+`spec.uses` node 和每个 nested call 使用 `Workflow` definition snapshot。job-level call path
+在 caller path 后增加 `/jobs/<job-name>`。job name 不允许包含 `/`，因此它在 reconciliation
+间没有歧义且保持稳定。`With` 保留在 call node，以便之后在 caller context 中求值；它绝不会被
+合并到 callee definition。
+
+definition revision 和 index name 都从 canonical JSON 与 root WorkflowRun UID 进行
+content-address。controller 先创建 definition revisions，再创建 index，最后才持久化
+`status.snapshotName`。因此 restart 要么找到完整且匹配的 index，要么安全重建缺失的 immutable
+records。在接受 WorkflowRun 前，它只删除未被完整 index 引用的 root-owned definition revisions。
+resolver 会在创建 index 或 execution child 前拒绝超过 Kubernetes object size limit 的 record。
+
 snapshot 不放在 status 中，而是存储在由 WorkflowRun owner 的 `ControllerRevision`
 objects 中。Kubernetes API validation 会使已成功创建 revision 的 `data` 不可变：
 


### PR DESCRIPTION
## Summary
- define the controller-private ControllerRevision index and definition record formats
- define stable root and nested call paths, captured source versions, and call-local inputs
- define content-addressed naming and the definition -> index -> status persistence order

This design update precedes the snapshot resolver implementation.