### PR TITLE
feat(api): lock Run execution inputs

### DIFF
--- a/api/v1alpha1/run_types.go
+++ b/api/v1alpha1/run_types.go
@@ -19,6 +19,10 @@ const (
 	RunFailed    RunPhase = "Failed"
 	RunTimeout   RunPhase = "Timeout"
 	RunCancelled RunPhase = "Cancelled"
+
+	// RunFunctionCleanupFinalizer ensures that a function registration is
+	// released before its Run is deleted.
+	RunFunctionCleanupFinalizer = "kruntimes.io/function-cleanup"
 )
 
 // RunEndpointProtocol identifies the public protocol for invoking a function Run.
@@ -334,7 +338,9 @@ type RunAffinityTerm struct {
 // +kubebuilder:object:generate=true
 // RunSpec defines the desired state of Run.
 // +kubebuilder:validation:XValidation:rule="!has(self.mode.task) || !has(self.mode.task.entrypoint) || (has(self.source) && has(self.source.inline)) || (!self.mode.task.entrypoint.startsWith('/') && !self.mode.task.entrypoint.split('/').exists(segment, segment == '..'))",message="mode.task.entrypoint must be a relative path that does not contain '..'"
+// +kubebuilder:validation:XValidation:rule="self.runtime == oldSelf.runtime && has(self.source) == has(oldSelf.source) && (!has(self.source) || self.source == oldSelf.source) && self.mode == oldSelf.mode && has(self.env) == has(oldSelf.env) && (!has(self.env) || self.env == oldSelf.env) && has(self.timeout) == has(oldSelf.timeout) && (!has(self.timeout) || self.timeout == oldSelf.timeout) && has(self.retryPolicy) == has(oldSelf.retryPolicy) && (!has(self.retryPolicy) || self.retryPolicy == oldSelf.retryPolicy)",message="runtime, source, mode, env, timeout, and retryPolicy are immutable after Run creation"
 // +kubebuilder:validation:XValidation:rule="has(self.workspace) == has(oldSelf.workspace) && (!has(self.workspace) || self.workspace == oldSelf.workspace) && has(self.affinity) == has(oldSelf.affinity) && (!has(self.affinity) || self.affinity == oldSelf.affinity)",message="workspace and affinity are immutable after Run creation"
+// +kubebuilder:validation:XValidation:rule="!has(oldSelf.cancelRequested) || !oldSelf.cancelRequested || (has(self.cancelRequested) && self.cancelRequested)",message="cancelRequested may not transition from true to false"
 type RunSpec struct {
 	// Runtime is the execution environment type (e.g., "python").
 	// It maps to the "runtime" label on Runtime Pods.

--- a/charts/kruntimes/crds/kruntimes.io_runs.yaml
+++ b/charts/kruntimes/crds/kruntimes.io_runs.yaml
@@ -708,10 +708,22 @@ spec:
                 && has(self.source.inline)) || (!self.mode.task.entrypoint.startsWith(''/'')
                 && !self.mode.task.entrypoint.split(''/'').exists(segment, segment
                 == ''..''))'
+            - message: runtime, source, mode, env, timeout, and retryPolicy are immutable
+                after Run creation
+              rule: self.runtime == oldSelf.runtime && has(self.source) == has(oldSelf.source)
+                && (!has(self.source) || self.source == oldSelf.source) && self.mode
+                == oldSelf.mode && has(self.env) == has(oldSelf.env) && (!has(self.env)
+                || self.env == oldSelf.env) && has(self.timeout) == has(oldSelf.timeout)
+                && (!has(self.timeout) || self.timeout == oldSelf.timeout) && has(self.retryPolicy)
+                == has(oldSelf.retryPolicy) && (!has(self.retryPolicy) || self.retryPolicy
+                == oldSelf.retryPolicy)
             - message: workspace and affinity are immutable after Run creation
               rule: has(self.workspace) == has(oldSelf.workspace) && (!has(self.workspace)
                 || self.workspace == oldSelf.workspace) && has(self.affinity) == has(oldSelf.affinity)
                 && (!has(self.affinity) || self.affinity == oldSelf.affinity)
+            - message: cancelRequested may not transition from true to false
+              rule: '!has(oldSelf.cancelRequested) || !oldSelf.cancelRequested ||
+                (has(self.cancelRequested) && self.cancelRequested)'
           status:
             description: RunStatus defines the observed state of Run.
             properties:

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -653,6 +653,125 @@ func TestCRDValidationRejectsRunWorkspaceAndAffinityMutation(t *testing.T) {
 	}
 }
 
