### PR TITLE
feat(controller): snapshot WorkflowRun execution

### DIFF
--- a/api/v1alpha1/workflowrun_types.go
+++ b/api/v1alpha1/workflowrun_types.go
@@ -108,8 +108,8 @@ type WorkflowRunStatus struct {
 	// +kubebuilder:validation:MaxProperties=64
 	Jobs map[string]JobStatus `json:"jobs,omitempty"`
 
-	// SnapshotName is the name of the immutable ControllerRevision index that
-	// captures the WorkflowRun's resolved execution definitions.
+	// SnapshotName is the name of the immutable ControllerRevision that captures
+	// the WorkflowRun's resolved execution definitions.
 	// +optional
 	// +kubebuilder:validation:MaxLength=253
 	SnapshotName string `json:"snapshotName,omitempty"`

--- a/charts/kruntimes/crds/kruntimes.io_workflowruns.yaml
+++ b/charts/kruntimes/crds/kruntimes.io_workflowruns.yaml
@@ -351,8 +351,8 @@ spec:
                 type: string
               snapshotName:
                 description: |-
-                  SnapshotName is the name of the immutable ControllerRevision index that
-                  captures the WorkflowRun's resolved execution definitions.
+                  SnapshotName is the name of the immutable ControllerRevision that captures
+                  the WorkflowRun's resolved execution definitions.
                 maxLength: 253
                 type: string
             required:

--- a/docs/design/workflow-job-reuse.md
+++ b/docs/design/workflow-job-reuse.md
@@ -221,8 +221,6 @@ metadata:
   namespace: default
   labels:
     kruntimes.io/root-workflowrun-uid: 7e4d41cb-69c8-4fa1-8e31-f9135512c22b
-  annotations:
-    kruntimes.io/workflow-call-path: root
   ownerReferences:
     - apiVersion: kruntimes.io/v1alpha1
       kind: WorkflowRun

--- a/docs/design/workflow-job-reuse.md
+++ b/docs/design/workflow-job-reuse.md
@@ -195,8 +195,10 @@ Each root WorkflowRun owns exactly one snapshot `ControllerRevision`.
 `ControllerRevision.data` is a small envelope around direct serialized public
 specs, not a second Workflow model:
 
-- `root.spec` is the exact accepted `WorkflowRun.spec` for an inline root, or
-  the resolved `Workflow.spec` for a root `spec.uses`;
+- `root.spec` is always the exact accepted `WorkflowRun.spec`;
+- `root.workflow`, when the root uses a reusable Workflow, is the exact
+  resolved `Workflow.spec` for that reference; it is omitted for an inline
+  root;
 - `workflows[call-path]` is the exact `Workflow.spec` resolved for each
   job-level call.
 
@@ -231,7 +233,6 @@ metadata:
 revision: 1
 data:
   root:
-    kind: WorkflowRun
     spec: # exact accepted WorkflowRun.spec
       jobs:
         build: { runs-on: bash, steps: [{ name: package, run: make package }] }
@@ -251,9 +252,10 @@ data:
         smoke: { runs-on: bash, steps: [{ name: check, run: check-service }] }
 ```
 
-The root snapshot stores the direct `WorkflowRun.spec`, the resolved
-`Workflow.spec` for `root/jobs/deploy`, and the nested `Workflow.spec` for
-`root/jobs/deploy/jobs/verify`. When `deploy` becomes runnable, the controller
+The root snapshot always stores the direct `WorkflowRun.spec`. For a root
+`spec.uses`, it also stores that resolved `Workflow.spec` at `root.workflow`.
+It stores the resolved `Workflow.spec` for `root/jobs/deploy`, and the nested
+`Workflow.spec` for `root/jobs/deploy/jobs/verify`. When `deploy` becomes runnable, the controller
 evaluates its stored `with.environment` in the caller context and creates a
 child WorkflowRun with the same snapshot name and the `root/jobs/deploy` call
 path. That child later resolves `verify` from the same snapshot. Neither

--- a/docs/design/workflow-job-reuse.zh.md
+++ b/docs/design/workflow-job-reuse.zh.md
@@ -197,8 +197,6 @@ metadata:
   namespace: default
   labels:
     kruntimes.io/root-workflowrun-uid: 7e4d41cb-69c8-4fa1-8e31-f9135512c22b
-  annotations:
-    kruntimes.io/workflow-call-path: root
   ownerReferences:
     - apiVersion: kruntimes.io/v1alpha1
       kind: WorkflowRun

--- a/docs/design/workflow-job-reuse.zh.md
+++ b/docs/design/workflow-job-reuse.zh.md
@@ -176,8 +176,9 @@ immutable execution snapshot。
 `ControllerRevision.data` 是对直接序列化的 public specs 的一个很小的 envelope，不引入第二套
 Workflow model：
 
-- inline root 的 `root.spec` 是 accepted 时完整的 `WorkflowRun.spec`；root `spec.uses` 则保存
-  解析到的 `Workflow.spec`；
+- `root.spec` 始终是 accepted 时完整的 `WorkflowRun.spec`；
+- root 使用 reusable Workflow 时，`root.workflow` 保存该引用解析到的完整 `Workflow.spec`；
+  inline root 则省略它；
 - `workflows[call-path]` 是每个 job-level call 解析到的完整 `Workflow.spec`。
 
 root revision name 保存在 `WorkflowRun.status.snapshotName`。nested child 通过保留 metadata 接收
@@ -208,7 +209,6 @@ metadata:
 revision: 1
 data:
   root:
-    kind: WorkflowRun
     spec: # accepted 时完整的 WorkflowRun.spec
       jobs:
         build: { runs-on: bash, steps: [{ name: package, run: make package }] }
@@ -228,7 +228,8 @@ data:
         smoke: { runs-on: bash, steps: [{ name: check, run: check-service }] }
 ```
 
-root snapshot 直接保存 `WorkflowRun.spec`、`root/jobs/deploy` 对应的解析后 `Workflow.spec`，以及
+root snapshot 始终保存 `WorkflowRun.spec`。root 使用 `spec.uses` 时，还会在 `root.workflow`
+保存解析后的 `Workflow.spec`。它还保存 `root/jobs/deploy` 对应的解析后 `Workflow.spec`，以及
 `root/jobs/deploy/jobs/verify` 对应的 nested `Workflow.spec`。当 `deploy` runnable 时，controller
 在 caller context 中求值已存储的 `with.environment`，并使用相同的 snapshot name 与
 `root/jobs/deploy` call path 创建 child WorkflowRun。该 child 后续会从同一份 snapshot 解析

--- a/internal/controller/workflow_snapshot.go
+++ b/internal/controller/workflow_snapshot.go
@@ -101,7 +101,7 @@ func (r *WorkflowRunReconciler) resolveWorkflowCalls(ctx context.Context, namesp
 		if len(snapshot.Workflows) >= maxWorkflowCallNodes {
 			return &workflowSnapshotResolutionError{err: fmt.Errorf("workflow call count exceeds %d", maxWorkflowCallNodes)}
 		}
-		if containsString(stack, job.Uses) {
+		if strings.Contains("\x00"+strings.Join(stack, "\x00")+"\x00", "\x00"+job.Uses+"\x00") {
 			cycle := append(append([]string(nil), stack...), job.Uses)
 			return &workflowSnapshotResolutionError{err: fmt.Errorf("workflow reuse cycle: %s", strings.Join(cycle, " -> "))}
 		}
@@ -128,10 +128,6 @@ func (r *WorkflowRunReconciler) getWorkflow(ctx context.Context, namespace strin
 		return nil, fmt.Errorf("get workflow %s/%s: %w", namespace, name, err)
 	}
 	return workflow, nil
-}
-
-func containsString(values []string, value string) bool {
-	return strings.Contains("\x00"+strings.Join(values, "\x00")+"\x00", "\x00"+value+"\x00")
 }
 
 func (r *WorkflowRunReconciler) ensureWorkflowSnapshot(ctx context.Context, workflowRun *v1alpha1.WorkflowRun, snapshot *workflowExecutionSnapshot) (string, *workflowExecutionSnapshot, error) {

--- a/internal/controller/workflow_snapshot.go
+++ b/internal/controller/workflow_snapshot.go
@@ -131,12 +131,7 @@ func (r *WorkflowRunReconciler) getWorkflow(ctx context.Context, namespace strin
 }
 
 func containsString(values []string, value string) bool {
-	for _, candidate := range values {
-		if candidate == value {
-			return true
-		}
-	}
-	return false
+	return strings.Contains("\x00"+strings.Join(values, "\x00")+"\x00", "\x00"+value+"\x00")
 }
 
 func (r *WorkflowRunReconciler) ensureWorkflowSnapshot(ctx context.Context, workflowRun *v1alpha1.WorkflowRun, snapshot *workflowExecutionSnapshot) (string, *workflowExecutionSnapshot, error) {
@@ -155,9 +150,6 @@ func (r *WorkflowRunReconciler) ensureWorkflowSnapshot(ctx context.Context, work
 			Namespace: workflowRun.Namespace,
 			Labels: map[string]string{
 				v1alpha1.WorkflowRootRunUIDLabel: string(workflowRun.UID),
-			},
-			Annotations: map[string]string{
-				v1alpha1.WorkflowCallPathAnnotation: "root",
 			},
 		},
 		Revision: 1,
@@ -195,15 +187,14 @@ func loadWorkflowSnapshot(revision *appsv1.ControllerRevision) (*workflowExecuti
 	if err := json.Unmarshal(revision.Data.Raw, snapshot); err != nil {
 		return nil, fmt.Errorf("decode workflow snapshot %s/%s: %w", revision.Namespace, revision.Name, err)
 	}
-	if len(snapshot.Root.Spec.Jobs) > 0 {
-		if snapshot.Root.Workflow != nil {
-			return nil, fmt.Errorf("workflow snapshot %s/%s has both inline jobs and a root workflow", revision.Namespace, revision.Name)
-		}
-	} else if snapshot.Root.Spec.Uses != "" {
-		if snapshot.Root.Workflow == nil {
-			return nil, fmt.Errorf("workflow snapshot %s/%s is missing the resolved root workflow", revision.Namespace, revision.Name)
-		}
-	} else {
+	switch {
+	case len(snapshot.Root.Spec.Jobs) > 0 && snapshot.Root.Workflow != nil:
+		return nil, fmt.Errorf("workflow snapshot %s/%s has both inline jobs and a root workflow", revision.Namespace, revision.Name)
+	case len(snapshot.Root.Spec.Jobs) > 0:
+	case snapshot.Root.Spec.Uses != "" && snapshot.Root.Workflow == nil:
+		return nil, fmt.Errorf("workflow snapshot %s/%s is missing the resolved root workflow", revision.Namespace, revision.Name)
+	case snapshot.Root.Spec.Uses != "":
+	default:
 		return nil, fmt.Errorf("workflow snapshot %s/%s has no root execution definition", revision.Namespace, revision.Name)
 	}
 	return snapshot, nil

--- a/internal/controller/workflow_snapshot.go
+++ b/internal/controller/workflow_snapshot.go
@@ -32,6 +32,11 @@ const (
 type workflowExecutionSnapshot struct {
 	Root      workflowSnapshotRoot             `json:"root"`
 	Workflows map[string]v1alpha1.WorkflowSpec `json:"workflows,omitempty"`
+
+	// rootJobs is decoded from Root.Spec when the snapshot is loaded. It keeps
+	// planning on the immutable execution definition without duplicating it in
+	// the persisted ControllerRevision payload.
+	rootJobs map[string]v1alpha1.JobSpec
 }
 
 type workflowSnapshotRoot struct {
@@ -140,7 +145,7 @@ func containsString(values []string, value string) bool {
 	return false
 }
 
-func (r *WorkflowRunReconciler) ensureWorkflowSnapshot(ctx context.Context, workflowRun *v1alpha1.WorkflowRun, snapshot *workflowExecutionSnapshot) (string, map[string]v1alpha1.JobSpec, error) {
+func (r *WorkflowRunReconciler) ensureWorkflowSnapshot(ctx context.Context, workflowRun *v1alpha1.WorkflowRun, snapshot *workflowExecutionSnapshot) (string, *workflowExecutionSnapshot, error) {
 	raw, err := json.Marshal(snapshot)
 	if err != nil {
 		return "", nil, fmt.Errorf("serialize workflow snapshot: %w", err)
@@ -168,11 +173,11 @@ func (r *WorkflowRunReconciler) ensureWorkflowSnapshot(ctx context.Context, work
 		return "", nil, fmt.Errorf("set workflowrun owner reference on snapshot %s/%s: %w", revision.Namespace, revision.Name, err)
 	}
 	if err := r.Create(ctx, revision); err == nil {
-		_, jobs, loadErr := loadWorkflowSnapshot(revision)
+		loaded, loadErr := loadWorkflowSnapshot(revision)
 		if loadErr != nil {
 			return "", nil, loadErr
 		}
-		return name, jobs, nil
+		return name, loaded, nil
 	} else if !apierrors.IsAlreadyExists(err) {
 		return "", nil, fmt.Errorf("create workflow snapshot %s/%s: %w", revision.Namespace, revision.Name, err)
 	}
@@ -184,36 +189,37 @@ func (r *WorkflowRunReconciler) ensureWorkflowSnapshot(ctx context.Context, work
 	if existing.Labels[v1alpha1.WorkflowRootRunUIDLabel] != string(workflowRun.UID) {
 		return "", nil, fmt.Errorf("workflow snapshot %s/%s belongs to another workflowrun", existing.Namespace, existing.Name)
 	}
-	_, jobs, err := loadWorkflowSnapshot(existing)
+	loaded, err := loadWorkflowSnapshot(existing)
 	if err != nil {
 		return "", nil, err
 	}
-	return name, jobs, nil
+	return name, loaded, nil
 }
 
-func loadWorkflowSnapshot(revision *appsv1.ControllerRevision) (*workflowExecutionSnapshot, map[string]v1alpha1.JobSpec, error) {
+func loadWorkflowSnapshot(revision *appsv1.ControllerRevision) (*workflowExecutionSnapshot, error) {
 	snapshot := &workflowExecutionSnapshot{}
 	if err := json.Unmarshal(revision.Data.Raw, snapshot); err != nil {
-		return nil, nil, fmt.Errorf("decode workflow snapshot %s/%s: %w", revision.Namespace, revision.Name, err)
+		return nil, fmt.Errorf("decode workflow snapshot %s/%s: %w", revision.Namespace, revision.Name, err)
 	}
 	var jobs map[string]v1alpha1.JobSpec
 	switch snapshot.Root.Kind {
 	case workflowSnapshotRootKindWorkflowRun:
 		var spec v1alpha1.WorkflowRunSpec
 		if err := json.Unmarshal(snapshot.Root.Spec, &spec); err != nil {
-			return nil, nil, fmt.Errorf("decode workflowrun root snapshot %s/%s: %w", revision.Namespace, revision.Name, err)
+			return nil, fmt.Errorf("decode workflowrun root snapshot %s/%s: %w", revision.Namespace, revision.Name, err)
 		}
 		jobs = spec.Jobs
 	case workflowSnapshotRootKindWorkflow:
 		var spec v1alpha1.WorkflowSpec
 		if err := json.Unmarshal(snapshot.Root.Spec, &spec); err != nil {
-			return nil, nil, fmt.Errorf("decode workflow root snapshot %s/%s: %w", revision.Namespace, revision.Name, err)
+			return nil, fmt.Errorf("decode workflow root snapshot %s/%s: %w", revision.Namespace, revision.Name, err)
 		}
 		jobs = spec.Jobs
 	default:
-		return nil, nil, fmt.Errorf("workflow snapshot %s/%s has unsupported root kind %q", revision.Namespace, revision.Name, snapshot.Root.Kind)
+		return nil, fmt.Errorf("workflow snapshot %s/%s has unsupported root kind %q", revision.Namespace, revision.Name, snapshot.Root.Kind)
 	}
-	return snapshot, jobs, nil
+	snapshot.rootJobs = jobs
+	return snapshot, nil
 }
 
 func workflowSnapshotName(workflowRun *v1alpha1.WorkflowRun) string {

--- a/internal/controller/workflow_snapshot.go
+++ b/internal/controller/workflow_snapshot.go
@@ -20,28 +20,31 @@ import (
 )
 
 const (
-	workflowSnapshotRootKindWorkflowRun = "WorkflowRun"
-	workflowSnapshotRootKindWorkflow    = "Workflow"
-	maxWorkflowSnapshotBytes            = 1 << 20
-	maxWorkflowCallDepth                = 8
-	maxWorkflowCallNodes                = 64
+	maxWorkflowSnapshotBytes = 1 << 20
+	maxWorkflowCallDepth     = 8
+	maxWorkflowCallNodes     = 64
 )
 
-// workflowExecutionSnapshot is controller-private storage. Its payloads are
-// direct WorkflowRunSpec and WorkflowSpec values rather than copied API types.
+// workflowExecutionSnapshot is controller-private storage. It retains the
+// accepted WorkflowRun spec and every resolved reusable Workflow spec.
 type workflowExecutionSnapshot struct {
 	Root      workflowSnapshotRoot             `json:"root"`
 	Workflows map[string]v1alpha1.WorkflowSpec `json:"workflows,omitempty"`
-
-	// rootJobs is decoded from Root.Spec when the snapshot is loaded. It keeps
-	// planning on the immutable execution definition without duplicating it in
-	// the persisted ControllerRevision payload.
-	rootJobs map[string]v1alpha1.JobSpec
 }
 
 type workflowSnapshotRoot struct {
-	Kind string          `json:"kind"`
-	Spec json.RawMessage `json:"spec"`
+	// Spec is the exact accepted WorkflowRun spec for this root execution.
+	Spec v1alpha1.WorkflowRunSpec `json:"spec"`
+	// Workflow is the resolved reusable definition when Spec.Uses is set.
+	// It is omitted for inline WorkflowRuns.
+	Workflow *v1alpha1.WorkflowSpec `json:"workflow,omitempty"`
+}
+
+func (s *workflowExecutionSnapshot) rootJobs() map[string]v1alpha1.JobSpec {
+	if s.Root.Workflow != nil {
+		return s.Root.Workflow.Jobs
+	}
+	return s.Root.Spec.Jobs
 }
 
 type workflowSnapshotResolutionError struct {
@@ -51,42 +54,33 @@ type workflowSnapshotResolutionError struct {
 func (e *workflowSnapshotResolutionError) Error() string { return e.err.Error() }
 func (e *workflowSnapshotResolutionError) Unwrap() error { return e.err }
 
-func (r *WorkflowRunReconciler) resolveWorkflowRunSnapshot(ctx context.Context, workflowRun *v1alpha1.WorkflowRun) (*workflowExecutionSnapshot, map[string]v1alpha1.JobSpec, error) {
-	snapshot := &workflowExecutionSnapshot{Workflows: map[string]v1alpha1.WorkflowSpec{}}
-	var jobs map[string]v1alpha1.JobSpec
+func (r *WorkflowRunReconciler) resolveWorkflowRunSnapshot(ctx context.Context, workflowRun *v1alpha1.WorkflowRun) (*workflowExecutionSnapshot, error) {
+	snapshot := &workflowExecutionSnapshot{
+		Root:      workflowSnapshotRoot{Spec: *workflowRun.Spec.DeepCopy()},
+		Workflows: map[string]v1alpha1.WorkflowSpec{},
+	}
 	var stack []string
 
 	if len(workflowRun.Spec.Jobs) > 0 {
-		raw, err := json.Marshal(workflowRun.Spec)
-		if err != nil {
-			return nil, nil, fmt.Errorf("serialize workflowrun spec: %w", err)
-		}
-		snapshot.Root = workflowSnapshotRoot{Kind: workflowSnapshotRootKindWorkflowRun, Spec: raw}
-		jobs = workflowRun.Spec.Jobs
 	} else {
 		workflow, err := r.getWorkflow(ctx, workflowRun.Namespace, workflowRun.Spec.Uses)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		if _, err := bindWorkflowInputs(workflow.Spec.Inputs, workflowRun.Spec.With); err != nil {
-			return nil, nil, &workflowInputBindingError{err: fmt.Errorf("bind workflow inputs for %s/%s: %w", workflowRun.Namespace, workflowRun.Spec.Uses, err)}
+			return nil, &workflowInputBindingError{err: fmt.Errorf("bind workflow inputs for %s/%s: %w", workflowRun.Namespace, workflowRun.Spec.Uses, err)}
 		}
-		raw, err := json.Marshal(workflow.Spec)
-		if err != nil {
-			return nil, nil, fmt.Errorf("serialize workflow spec %s/%s: %w", workflowRun.Namespace, workflow.Name, err)
-		}
-		snapshot.Root = workflowSnapshotRoot{Kind: workflowSnapshotRootKindWorkflow, Spec: raw}
-		jobs = workflow.Spec.Jobs
+		snapshot.Root.Workflow = workflow.Spec.DeepCopy()
 		stack = []string{workflow.Name}
 	}
 
-	if err := r.resolveWorkflowCalls(ctx, workflowRun.Namespace, snapshot, jobs, "root", stack, 0); err != nil {
-		return nil, nil, err
+	if err := r.resolveWorkflowCalls(ctx, workflowRun.Namespace, snapshot, snapshot.rootJobs(), "root", stack, 0); err != nil {
+		return nil, err
 	}
 	if _, err := json.Marshal(snapshot); err != nil {
-		return nil, nil, fmt.Errorf("serialize workflow snapshot: %w", err)
+		return nil, fmt.Errorf("serialize workflow snapshot: %w", err)
 	}
-	return snapshot, jobs, nil
+	return snapshot, nil
 }
 
 func (r *WorkflowRunReconciler) resolveWorkflowCalls(ctx context.Context, namespace string, snapshot *workflowExecutionSnapshot, jobs map[string]v1alpha1.JobSpec, parentPath string, stack []string, depth int) error {
@@ -201,24 +195,17 @@ func loadWorkflowSnapshot(revision *appsv1.ControllerRevision) (*workflowExecuti
 	if err := json.Unmarshal(revision.Data.Raw, snapshot); err != nil {
 		return nil, fmt.Errorf("decode workflow snapshot %s/%s: %w", revision.Namespace, revision.Name, err)
 	}
-	var jobs map[string]v1alpha1.JobSpec
-	switch snapshot.Root.Kind {
-	case workflowSnapshotRootKindWorkflowRun:
-		var spec v1alpha1.WorkflowRunSpec
-		if err := json.Unmarshal(snapshot.Root.Spec, &spec); err != nil {
-			return nil, fmt.Errorf("decode workflowrun root snapshot %s/%s: %w", revision.Namespace, revision.Name, err)
+	if len(snapshot.Root.Spec.Jobs) > 0 {
+		if snapshot.Root.Workflow != nil {
+			return nil, fmt.Errorf("workflow snapshot %s/%s has both inline jobs and a root workflow", revision.Namespace, revision.Name)
 		}
-		jobs = spec.Jobs
-	case workflowSnapshotRootKindWorkflow:
-		var spec v1alpha1.WorkflowSpec
-		if err := json.Unmarshal(snapshot.Root.Spec, &spec); err != nil {
-			return nil, fmt.Errorf("decode workflow root snapshot %s/%s: %w", revision.Namespace, revision.Name, err)
+	} else if snapshot.Root.Spec.Uses != "" {
+		if snapshot.Root.Workflow == nil {
+			return nil, fmt.Errorf("workflow snapshot %s/%s is missing the resolved root workflow", revision.Namespace, revision.Name)
 		}
-		jobs = spec.Jobs
-	default:
-		return nil, fmt.Errorf("workflow snapshot %s/%s has unsupported root kind %q", revision.Namespace, revision.Name, snapshot.Root.Kind)
+	} else {
+		return nil, fmt.Errorf("workflow snapshot %s/%s has no root execution definition", revision.Namespace, revision.Name)
 	}
-	snapshot.rootJobs = jobs
 	return snapshot, nil
 }
 

--- a/internal/controller/workflow_snapshot.go
+++ b/internal/controller/workflow_snapshot.go
@@ -1,0 +1,233 @@
+package controller
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+const (
+	workflowSnapshotRootKindWorkflowRun = "WorkflowRun"
+	workflowSnapshotRootKindWorkflow    = "Workflow"
+	maxWorkflowSnapshotBytes            = 1 << 20
+	maxWorkflowCallDepth                = 8
+	maxWorkflowCallNodes                = 64
+)
+
+// workflowExecutionSnapshot is controller-private storage. Its payloads are
+// direct WorkflowRunSpec and WorkflowSpec values rather than copied API types.
+type workflowExecutionSnapshot struct {
+	Root      workflowSnapshotRoot             `json:"root"`
+	Workflows map[string]v1alpha1.WorkflowSpec `json:"workflows,omitempty"`
+}
+
+type workflowSnapshotRoot struct {
+	Kind string          `json:"kind"`
+	Spec json.RawMessage `json:"spec"`
+}
+
+type workflowSnapshotResolutionError struct {
+	err error
+}
+
+func (e *workflowSnapshotResolutionError) Error() string { return e.err.Error() }
+func (e *workflowSnapshotResolutionError) Unwrap() error { return e.err }
+
+func (r *WorkflowRunReconciler) resolveWorkflowRunSnapshot(ctx context.Context, workflowRun *v1alpha1.WorkflowRun) (*workflowExecutionSnapshot, map[string]v1alpha1.JobSpec, error) {
+	snapshot := &workflowExecutionSnapshot{Workflows: map[string]v1alpha1.WorkflowSpec{}}
+	var jobs map[string]v1alpha1.JobSpec
+	var stack []string
+
+	if len(workflowRun.Spec.Jobs) > 0 {
+		raw, err := json.Marshal(workflowRun.Spec)
+		if err != nil {
+			return nil, nil, fmt.Errorf("serialize workflowrun spec: %w", err)
+		}
+		snapshot.Root = workflowSnapshotRoot{Kind: workflowSnapshotRootKindWorkflowRun, Spec: raw}
+		jobs = workflowRun.Spec.Jobs
+	} else {
+		workflow, err := r.getWorkflow(ctx, workflowRun.Namespace, workflowRun.Spec.Uses)
+		if err != nil {
+			return nil, nil, err
+		}
+		if _, err := bindWorkflowInputs(workflow.Spec.Inputs, workflowRun.Spec.With); err != nil {
+			return nil, nil, &workflowInputBindingError{err: fmt.Errorf("bind workflow inputs for %s/%s: %w", workflowRun.Namespace, workflowRun.Spec.Uses, err)}
+		}
+		raw, err := json.Marshal(workflow.Spec)
+		if err != nil {
+			return nil, nil, fmt.Errorf("serialize workflow spec %s/%s: %w", workflowRun.Namespace, workflow.Name, err)
+		}
+		snapshot.Root = workflowSnapshotRoot{Kind: workflowSnapshotRootKindWorkflow, Spec: raw}
+		jobs = workflow.Spec.Jobs
+		stack = []string{workflow.Name}
+	}
+
+	if err := r.resolveWorkflowCalls(ctx, workflowRun.Namespace, snapshot, jobs, "root", stack, 0); err != nil {
+		return nil, nil, err
+	}
+	if _, err := json.Marshal(snapshot); err != nil {
+		return nil, nil, fmt.Errorf("serialize workflow snapshot: %w", err)
+	}
+	return snapshot, jobs, nil
+}
+
+func (r *WorkflowRunReconciler) resolveWorkflowCalls(ctx context.Context, namespace string, snapshot *workflowExecutionSnapshot, jobs map[string]v1alpha1.JobSpec, parentPath string, stack []string, depth int) error {
+	jobNames := make([]string, 0, len(jobs))
+	for jobName := range jobs {
+		jobNames = append(jobNames, jobName)
+	}
+	sort.Strings(jobNames)
+
+	for _, jobName := range jobNames {
+		job := jobs[jobName]
+		if job.Uses == "" {
+			continue
+		}
+		if depth >= maxWorkflowCallDepth {
+			return &workflowSnapshotResolutionError{err: fmt.Errorf("workflow call depth exceeds %d at %s/jobs/%s", maxWorkflowCallDepth, parentPath, jobName)}
+		}
+		if len(snapshot.Workflows) >= maxWorkflowCallNodes {
+			return &workflowSnapshotResolutionError{err: fmt.Errorf("workflow call count exceeds %d", maxWorkflowCallNodes)}
+		}
+		if containsString(stack, job.Uses) {
+			cycle := append(append([]string(nil), stack...), job.Uses)
+			return &workflowSnapshotResolutionError{err: fmt.Errorf("workflow reuse cycle: %s", strings.Join(cycle, " -> "))}
+		}
+
+		workflow, err := r.getWorkflow(ctx, namespace, job.Uses)
+		if err != nil {
+			return err
+		}
+		if _, err := bindWorkflowInputs(workflow.Spec.Inputs, job.With); err != nil {
+			return &workflowInputBindingError{err: fmt.Errorf("bind workflow inputs for %s/%s: %w", namespace, workflow.Name, err)}
+		}
+		callPath := parentPath + "/jobs/" + jobName
+		snapshot.Workflows[callPath] = *workflow.Spec.DeepCopy()
+		if err := r.resolveWorkflowCalls(ctx, namespace, snapshot, workflow.Spec.Jobs, callPath, append(append([]string(nil), stack...), workflow.Name), depth+1); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *WorkflowRunReconciler) getWorkflow(ctx context.Context, namespace string, name string) (*v1alpha1.Workflow, error) {
+	workflow := &v1alpha1.Workflow{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, workflow); err != nil {
+		return nil, fmt.Errorf("get workflow %s/%s: %w", namespace, name, err)
+	}
+	return workflow, nil
+}
+
+func containsString(values []string, value string) bool {
+	for _, candidate := range values {
+		if candidate == value {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *WorkflowRunReconciler) ensureWorkflowSnapshot(ctx context.Context, workflowRun *v1alpha1.WorkflowRun, snapshot *workflowExecutionSnapshot) (string, map[string]v1alpha1.JobSpec, error) {
+	raw, err := json.Marshal(snapshot)
+	if err != nil {
+		return "", nil, fmt.Errorf("serialize workflow snapshot: %w", err)
+	}
+	if len(raw) > maxWorkflowSnapshotBytes {
+		return "", nil, &workflowSnapshotResolutionError{err: fmt.Errorf("workflow snapshot is %d bytes, exceeds %d byte limit", len(raw), maxWorkflowSnapshotBytes)}
+	}
+
+	name := workflowSnapshotName(workflowRun)
+	revision := &appsv1.ControllerRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: workflowRun.Namespace,
+			Labels: map[string]string{
+				v1alpha1.WorkflowRootRunUIDLabel: string(workflowRun.UID),
+			},
+			Annotations: map[string]string{
+				v1alpha1.WorkflowCallPathAnnotation: "root",
+			},
+		},
+		Revision: 1,
+		Data:     runtime.RawExtension{Raw: raw},
+	}
+	if err := controllerutil.SetControllerReference(workflowRun, revision, r.Scheme); err != nil {
+		return "", nil, fmt.Errorf("set workflowrun owner reference on snapshot %s/%s: %w", revision.Namespace, revision.Name, err)
+	}
+	if err := r.Create(ctx, revision); err == nil {
+		_, jobs, loadErr := loadWorkflowSnapshot(revision)
+		if loadErr != nil {
+			return "", nil, loadErr
+		}
+		return name, jobs, nil
+	} else if !apierrors.IsAlreadyExists(err) {
+		return "", nil, fmt.Errorf("create workflow snapshot %s/%s: %w", revision.Namespace, revision.Name, err)
+	}
+
+	existing := &appsv1.ControllerRevision{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(revision), existing); err != nil {
+		return "", nil, fmt.Errorf("get workflow snapshot %s/%s after create conflict: %w", revision.Namespace, revision.Name, err)
+	}
+	if existing.Labels[v1alpha1.WorkflowRootRunUIDLabel] != string(workflowRun.UID) {
+		return "", nil, fmt.Errorf("workflow snapshot %s/%s belongs to another workflowrun", existing.Namespace, existing.Name)
+	}
+	_, jobs, err := loadWorkflowSnapshot(existing)
+	if err != nil {
+		return "", nil, err
+	}
+	return name, jobs, nil
+}
+
+func loadWorkflowSnapshot(revision *appsv1.ControllerRevision) (*workflowExecutionSnapshot, map[string]v1alpha1.JobSpec, error) {
+	snapshot := &workflowExecutionSnapshot{}
+	if err := json.Unmarshal(revision.Data.Raw, snapshot); err != nil {
+		return nil, nil, fmt.Errorf("decode workflow snapshot %s/%s: %w", revision.Namespace, revision.Name, err)
+	}
+	var jobs map[string]v1alpha1.JobSpec
+	switch snapshot.Root.Kind {
+	case workflowSnapshotRootKindWorkflowRun:
+		var spec v1alpha1.WorkflowRunSpec
+		if err := json.Unmarshal(snapshot.Root.Spec, &spec); err != nil {
+			return nil, nil, fmt.Errorf("decode workflowrun root snapshot %s/%s: %w", revision.Namespace, revision.Name, err)
+		}
+		jobs = spec.Jobs
+	case workflowSnapshotRootKindWorkflow:
+		var spec v1alpha1.WorkflowSpec
+		if err := json.Unmarshal(snapshot.Root.Spec, &spec); err != nil {
+			return nil, nil, fmt.Errorf("decode workflow root snapshot %s/%s: %w", revision.Namespace, revision.Name, err)
+		}
+		jobs = spec.Jobs
+	default:
+		return nil, nil, fmt.Errorf("workflow snapshot %s/%s has unsupported root kind %q", revision.Namespace, revision.Name, snapshot.Root.Kind)
+	}
+	return snapshot, jobs, nil
+}
+
+func workflowSnapshotName(workflowRun *v1alpha1.WorkflowRun) string {
+	sum := sha256.Sum256([]byte(workflowRun.UID))
+	suffix := hex.EncodeToString(sum[:])[:10]
+	const separator = "-snapshot-"
+	const maxNameLength = 253
+	maxPrefixLength := maxNameLength - len(separator) - len(suffix)
+	prefix := workflowRun.Name
+	if len(prefix) > maxPrefixLength {
+		prefix = strings.TrimRight(prefix[:maxPrefixLength], "-.")
+	}
+	if prefix == "" {
+		return "snapshot-" + suffix
+	}
+	return prefix + separator + suffix
+}

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -76,7 +76,7 @@ type workflowRunStepTarget struct {
 
 func workflowRunJobs(resources *workflowRunResources) map[string]v1alpha1.JobSpec {
 	if resources.snapshot != nil {
-		return resources.snapshot.rootJobs
+		return resources.snapshot.rootJobs()
 	}
 	return resources.workflowRun.Spec.Jobs
 }
@@ -213,14 +213,14 @@ func workflowRunStateFor(workflowRun *v1alpha1.WorkflowRun) workflowRunState {
 }
 
 func (r *WorkflowRunReconciler) applyInitializeWorkflowRun(ctx context.Context, workflowRun *v1alpha1.WorkflowRun) error {
-	snapshot, jobs, err := r.resolveWorkflowRunSnapshot(ctx, workflowRun)
+	snapshot, err := r.resolveWorkflowRunSnapshot(ctx, workflowRun)
 	if err != nil {
 		if reason, rejected := workflowRunRejectionReason(err); rejected {
 			return rejectWorkflowRun(workflowRun, reason, err.Error())
 		}
 		return err
 	}
-	if err := validateResolvedWorkflowJobs(jobs); err != nil {
+	if err := validateResolvedWorkflowJobs(snapshot.rootJobs()); err != nil {
 		return rejectWorkflowRun(workflowRun, "WorkflowValidationFailed", err.Error())
 	}
 	snapshotName, persistedSnapshot, err := r.ensureWorkflowSnapshot(ctx, workflowRun, snapshot)
@@ -232,7 +232,7 @@ func (r *WorkflowRunReconciler) applyInitializeWorkflowRun(ctx context.Context, 
 	}
 	workflowRun.Status.Phase = v1alpha1.WorkflowPending
 	workflowRun.Status.Message = ""
-	workflowRun.Status.Jobs = resolvedJobStatuses(persistedSnapshot.rootJobs)
+	workflowRun.Status.Jobs = resolvedJobStatuses(persistedSnapshot.rootJobs())
 	workflowRun.Status.SnapshotName = snapshotName
 	setWorkflowRunAcceptedCondition(workflowRun, metav1.ConditionTrue, "Accepted", "WorkflowRun accepted and initialized")
 	return nil

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -74,10 +74,6 @@ type workflowRunStepTarget struct {
 	stepIndex int
 }
 
-func workflowRunJobs(resources *workflowRunResources) map[string]v1alpha1.JobSpec {
-	return resources.snapshot.rootJobs()
-}
-
 // WorkflowRunReconciler owns WorkflowRun execution-instance status.
 type WorkflowRunReconciler struct {
 	client.Client
@@ -192,7 +188,7 @@ func calculateWorkflowRunPlan(resources *workflowRunResources) workflowRunPlan {
 	if state == workflowRunStateCancelling {
 		return plan
 	}
-	jobs := workflowRunJobs(resources)
+	jobs := resources.snapshot.rootJobs()
 	if len(jobs) == 0 || len(workflowRun.Status.Jobs) == 0 {
 		return plan
 	}
@@ -428,7 +424,7 @@ func resolvedJobStatuses(jobs map[string]v1alpha1.JobSpec) map[string]v1alpha1.J
 func (r *WorkflowRunReconciler) applyStartRunnableSteps(ctx context.Context, resources *workflowRunResources, targets []workflowRunStepTarget) error {
 	workflowRun := resources.workflowRun
 	for _, target := range targets {
-		job := workflowRunJobs(resources)[target.jobName]
+		job := resources.snapshot.rootJobs()[target.jobName]
 		run, err := r.createOrReuseStepRun(ctx, resources, target.jobName, job, target.stepIndex)
 		if err != nil {
 			return err

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -75,10 +75,7 @@ type workflowRunStepTarget struct {
 }
 
 func workflowRunJobs(resources *workflowRunResources) map[string]v1alpha1.JobSpec {
-	if resources.snapshot != nil {
-		return resources.snapshot.rootJobs()
-	}
-	return resources.workflowRun.Spec.Jobs
+	return resources.snapshot.rootJobs()
 }
 
 // WorkflowRunReconciler owns WorkflowRun execution-instance status.
@@ -131,16 +128,27 @@ func (r *WorkflowRunReconciler) loadWorkflowRunResources(ctx context.Context, ke
 	}
 
 	resources := &workflowRunResources{workflowRun: workflowRun}
-	if workflowRun.Status.SnapshotName != "" {
-		revision := &appsv1.ControllerRevision{}
-		if err := r.Get(ctx, client.ObjectKey{Namespace: workflowRun.Namespace, Name: workflowRun.Status.SnapshotName}, revision); err != nil {
-			return nil, fmt.Errorf("get workflow snapshot %s/%s: %w", workflowRun.Namespace, workflowRun.Status.SnapshotName, err)
+	snapshotName := workflowRun.Status.SnapshotName
+	if snapshotName == "" {
+		snapshotName = workflowSnapshotName(workflowRun)
+	}
+	revision := &appsv1.ControllerRevision{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: workflowRun.Namespace, Name: snapshotName}, revision); err == nil {
+		if revision.Labels[v1alpha1.WorkflowRootRunUIDLabel] != string(workflowRun.UID) {
+			return nil, fmt.Errorf("workflow snapshot %s/%s belongs to another workflowrun", revision.Namespace, revision.Name)
 		}
 		snapshot, err := loadWorkflowSnapshot(revision)
 		if err != nil {
 			return nil, err
 		}
 		resources.snapshot = snapshot
+	} else if !apierrors.IsNotFound(err) {
+		return nil, fmt.Errorf("get workflow snapshot %s/%s: %w", workflowRun.Namespace, snapshotName, err)
+	} else if workflowRun.Status.SnapshotName != "" {
+		return nil, fmt.Errorf("get workflow snapshot %s/%s: %w", workflowRun.Namespace, snapshotName, err)
+	}
+	if resources.snapshot == nil && workflowRun.Status.Jobs != nil {
+		return nil, fmt.Errorf("workflowrun %s/%s has initialized jobs without an execution snapshot", workflowRun.Namespace, workflowRun.Name)
 	}
 
 	var runs v1alpha1.RunList
@@ -188,7 +196,7 @@ func calculateWorkflowRunPlan(resources *workflowRunResources) workflowRunPlan {
 	if len(jobs) == 0 || len(workflowRun.Status.Jobs) == 0 {
 		return plan
 	}
-	if targets := runnableStepTargets(workflowRun, jobs); len(targets) > 0 {
+	if targets := runnableStepTargets(workflowRun.Status.Jobs, jobs); len(targets) > 0 {
 		plan.action = workflowRunActionStartRunnableSteps
 		plan.targets = targets
 		return plan
@@ -212,37 +220,45 @@ func workflowRunStateFor(workflowRun *v1alpha1.WorkflowRun) workflowRunState {
 	return workflowRunStatePending
 }
 
-func (r *WorkflowRunReconciler) applyInitializeWorkflowRun(ctx context.Context, workflowRun *v1alpha1.WorkflowRun) error {
-	snapshot, err := r.resolveWorkflowRunSnapshot(ctx, workflowRun)
-	if err != nil {
-		if reason, rejected := workflowRunRejectionReason(err); rejected {
-			return rejectWorkflowRun(workflowRun, reason, err.Error())
+func (r *WorkflowRunReconciler) applyInitializeWorkflowRun(ctx context.Context, resources *workflowRunResources) error {
+	workflowRun := resources.workflowRun
+	snapshot := resources.snapshot
+	snapshotName := workflowRun.Status.SnapshotName
+	if snapshot == nil {
+		var err error
+		snapshot, err = r.resolveWorkflowRunSnapshot(ctx, workflowRun)
+		if err != nil {
+			if reason, rejected := workflowRunRejectionReason(err); rejected {
+				return rejectWorkflowRun(workflowRun, reason, err.Error())
+			}
+			return err
 		}
-		return err
-	}
-	if err := validateResolvedWorkflowJobs(snapshot.rootJobs()); err != nil {
-		return rejectWorkflowRun(workflowRun, "WorkflowValidationFailed", err.Error())
-	}
-	snapshotName, persistedSnapshot, err := r.ensureWorkflowSnapshot(ctx, workflowRun, snapshot)
-	if err != nil {
-		if reason, rejected := workflowRunRejectionReason(err); rejected {
-			return rejectWorkflowRun(workflowRun, reason, err.Error())
+		if err := validateResolvedWorkflowJobs(snapshot.rootJobs()); err != nil {
+			return rejectWorkflowRun(workflowRun, "WorkflowValidationFailed", err.Error())
 		}
-		return err
+		persistedName, persistedSnapshot, err := r.ensureWorkflowSnapshot(ctx, workflowRun, snapshot)
+		if err != nil {
+			if reason, rejected := workflowRunRejectionReason(err); rejected {
+				return rejectWorkflowRun(workflowRun, reason, err.Error())
+			}
+			return err
+		}
+		snapshotName = persistedName
+		snapshot = persistedSnapshot
+		resources.snapshot = snapshot
 	}
 	workflowRun.Status.Phase = v1alpha1.WorkflowPending
 	workflowRun.Status.Message = ""
-	workflowRun.Status.Jobs = resolvedJobStatuses(persistedSnapshot.rootJobs())
+	workflowRun.Status.Jobs = resolvedJobStatuses(snapshot.rootJobs())
 	workflowRun.Status.SnapshotName = snapshotName
 	setWorkflowRunAcceptedCondition(workflowRun, metav1.ConditionTrue, "Accepted", "WorkflowRun accepted and initialized")
 	return nil
 }
 
 func (r *WorkflowRunReconciler) applyWorkflowRunAction(ctx context.Context, resources *workflowRunResources, plan workflowRunPlan) error {
-	workflowRun := resources.workflowRun
 	switch plan.action {
 	case workflowRunActionInitialize:
-		return r.applyInitializeWorkflowRun(ctx, workflowRun)
+		return r.applyInitializeWorkflowRun(ctx, resources)
 	case workflowRunActionStartRunnableSteps:
 		return r.applyStartRunnableSteps(ctx, resources, plan.targets)
 	case workflowRunActionRequestChildRunCancellation:
@@ -456,7 +472,7 @@ func recordStepRun(workflowRun *v1alpha1.WorkflowRun, jobName string, stepIndex 
 	workflowRun.Status.Phase = v1alpha1.WorkflowRunning
 }
 
-func runnableStepTargets(workflowRun *v1alpha1.WorkflowRun, jobs map[string]v1alpha1.JobSpec) []workflowRunStepTarget {
+func runnableStepTargets(statuses map[string]v1alpha1.JobStatus, jobs map[string]v1alpha1.JobSpec) []workflowRunStepTarget {
 	jobNames := make([]string, 0, len(jobs))
 	for jobName := range jobs {
 		jobNames = append(jobNames, jobName)
@@ -466,11 +482,11 @@ func runnableStepTargets(workflowRun *v1alpha1.WorkflowRun, jobs map[string]v1al
 	targets := make([]workflowRunStepTarget, 0, len(jobNames))
 	for _, jobName := range jobNames {
 		job := jobs[jobName]
-		status, ok := workflowRun.Status.Jobs[jobName]
+		status, ok := statuses[jobName]
 		if !ok || len(status.Steps) != len(job.Steps) {
 			continue
 		}
-		if jobReadyToStart(status, workflowRun.Status.Jobs) && status.Steps[0].RunName == "" {
+		if jobReadyToStart(status, statuses) && status.Steps[0].RunName == "" {
 			targets = append(targets, workflowRunStepTarget{jobName: jobName, stepIndex: 0})
 			continue
 		}

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -58,6 +59,7 @@ const (
 type workflowRunResources struct {
 	workflowRun *v1alpha1.WorkflowRun
 	childRuns   map[string]*v1alpha1.Run
+	jobs        map[string]v1alpha1.JobSpec
 }
 
 type workflowRunPlan struct {
@@ -70,6 +72,13 @@ type workflowRunPlan struct {
 type workflowRunStepTarget struct {
 	jobName   string
 	stepIndex int
+}
+
+func workflowRunJobs(resources *workflowRunResources) map[string]v1alpha1.JobSpec {
+	if resources.jobs != nil {
+		return resources.jobs
+	}
+	return resources.workflowRun.Spec.Jobs
 }
 
 // WorkflowRunReconciler owns WorkflowRun execution-instance status.
@@ -121,6 +130,19 @@ func (r *WorkflowRunReconciler) loadWorkflowRunResources(ctx context.Context, ke
 		return nil, err
 	}
 
+	resources := &workflowRunResources{workflowRun: workflowRun}
+	if workflowRun.Status.SnapshotName != "" {
+		snapshot := &appsv1.ControllerRevision{}
+		if err := r.Get(ctx, client.ObjectKey{Namespace: workflowRun.Namespace, Name: workflowRun.Status.SnapshotName}, snapshot); err != nil {
+			return nil, fmt.Errorf("get workflow snapshot %s/%s: %w", workflowRun.Namespace, workflowRun.Status.SnapshotName, err)
+		}
+		_, jobs, err := loadWorkflowSnapshot(snapshot)
+		if err != nil {
+			return nil, err
+		}
+		resources.jobs = jobs
+	}
+
 	var runs v1alpha1.RunList
 	labels := client.MatchingLabels{v1alpha1.WorkflowRunUIDLabel: string(workflowRun.UID)}
 	if err := r.List(ctx, &runs, client.InNamespace(workflowRun.Namespace), labels); err != nil {
@@ -135,7 +157,8 @@ func (r *WorkflowRunReconciler) loadWorkflowRunResources(ctx context.Context, ke
 		}
 	}
 
-	return &workflowRunResources{workflowRun: workflowRun, childRuns: childRuns}, nil
+	resources.childRuns = childRuns
+	return resources, nil
 }
 
 func calculateWorkflowRunPlan(resources *workflowRunResources) workflowRunPlan {
@@ -161,10 +184,11 @@ func calculateWorkflowRunPlan(resources *workflowRunResources) workflowRunPlan {
 	if state == workflowRunStateCancelling {
 		return plan
 	}
-	if len(workflowRun.Spec.Jobs) == 0 || len(workflowRun.Status.Jobs) == 0 {
+	jobs := workflowRunJobs(resources)
+	if len(jobs) == 0 || len(workflowRun.Status.Jobs) == 0 {
 		return plan
 	}
-	if targets := runnableStepTargets(workflowRun); len(targets) > 0 {
+	if targets := runnableStepTargets(workflowRun, jobs); len(targets) > 0 {
 		plan.action = workflowRunActionStartRunnableSteps
 		plan.targets = targets
 		return plan
@@ -189,7 +213,7 @@ func workflowRunStateFor(workflowRun *v1alpha1.WorkflowRun) workflowRunState {
 }
 
 func (r *WorkflowRunReconciler) applyInitializeWorkflowRun(ctx context.Context, workflowRun *v1alpha1.WorkflowRun) error {
-	jobs, err := r.resolveWorkflowRunJobs(ctx, workflowRun)
+	snapshot, jobs, err := r.resolveWorkflowRunSnapshot(ctx, workflowRun)
 	if err != nil {
 		if reason, rejected := workflowRunRejectionReason(err); rejected {
 			return rejectWorkflowRun(workflowRun, reason, err.Error())
@@ -199,9 +223,17 @@ func (r *WorkflowRunReconciler) applyInitializeWorkflowRun(ctx context.Context, 
 	if err := validateResolvedWorkflowJobs(jobs); err != nil {
 		return rejectWorkflowRun(workflowRun, "WorkflowValidationFailed", err.Error())
 	}
+	snapshotName, snapshotJobs, err := r.ensureWorkflowSnapshot(ctx, workflowRun, snapshot)
+	if err != nil {
+		if reason, rejected := workflowRunRejectionReason(err); rejected {
+			return rejectWorkflowRun(workflowRun, reason, err.Error())
+		}
+		return err
+	}
 	workflowRun.Status.Phase = v1alpha1.WorkflowPending
 	workflowRun.Status.Message = ""
-	workflowRun.Status.Jobs = resolvedJobStatuses(jobs)
+	workflowRun.Status.Jobs = resolvedJobStatuses(snapshotJobs)
+	workflowRun.Status.SnapshotName = snapshotName
 	setWorkflowRunAcceptedCondition(workflowRun, metav1.ConditionTrue, "Accepted", "WorkflowRun accepted and initialized")
 	return nil
 }
@@ -224,35 +256,20 @@ func (r *WorkflowRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.WorkflowRun{}).
 		Owns(&v1alpha1.Run{}).
+		Owns(&appsv1.ControllerRevision{}).
 		Complete(r)
-}
-
-func (r *WorkflowRunReconciler) resolveWorkflowRunJobs(ctx context.Context, workflowRun *v1alpha1.WorkflowRun) (map[string]v1alpha1.JobSpec, error) {
-	if len(workflowRun.Spec.Jobs) > 0 {
-		return workflowRun.Spec.Jobs, nil
-	}
-	if workflowRun.Spec.Uses == "" {
-		return nil, nil
-	}
-
-	var workflow v1alpha1.Workflow
-	key := client.ObjectKey{Namespace: workflowRun.Namespace, Name: workflowRun.Spec.Uses}
-	if err := r.Get(ctx, key, &workflow); err != nil {
-		return nil, fmt.Errorf("get workflow %s/%s: %w", workflowRun.Namespace, workflowRun.Spec.Uses, err)
-	}
-	if _, err := bindWorkflowInputs(workflow.Spec.Inputs, workflowRun.Spec.With); err != nil {
-		return nil, &workflowInputBindingError{err: fmt.Errorf("bind workflow inputs for %s/%s: %w", workflowRun.Namespace, workflowRun.Spec.Uses, err)}
-	}
-	return workflow.Spec.Jobs, nil
 }
 
 func workflowRunRejectionReason(err error) (string, bool) {
 	var inputErr *workflowInputBindingError
+	var snapshotErr *workflowSnapshotResolutionError
 	switch {
 	case apierrors.IsNotFound(err):
 		return "WorkflowResolutionFailed", true
 	case errors.As(err, &inputErr):
 		return "WorkflowInputBindingFailed", true
+	case errors.As(err, &snapshotErr):
+		return "WorkflowResolutionFailed", true
 	default:
 		return "", false
 	}
@@ -395,7 +412,7 @@ func resolvedJobStatuses(jobs map[string]v1alpha1.JobSpec) map[string]v1alpha1.J
 func (r *WorkflowRunReconciler) applyStartRunnableSteps(ctx context.Context, resources *workflowRunResources, targets []workflowRunStepTarget) error {
 	workflowRun := resources.workflowRun
 	for _, target := range targets {
-		job := workflowRun.Spec.Jobs[target.jobName]
+		job := workflowRunJobs(resources)[target.jobName]
 		run, err := r.createOrReuseStepRun(ctx, resources, target.jobName, job, target.stepIndex)
 		if err != nil {
 			return err
@@ -439,16 +456,16 @@ func recordStepRun(workflowRun *v1alpha1.WorkflowRun, jobName string, stepIndex 
 	workflowRun.Status.Phase = v1alpha1.WorkflowRunning
 }
 
-func runnableStepTargets(workflowRun *v1alpha1.WorkflowRun) []workflowRunStepTarget {
-	jobNames := make([]string, 0, len(workflowRun.Spec.Jobs))
-	for jobName := range workflowRun.Spec.Jobs {
+func runnableStepTargets(workflowRun *v1alpha1.WorkflowRun, jobs map[string]v1alpha1.JobSpec) []workflowRunStepTarget {
+	jobNames := make([]string, 0, len(jobs))
+	for jobName := range jobs {
 		jobNames = append(jobNames, jobName)
 	}
 	sort.Strings(jobNames)
 
 	targets := make([]workflowRunStepTarget, 0, len(jobNames))
 	for _, jobName := range jobNames {
-		job := workflowRun.Spec.Jobs[jobName]
+		job := jobs[jobName]
 		status, ok := workflowRun.Status.Jobs[jobName]
 		if !ok || len(status.Steps) != len(job.Steps) {
 			continue

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -59,7 +59,7 @@ const (
 type workflowRunResources struct {
 	workflowRun *v1alpha1.WorkflowRun
 	childRuns   map[string]*v1alpha1.Run
-	jobs        map[string]v1alpha1.JobSpec
+	snapshot    *workflowExecutionSnapshot
 }
 
 type workflowRunPlan struct {
@@ -75,8 +75,8 @@ type workflowRunStepTarget struct {
 }
 
 func workflowRunJobs(resources *workflowRunResources) map[string]v1alpha1.JobSpec {
-	if resources.jobs != nil {
-		return resources.jobs
+	if resources.snapshot != nil {
+		return resources.snapshot.rootJobs
 	}
 	return resources.workflowRun.Spec.Jobs
 }
@@ -132,15 +132,15 @@ func (r *WorkflowRunReconciler) loadWorkflowRunResources(ctx context.Context, ke
 
 	resources := &workflowRunResources{workflowRun: workflowRun}
 	if workflowRun.Status.SnapshotName != "" {
-		snapshot := &appsv1.ControllerRevision{}
-		if err := r.Get(ctx, client.ObjectKey{Namespace: workflowRun.Namespace, Name: workflowRun.Status.SnapshotName}, snapshot); err != nil {
+		revision := &appsv1.ControllerRevision{}
+		if err := r.Get(ctx, client.ObjectKey{Namespace: workflowRun.Namespace, Name: workflowRun.Status.SnapshotName}, revision); err != nil {
 			return nil, fmt.Errorf("get workflow snapshot %s/%s: %w", workflowRun.Namespace, workflowRun.Status.SnapshotName, err)
 		}
-		_, jobs, err := loadWorkflowSnapshot(snapshot)
+		snapshot, err := loadWorkflowSnapshot(revision)
 		if err != nil {
 			return nil, err
 		}
-		resources.jobs = jobs
+		resources.snapshot = snapshot
 	}
 
 	var runs v1alpha1.RunList
@@ -223,7 +223,7 @@ func (r *WorkflowRunReconciler) applyInitializeWorkflowRun(ctx context.Context, 
 	if err := validateResolvedWorkflowJobs(jobs); err != nil {
 		return rejectWorkflowRun(workflowRun, "WorkflowValidationFailed", err.Error())
 	}
-	snapshotName, snapshotJobs, err := r.ensureWorkflowSnapshot(ctx, workflowRun, snapshot)
+	snapshotName, persistedSnapshot, err := r.ensureWorkflowSnapshot(ctx, workflowRun, snapshot)
 	if err != nil {
 		if reason, rejected := workflowRunRejectionReason(err); rejected {
 			return rejectWorkflowRun(workflowRun, reason, err.Error())
@@ -232,7 +232,7 @@ func (r *WorkflowRunReconciler) applyInitializeWorkflowRun(ctx context.Context, 
 	}
 	workflowRun.Status.Phase = v1alpha1.WorkflowPending
 	workflowRun.Status.Message = ""
-	workflowRun.Status.Jobs = resolvedJobStatuses(snapshotJobs)
+	workflowRun.Status.Jobs = resolvedJobStatuses(persistedSnapshot.rootJobs)
 	workflowRun.Status.SnapshotName = snapshotName
 	setWorkflowRunAcceptedCondition(workflowRun, metav1.ConditionTrue, "Accepted", "WorkflowRun accepted and initialized")
 	return nil

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -176,14 +177,14 @@ func TestCalculateWorkflowRunPlanSeparatesCurrentStateFromAction(t *testing.T) {
 			Jobs:  resolvedJobStatuses(map[string]v1alpha1.JobSpec{"build": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}}}}),
 		},
 	}
-	plan = calculateWorkflowRunPlan(&workflowRunResources{workflowRun: pending})
+	plan = calculateWorkflowRunPlan(&workflowRunResources{workflowRun: pending, snapshot: snapshotForWorkflowRun(pending)})
 	if plan.state != workflowRunStatePending || plan.action != workflowRunActionStartRunnableSteps || len(plan.targets) != 1 || plan.targets[0] != (workflowRunStepTarget{jobName: "build", stepIndex: 0}) {
 		t.Fatalf("pending plan = %#v, want Pending + StartRunnableSteps(build[0])", plan)
 	}
 
 	cancelled := pending.DeepCopy()
 	cancelled.Status.Phase = v1alpha1.WorkflowCancelled
-	plan = calculateWorkflowRunPlan(&workflowRunResources{workflowRun: cancelled})
+	plan = calculateWorkflowRunPlan(&workflowRunResources{workflowRun: cancelled, snapshot: snapshotForWorkflowRun(cancelled)})
 	if plan.state != workflowRunStateTerminal || plan.action != workflowRunActionNone {
 		t.Fatalf("cancelled plan = %#v, want Terminal + None", plan)
 	}
@@ -194,6 +195,7 @@ func TestCalculateWorkflowRunPlanSeparatesCurrentStateFromAction(t *testing.T) {
 	plan = calculateWorkflowRunPlan(&workflowRunResources{
 		workflowRun: cancelling,
 		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): activeRun},
+		snapshot:    snapshotForWorkflowRun(cancelling),
 	})
 	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildRunCancellation || !slices.Equal(plan.runNames, []string{"build-run"}) {
 		t.Fatalf("cancelling plan = %#v, want Cancelling + RequestChildRunCancellation(build-run)", plan)
@@ -205,9 +207,16 @@ func TestCalculateWorkflowRunPlanSeparatesCurrentStateFromAction(t *testing.T) {
 	plan = calculateWorkflowRunPlan(&workflowRunResources{
 		workflowRun: cancelling,
 		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): activeRun},
+		snapshot:    snapshotForWorkflowRun(cancelling),
 	})
 	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildRunCancellation || !slices.Equal(plan.runNames, []string{"build-run"}) {
 		t.Fatalf("late child plan = %#v, want cancellation repair", plan)
+	}
+}
+
+func snapshotForWorkflowRun(workflowRun *v1alpha1.WorkflowRun) *workflowExecutionSnapshot {
+	return &workflowExecutionSnapshot{
+		Root: workflowSnapshotRoot{Spec: *workflowRun.Spec.DeepCopy()},
 	}
 }
 
@@ -230,6 +239,7 @@ func TestCalculateWorkflowRunPlanProjectsStatusBeforeStartingReadyJobs(t *testin
 	plan := calculateWorkflowRunPlan(&workflowRunResources{
 		workflowRun: workflowRun,
 		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): buildRun},
+		snapshot:    snapshotForWorkflowRun(workflowRun),
 	})
 	want := []workflowRunStepTarget{{jobName: "lint", stepIndex: 0}}
 	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableSteps || !slices.Equal(plan.targets, want) {
@@ -255,7 +265,7 @@ func TestPlanWorkflowRunStartsAllRunnableSteps(t *testing.T) {
 		},
 	}
 
-	plan := calculateWorkflowRunPlan(&workflowRunResources{workflowRun: workflowRun})
+	plan := calculateWorkflowRunPlan(&workflowRunResources{workflowRun: workflowRun, snapshot: snapshotForWorkflowRun(workflowRun)})
 	want := []workflowRunStepTarget{{jobName: "build", stepIndex: 1}, {jobName: "lint", stepIndex: 0}}
 	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableSteps || !slices.Equal(plan.targets, want) {
 		t.Fatalf("plan = %#v, want Running + StartRunnableSteps(%#v)", plan, want)
@@ -277,7 +287,7 @@ func TestCalculateWorkflowRunPlanFinalizesJobsBeforeStartingReadyJobs(t *testing
 		},
 	}
 
-	plan := calculateWorkflowRunPlan(&workflowRunResources{workflowRun: workflowRun})
+	plan := calculateWorkflowRunPlan(&workflowRunResources{workflowRun: workflowRun, snapshot: snapshotForWorkflowRun(workflowRun)})
 	want := []workflowRunStepTarget{{jobName: "lint", stepIndex: 0}}
 	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableSteps || !slices.Equal(plan.targets, want) {
 		t.Fatalf("plan = %#v, want Running + StartRunnableSteps(%#v)", plan, want)
@@ -747,13 +757,18 @@ func TestWorkflowRunReconcilerDoesNotPatchDerivedStatusWhenActionFails(t *testin
 		WithObjects(workflowRun, compileRun).
 		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
 		WithInterceptorFuncs(interceptor.Funcs{
-			Create: func(context.Context, client.WithWatch, client.Object, ...client.CreateOption) error {
+			Create: func(ctx context.Context, underlying client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*appsv1.ControllerRevision); ok {
+					return underlying.Create(ctx, obj, opts...)
+				}
 				return createErr
 			},
 		}).
 		Build()
 	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
-	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(workflowRun)})
+	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(workflowRun)}
+	seedInitializedWorkflowRunSnapshot(t, reconciler, req)
+	_, err := reconciler.Reconcile(context.Background(), req)
 	if !errors.Is(err, createErr) {
 		t.Fatalf("Reconcile error = %v, want %v", err, createErr)
 	}
@@ -811,6 +826,7 @@ func TestWorkflowRunReconcilerRecoversAfterRestartAcrossStatusPatchFailure(t *te
 	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(workflowRun)}
 
 	firstController := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	seedInitializedWorkflowRunSnapshot(t, firstController, req)
 	if _, err := firstController.Reconcile(context.Background(), req); !errors.Is(err, statusErr) {
 		t.Fatalf("first Reconcile error = %v, want %v", err, statusErr)
 	}
@@ -1266,6 +1282,74 @@ func TestWorkflowRunReconcilerExecutesTopLevelUsesFromSnapshot(t *testing.T) {
 	}
 }
 
+func TestWorkflowRunReconcilerRecoversSnapshotBeforeStatusPatch(t *testing.T) {
+	scheme := workflowRunTestScheme(t)
+	workflow := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default"},
+		Spec: v1alpha1.WorkflowSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"compile": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "run", Run: "echo snapshot"}}},
+		}},
+	}
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default", UID: "release-uid"},
+		Spec:       v1alpha1.WorkflowRunSpec{Uses: workflow.Name},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(workflow, workflowRun).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+
+	// Simulate a crash after the immutable revision is created but before the
+	// WorkflowRun status patch records its name.
+	snapshot, err := reconciler.resolveWorkflowRunSnapshot(context.Background(), workflowRun)
+	if err != nil {
+		t.Fatalf("resolve workflow snapshot: %v", err)
+	}
+	if _, _, err := reconciler.ensureWorkflowSnapshot(context.Background(), workflowRun, snapshot); err != nil {
+		t.Fatalf("persist workflow snapshot: %v", err)
+	}
+	workflow.Spec.Jobs["compile"] = v1alpha1.JobSpec{RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "run", Run: "echo mutable"}}}
+	if err := c.Update(context.Background(), workflow); err != nil {
+		t.Fatalf("update reusable workflow: %v", err)
+	}
+
+	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(workflowRun)}
+	reconcileWorkflowRun(t, reconciler, req, 2)
+	var runs v1alpha1.RunList
+	if err := c.List(context.Background(), &runs, client.InNamespace(workflowRun.Namespace)); err != nil {
+		t.Fatalf("list child runs: %v", err)
+	}
+	if len(runs.Items) != 1 || runs.Items[0].Spec.Source == nil || runs.Items[0].Spec.Source.Inline == nil || *runs.Items[0].Spec.Source.Inline != "echo snapshot" {
+		t.Fatalf("child runs = %#v, want execution from recovered immutable snapshot", runs.Items)
+	}
+}
+
+func TestWorkflowRunReconcilerRejectsInitializedRunWithoutSnapshot(t *testing.T) {
+	scheme := workflowRunTestScheme(t)
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", UID: "workflowrun-uid"},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"build": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "run", Run: "echo build"}}},
+		}},
+		Status: v1alpha1.WorkflowRunStatus{
+			Phase: v1alpha1.WorkflowPending,
+			Jobs:  resolvedJobStatuses(map[string]v1alpha1.JobSpec{"build": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "run", Run: "echo build"}}}}),
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(workflowRun).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(workflowRun)})
+	if err == nil || !strings.Contains(err.Error(), "initialized jobs without an execution snapshot") {
+		t.Fatalf("Reconcile error = %v, want missing execution snapshot", err)
+	}
+}
+
 func TestResolveWorkflowRunSnapshotResolvesNestedCalls(t *testing.T) {
 	scheme := workflowRunTestScheme(t)
 	smoke := &v1alpha1.Workflow{
@@ -1493,10 +1577,38 @@ func ptrTo(value string) *string {
 
 func reconcileWorkflowRun(t *testing.T, reconciler *WorkflowRunReconciler, req ctrl.Request, times int) {
 	t.Helper()
+	seedInitializedWorkflowRunSnapshot(t, reconciler, req)
 	for range times {
 		if _, err := reconciler.Reconcile(context.Background(), req); err != nil {
 			t.Fatalf("reconcile workflowrun: %v", err)
 		}
+	}
+}
+
+// Existing plan tests construct an already-initialized WorkflowRun directly.
+// Seed the immutable revision they would have received during initialization so
+// they exercise the same execution model as a real reconciliation.
+func seedInitializedWorkflowRunSnapshot(t *testing.T, reconciler *WorkflowRunReconciler, req ctrl.Request) {
+	t.Helper()
+	workflowRun := &v1alpha1.WorkflowRun{}
+	if err := reconciler.Get(context.Background(), req.NamespacedName, workflowRun); err != nil {
+		t.Fatalf("get workflowrun fixture: %v", err)
+	}
+	if workflowRun.Status.Jobs == nil || workflowRun.Status.SnapshotName != "" {
+		return
+	}
+	revision := &appsv1.ControllerRevision{}
+	if err := reconciler.Get(context.Background(), client.ObjectKey{Namespace: workflowRun.Namespace, Name: workflowSnapshotName(workflowRun)}, revision); err == nil {
+		return
+	} else if !apierrors.IsNotFound(err) {
+		t.Fatalf("get workflow snapshot fixture: %v", err)
+	}
+	snapshot, err := reconciler.resolveWorkflowRunSnapshot(context.Background(), workflowRun)
+	if err != nil {
+		t.Fatalf("resolve workflow snapshot fixture: %v", err)
+	}
+	if _, _, err := reconciler.ensureWorkflowSnapshot(context.Background(), workflowRun, snapshot); err != nil {
+		t.Fatalf("persist workflow snapshot fixture: %v", err)
 	}
 }
 

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -1244,6 +1244,13 @@ func TestWorkflowRunReconcilerExecutesTopLevelUsesFromSnapshot(t *testing.T) {
 
 	// Initialization captures the reusable definition but creates no Run yet.
 	reconcileWorkflowRun(t, reconciler, req, 1)
+	resources, err := reconciler.loadWorkflowRunResources(context.Background(), client.ObjectKeyFromObject(workflowRun))
+	if err != nil {
+		t.Fatalf("load workflowrun resources: %v", err)
+	}
+	if resources.snapshot == nil || resources.snapshot.rootJobs["compile"].Steps[0].Run != "echo snapshot" {
+		t.Fatalf("loaded snapshot = %#v, want immutable root execution definition", resources.snapshot)
+	}
 	workflow.Spec.Jobs["compile"] = v1alpha1.JobSpec{RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "run", Run: "echo mutable"}}}
 	if err := c.Update(context.Background(), workflow); err != nil {
 		t.Fatalf("update reusable workflow: %v", err)

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -19,11 +20,20 @@ import (
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 )
 
-func TestWorkflowRunReconcilerAcceptsWorkflowRun(t *testing.T) {
+func workflowRunTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
 	scheme := runtime.NewScheme()
 	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
+		t.Fatalf("add kruntimes scheme: %v", err)
 	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add apps scheme: %v", err)
+	}
+	return scheme
+}
+
+func TestWorkflowRunReconcilerAcceptsWorkflowRun(t *testing.T) {
+	scheme := workflowRunTestScheme(t)
 
 	workflowRun := &v1alpha1.WorkflowRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", UID: "workflowrun-uid", Generation: 3},
@@ -121,10 +131,7 @@ func TestWorkflowRunReconcilerAcceptsWorkflowRun(t *testing.T) {
 }
 
 func TestWorkflowRunReconcilerStartsAllIndependentReadyJobs(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
+	scheme := workflowRunTestScheme(t)
 
 	workflowRun := &v1alpha1.WorkflowRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "parallel", Namespace: "default", UID: "workflowrun-uid"},
@@ -299,10 +306,7 @@ func TestJobReadyToStartChecksDependencyStatus(t *testing.T) {
 }
 
 func TestWorkflowRunReconcilerSkipsBlockedJobsAndStartsIndependentJobs(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
+	scheme := workflowRunTestScheme(t)
 
 	workflowRun := &v1alpha1.WorkflowRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "failure", Namespace: "default", UID: "workflowrun-uid"},
@@ -351,10 +355,7 @@ func TestWorkflowRunReconcilerSkipsBlockedJobsAndStartsIndependentJobs(t *testin
 }
 
 func TestWorkflowRunReconcilerRejectsUnsupportedJobLevelUsesDuringInitialization(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
+	scheme := workflowRunTestScheme(t)
 
 	workflowRun := &v1alpha1.WorkflowRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default", UID: "workflowrun-uid", Generation: 3},
@@ -366,9 +367,15 @@ func TestWorkflowRunReconcilerRejectsUnsupportedJobLevelUsesDuringInitialization
 			},
 		},
 	}
+	workflow := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "build-and-test", Namespace: workflowRun.Namespace},
+		Spec: v1alpha1.WorkflowSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"build": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}}},
+		}},
+	}
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(workflowRun).
+		WithObjects(workflowRun, workflow).
 		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
 		Build()
 
@@ -414,10 +421,7 @@ func TestWorkflowRunReconcilerRejectsCyclicJobDAG(t *testing.T) {
 		{name: "reusable", reusable: true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			scheme := runtime.NewScheme()
-			if err := v1alpha1.AddToScheme(scheme); err != nil {
-				t.Fatalf("add scheme: %v", err)
-			}
+			scheme := workflowRunTestScheme(t)
 
 			workflowRun := &v1alpha1.WorkflowRun{
 				ObjectMeta: metav1.ObjectMeta{Name: test.name, Namespace: "default", UID: "workflowrun-uid", Generation: 3},
@@ -473,10 +477,7 @@ func TestValidateResolvedWorkflowJobsRejectsUnknownDependency(t *testing.T) {
 }
 
 func TestWorkflowRunReconcilerReusesExistingFirstStepRun(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
+	scheme := workflowRunTestScheme(t)
 
 	workflowRun := &v1alpha1.WorkflowRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", UID: "workflowrun-uid", Generation: 3},
@@ -532,10 +533,7 @@ func TestWorkflowRunReconcilerReusesExistingFirstStepRun(t *testing.T) {
 }
 
 func TestWorkflowRunReconcilerRejectsJobWithoutRuntimeDuringInitialization(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
+	scheme := workflowRunTestScheme(t)
 
 	workflowRun := &v1alpha1.WorkflowRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", UID: "workflowrun-uid", Generation: 3},
@@ -598,10 +596,7 @@ func TestWorkflowRunReconcilerObservesTerminalChildRuns(t *testing.T) {
 		{runPhase: v1alpha1.RunCancelled, stepPhase: v1alpha1.StepFailed, workflowPhase: v1alpha1.WorkflowFailed},
 	} {
 		t.Run(string(test.runPhase), func(t *testing.T) {
-			scheme := runtime.NewScheme()
-			if err := v1alpha1.AddToScheme(scheme); err != nil {
-				t.Fatalf("add scheme: %v", err)
-			}
+			scheme := workflowRunTestScheme(t)
 			workflowRun := &v1alpha1.WorkflowRun{
 				ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", UID: "workflowrun-uid"},
 				Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
@@ -643,10 +638,7 @@ func TestWorkflowRunReconcilerObservesTerminalChildRuns(t *testing.T) {
 }
 
 func TestWorkflowRunReconcilerCreatesNextStepAfterObservedSuccess(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
+	scheme := workflowRunTestScheme(t)
 
 	workflowRun := &v1alpha1.WorkflowRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", UID: "workflowrun-uid"},
@@ -732,10 +724,7 @@ func TestWorkflowRunReconcilerCreatesNextStepAfterObservedSuccess(t *testing.T) 
 }
 
 func TestWorkflowRunReconcilerDoesNotPatchDerivedStatusWhenActionFails(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
+	scheme := workflowRunTestScheme(t)
 
 	workflowRun := &v1alpha1.WorkflowRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", UID: "workflowrun-uid"},
@@ -780,10 +769,7 @@ func TestWorkflowRunReconcilerDoesNotPatchDerivedStatusWhenActionFails(t *testin
 }
 
 func TestWorkflowRunReconcilerRecoversAfterRestartAcrossStatusPatchFailure(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
+	scheme := workflowRunTestScheme(t)
 
 	workflowRun := &v1alpha1.WorkflowRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", UID: "workflowrun-uid"},
@@ -945,10 +931,7 @@ func TestDeriveTerminalWorkflowRunStatus(t *testing.T) {
 }
 
 func TestWorkflowRunReconcilerRequestsCancellationWithoutStartingNewJobs(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
+	scheme := workflowRunTestScheme(t)
 	workflowRun := &v1alpha1.WorkflowRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "cancel-build", Namespace: "default", UID: "workflowrun-uid"},
 		Spec: v1alpha1.WorkflowRunSpec{
@@ -1008,10 +991,7 @@ func TestWorkflowRunReconcilerRequestsCancellationWithoutStartingNewJobs(t *test
 }
 
 func TestWorkflowRunReconcilerFinalizesCancellationAfterChildRunsSettle(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
+	scheme := workflowRunTestScheme(t)
 	workflowRun := &v1alpha1.WorkflowRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "cancelled-build", Namespace: "default", UID: "workflowrun-uid"},
 		Spec: v1alpha1.WorkflowRunSpec{
@@ -1052,10 +1032,7 @@ func TestWorkflowRunReconcilerFinalizesCancellationAfterChildRunsSettle(t *testi
 }
 
 func TestWorkflowRunReconcilerCancelsBeforeCreatingAnyChildRun(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
+	scheme := workflowRunTestScheme(t)
 	workflowRun := &v1alpha1.WorkflowRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "cancel-pending", Namespace: "default", UID: "workflowrun-uid"},
 		Spec: v1alpha1.WorkflowRunSpec{
@@ -1119,10 +1096,7 @@ func TestNextStepToStartRequiresPrecedingSuccess(t *testing.T) {
 }
 
 func TestWorkflowRunReconcilerPreservesResolvedJobStatus(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
+	scheme := workflowRunTestScheme(t)
 
 	workflowRun := &v1alpha1.WorkflowRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", Generation: 4},
@@ -1177,10 +1151,7 @@ func TestWorkflowRunReconcilerPreservesResolvedJobStatus(t *testing.T) {
 }
 
 func TestWorkflowRunReconcilerResolvesReusableWorkflow(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
+	scheme := workflowRunTestScheme(t)
 
 	workflow := &v1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{Name: "build-and-test", Namespace: "default"},
@@ -1226,14 +1197,14 @@ func TestWorkflowRunReconcilerResolvesReusableWorkflow(t *testing.T) {
 	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
 		t.Fatalf("get workflowrun: %v", err)
 	}
-	if updated.Status.Phase != v1alpha1.WorkflowPending {
-		t.Fatalf("phase = %q, want %q", updated.Status.Phase, v1alpha1.WorkflowPending)
+	if updated.Status.Phase != v1alpha1.WorkflowRunning {
+		t.Fatalf("phase = %q, want %q", updated.Status.Phase, v1alpha1.WorkflowRunning)
 	}
 	if len(updated.Status.Jobs) != 2 {
 		t.Fatalf("jobs = %#v, want 2 resolved jobs", updated.Status.Jobs)
 	}
-	if got := updated.Status.Jobs["build"]; got.Phase != v1alpha1.JobPending || len(got.Pre) != 0 || len(got.Steps) != 1 || got.Steps[0].Name != "compile" {
-		t.Fatalf("build status = %#v, want pending compile step", got)
+	if got := updated.Status.Jobs["build"]; got.Phase != v1alpha1.JobRunning || len(got.Pre) != 0 || len(got.Steps) != 1 || got.Steps[0].Name != "compile" || got.Steps[0].RunName == "" {
+		t.Fatalf("build status = %#v, want running compile step", got)
 	}
 	if got := updated.Status.Jobs["test"]; got.Phase != v1alpha1.JobWaiting || len(got.Pre) != 1 || got.Pre[0] != "build" {
 		t.Fatalf("test status = %#v, want waiting on build", got)
@@ -1242,13 +1213,110 @@ func TestWorkflowRunReconcilerResolvesReusableWorkflow(t *testing.T) {
 	if cond == nil || cond.Status != metav1.ConditionTrue {
 		t.Fatalf("condition = %#v, want accepted true", cond)
 	}
+	if updated.Status.SnapshotName == "" {
+		t.Fatal("snapshotName is empty")
+	}
+	var snapshot appsv1.ControllerRevision
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: updated.Namespace, Name: updated.Status.SnapshotName}, &snapshot); err != nil {
+		t.Fatalf("get workflow snapshot: %v", err)
+	}
+}
+
+func TestWorkflowRunReconcilerExecutesTopLevelUsesFromSnapshot(t *testing.T) {
+	scheme := workflowRunTestScheme(t)
+	workflow := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default"},
+		Spec: v1alpha1.WorkflowSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"compile": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "run", Run: "echo snapshot"}}},
+		}},
+	}
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default", UID: "release-uid"},
+		Spec:       v1alpha1.WorkflowRunSpec{Uses: workflow.Name},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(workflow, workflowRun).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(workflowRun)}
+
+	// Initialization captures the reusable definition but creates no Run yet.
+	reconcileWorkflowRun(t, reconciler, req, 1)
+	workflow.Spec.Jobs["compile"] = v1alpha1.JobSpec{RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "run", Run: "echo mutable"}}}
+	if err := c.Update(context.Background(), workflow); err != nil {
+		t.Fatalf("update reusable workflow: %v", err)
+	}
+
+	reconcileWorkflowRun(t, reconciler, req, 1)
+	var runs v1alpha1.RunList
+	if err := c.List(context.Background(), &runs, client.InNamespace(workflowRun.Namespace)); err != nil {
+		t.Fatalf("list child runs: %v", err)
+	}
+	if len(runs.Items) != 1 || runs.Items[0].Spec.Source == nil || runs.Items[0].Spec.Source.Inline == nil || *runs.Items[0].Spec.Source.Inline != "echo snapshot" {
+		t.Fatalf("child runs = %#v, want execution from immutable snapshot", runs.Items)
+	}
+}
+
+func TestResolveWorkflowRunSnapshotResolvesNestedCalls(t *testing.T) {
+	scheme := workflowRunTestScheme(t)
+	smoke := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "smoke", Namespace: "default"},
+		Spec: v1alpha1.WorkflowSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"check": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "run", Run: "check"}}},
+		}},
+	}
+	deploy := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "deploy", Namespace: "default"},
+		Spec: v1alpha1.WorkflowSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"verify": {Uses: smoke.Name},
+		}},
+	}
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default"},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"deploy": {Uses: deploy.Name},
+		}},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(smoke, deploy).Build()
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	snapshot, _, err := reconciler.resolveWorkflowRunSnapshot(context.Background(), workflowRun)
+	if err != nil {
+		t.Fatalf("resolve workflow snapshot: %v", err)
+	}
+	if _, ok := snapshot.Workflows["root/jobs/deploy"]; !ok {
+		t.Fatalf("snapshot workflows = %#v, want deploy call", snapshot.Workflows)
+	}
+	if _, ok := snapshot.Workflows["root/jobs/deploy/jobs/verify"]; !ok {
+		t.Fatalf("snapshot workflows = %#v, want nested smoke call", snapshot.Workflows)
+	}
+}
+
+func TestResolveWorkflowRunSnapshotRejectsReuseCycle(t *testing.T) {
+	scheme := workflowRunTestScheme(t)
+	workflowA := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "workflow-a", Namespace: "default"},
+		Spec:       v1alpha1.WorkflowSpec{Jobs: map[string]v1alpha1.JobSpec{"call-b": {Uses: "workflow-b"}}},
+	}
+	workflowB := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "workflow-b", Namespace: "default"},
+		Spec:       v1alpha1.WorkflowSpec{Jobs: map[string]v1alpha1.JobSpec{"call-a": {Uses: "workflow-a"}}},
+	}
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default"},
+		Spec:       v1alpha1.WorkflowRunSpec{Uses: workflowA.Name},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(workflowA, workflowB).Build()
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	_, _, err := reconciler.resolveWorkflowRunSnapshot(context.Background(), workflowRun)
+	if err == nil || !strings.Contains(err.Error(), "workflow reuse cycle") {
+		t.Fatalf("resolve workflow snapshot error = %v, want reuse cycle", err)
+	}
 }
 
 func TestWorkflowRunReconcilerFailsWhenReusableWorkflowMissing(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
+	scheme := workflowRunTestScheme(t)
 
 	workflowRun := &v1alpha1.WorkflowRun{
 		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default", Generation: 6},
@@ -1289,10 +1357,7 @@ func TestWorkflowRunReconcilerFailsWhenReusableWorkflowMissing(t *testing.T) {
 }
 
 func TestWorkflowRunReconcilerFailsWhenWorkflowInputUnknown(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
+	scheme := workflowRunTestScheme(t)
 
 	workflow := &v1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{Name: "build-and-test", Namespace: "default"},
@@ -1348,10 +1413,7 @@ func TestWorkflowRunReconcilerFailsWhenWorkflowInputUnknown(t *testing.T) {
 }
 
 func TestWorkflowRunReconcilerFailsWhenWorkflowInputRequired(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add scheme: %v", err)
-	}
+	scheme := workflowRunTestScheme(t)
 
 	workflow := &v1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{Name: "build-and-test", Namespace: "default"},

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -1248,7 +1248,7 @@ func TestWorkflowRunReconcilerExecutesTopLevelUsesFromSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load workflowrun resources: %v", err)
 	}
-	if resources.snapshot == nil || resources.snapshot.rootJobs["compile"].Steps[0].Run != "echo snapshot" {
+	if resources.snapshot == nil || resources.snapshot.Root.Spec.Uses != workflow.Name || resources.snapshot.Root.Workflow == nil || resources.snapshot.rootJobs()["compile"].Steps[0].Run != "echo snapshot" {
 		t.Fatalf("loaded snapshot = %#v, want immutable root execution definition", resources.snapshot)
 	}
 	workflow.Spec.Jobs["compile"] = v1alpha1.JobSpec{RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "run", Run: "echo mutable"}}}
@@ -1288,7 +1288,7 @@ func TestResolveWorkflowRunSnapshotResolvesNestedCalls(t *testing.T) {
 	}
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(smoke, deploy).Build()
 	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
-	snapshot, _, err := reconciler.resolveWorkflowRunSnapshot(context.Background(), workflowRun)
+	snapshot, err := reconciler.resolveWorkflowRunSnapshot(context.Background(), workflowRun)
 	if err != nil {
 		t.Fatalf("resolve workflow snapshot: %v", err)
 	}
@@ -1316,7 +1316,7 @@ func TestResolveWorkflowRunSnapshotRejectsReuseCycle(t *testing.T) {
 	}
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(workflowA, workflowB).Build()
 	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
-	_, _, err := reconciler.resolveWorkflowRunSnapshot(context.Background(), workflowRun)
+	_, err := reconciler.resolveWorkflowRunSnapshot(context.Background(), workflowRun)
 	if err == nil || !strings.Contains(err.Error(), "workflow reuse cycle") {
 		t.Fatalf("resolve workflow snapshot error = %v, want reuse cycle", err)
 	}


### PR DESCRIPTION
## Summary
- persist one immutable ControllerRevision snapshot for each accepted WorkflowRun
- execute top-level reusable Workflows from the snapshot rather than mutable Workflow definitions
- recursively resolve reusable call trees with cycle, depth, node-count, and size limits
- recover from a status-patch retry by reusing the existing root-UID snapshot