+func TestCRDValidationRunExecutionInputsAreImmutable(t *testing.T) {
+	ctx := context.Background()
+	ns := testNamespace(t, "test-run-immutable-inputs-")
+	inline := "echo original"
+	timeout := metav1.Duration{Duration: time.Minute}
+	ttl := int32(60)
+
+	newRun := func(t *testing.T) *v1alpha1.Run {
+		t.Helper()
+		run := &v1alpha1.Run{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "build-", Namespace: ns.Name},
+			Spec: v1alpha1.RunSpec{
+				Runtime: "bash",
+				Source:  &v1alpha1.CodeSource{Inline: &inline},
+				Mode: v1alpha1.RunMode{Task: &v1alpha1.RunTaskMode{
+					Entrypoint: "script",
+					Args:       []string{"--verbose"},
+				}},
+				Env:     []corev1.EnvVar{{Name: "LOG_LEVEL", Value: "info"}},
+				Timeout: &timeout,
+				RetryPolicy: &v1alpha1.RetryPolicy{
+					MaxAttempts: 2,
+				},
+				TTLSecondsAfterFinished: &ttl,
+			},
+		}
+		if err := k8sClient.Create(ctx, run); err != nil {
+			t.Fatalf("create run: %v", err)
+		}
+		return run
+	}
+	updateRun := func(run *v1alpha1.Run, mutate func(*v1alpha1.Run)) error {
+		key := client.ObjectKeyFromObject(run)
+		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			current := &v1alpha1.Run{}
+			if err := k8sClient.Get(ctx, key, current); err != nil {
+				return err
+			}
+			mutate(current)
+			return k8sClient.Update(ctx, current)
+		})
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*v1alpha1.Run)
+	}{
+		{
+			name: "runtime",
+			mutate: func(run *v1alpha1.Run) {
+				run.Spec.Runtime = "python"
+			},
+		},
+		{
+			name: "source",
+			mutate: func(run *v1alpha1.Run) {
+				updated := "echo updated"
+				run.Spec.Source.Inline = &updated
+			},
+		},
+		{
+			name: "mode",
+			mutate: func(run *v1alpha1.Run) {
+				run.Spec.Mode = v1alpha1.RunMode{Function: &v1alpha1.RunFunctionMode{Handler: "main.handle"}}
+			},
+		},
+		{
+			name: "env",
+			mutate: func(run *v1alpha1.Run) {
+				run.Spec.Env[0].Value = "debug"
+			},
+		},
+		{
+			name: "timeout",
+			mutate: func(run *v1alpha1.Run) {
+				run.Spec.Timeout.Duration = 2 * time.Minute
+			},
+		},
+		{
+			name: "retry-policy",
+			mutate: func(run *v1alpha1.Run) {
+				run.Spec.RetryPolicy.MaxAttempts = 3
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			run := newRun(t)
+			if err := updateRun(run, tt.mutate); !apierrors.IsInvalid(err) {
+				t.Fatalf("mutating run %s error = %v, want Invalid", tt.name, err)
+			}
+		})
+	}
+
+	t.Run("cancel-request-is-one-way", func(t *testing.T) {
+		run := newRun(t)
+		if err := updateRun(run, func(run *v1alpha1.Run) {
+			run.Spec.CancelRequested = true
+		}); err != nil {
+			t.Fatalf("request run cancellation: %v", err)
+		}
+		if err := updateRun(run, func(run *v1alpha1.Run) {
+			run.Spec.CancelRequested = false
+		}); !apierrors.IsInvalid(err) {
+			t.Fatalf("clearing run cancellation error = %v, want Invalid", err)
+		}
+	})
+
+	t.Run("ttl-remains-mutable", func(t *testing.T) {
+		run := newRun(t)
+		updatedTTL := int32(120)
+		if err := updateRun(run, func(run *v1alpha1.Run) {
+			run.Spec.TTLSecondsAfterFinished = &updatedTTL
+		}); err != nil {
+			t.Fatalf("update run ttl: %v", err)
+		}
+	})
+}
+
 func runSpecWithRequiredAffinity(term v1alpha1.RunAffinityTerm) v1alpha1.RunSpec {
 	return v1alpha1.RunSpec{
 		Runtime: "bash",


### PR DESCRIPTION
## Summary
- make Run execution inputs immutable after creation
- make cancellation one-way while retaining a mutable completion TTL
- reserve the function cleanup finalizer API constant
- cover CRD validation with envtest