### PR TITLE
feat(workflow): execute reusable workflow jobs

### DIFF
--- a/api/v1alpha1/workflow_types.go
+++ b/api/v1alpha1/workflow_types.go
@@ -59,6 +59,7 @@ type WorkflowSpec struct {
 // JobSpec defines a single job within a workflow.
 // +kubebuilder:validation:XValidation:rule="has(self.steps) != has(self.uses)",message="exactly one of steps or uses must be set"
 // +kubebuilder:validation:XValidation:rule="!has(self.with) || has(self.uses)",message="with can only be set when uses is set"
+// +kubebuilder:validation:XValidation:rule="!has(self.uses) || !has(self.outputs)",message="outputs may not be set when uses is set"
 type JobSpec struct {
 	// RunsOn is the runtime to use for all steps in this job (e.g., "bash", "python").
 	// Runtime names are propagated to Kubernetes label values.

--- a/charts/kruntimes/crds/kruntimes.io_workflowruns.yaml
+++ b/charts/kruntimes/crds/kruntimes.io_workflowruns.yaml
@@ -154,6 +154,8 @@ spec:
                     rule: has(self.steps) != has(self.uses)
                   - message: with can only be set when uses is set
                     rule: '!has(self.with) || has(self.uses)'
+                  - message: outputs may not be set when uses is set
+                    rule: '!has(self.uses) || !has(self.outputs)'
                 description: |-
                   Jobs is a map of inline job names to job specs. Jobs run in parallel
                   unless constrained by needs; the map order is not significant.

--- a/charts/kruntimes/crds/kruntimes.io_workflows.yaml
+++ b/charts/kruntimes/crds/kruntimes.io_workflows.yaml
@@ -170,6 +170,8 @@ spec:
                     rule: has(self.steps) != has(self.uses)
                   - message: with can only be set when uses is set
                     rule: '!has(self.with) || has(self.uses)'
+                  - message: outputs may not be set when uses is set
+                    rule: '!has(self.uses) || !has(self.outputs)'
                 description: |-
                   Jobs is a map of reusable job names to job specs. Jobs run in parallel
                   unless constrained by needs; the map order is not significant.

--- a/charts/kruntimes/templates/controller-rbac.yaml
+++ b/charts/kruntimes/templates/controller-rbac.yaml
@@ -81,6 +81,7 @@ rules:
       - get
       - list
       - watch
+      - create
       - update
       - patch
   - apiGroups:

--- a/docs/api.md
+++ b/docs/api.md
@@ -179,18 +179,23 @@ Current status fields:
 | --- | --- |
 | `status.conditions` | Definition-level readiness and validation conditions. The skeleton controller records `Ready=True`. |
 
-Workflow execution moved to the `WorkflowRun` API. Namespace-local `uses`
-resolution, input binding, output propagation, and WorkflowRun execution are
-tracked in the roadmap.
+Workflow execution is provided by the `WorkflowRun` controller. Namespace-local
+references are resolved into an immutable execution snapshot before any child
+execution starts. Expression evaluation and output propagation remain roadmap
+work.
 
 ### WorkflowRun
 
 `WorkflowRun` is the execution-instance API for the reusable workflow model.
-The controller currently resolves top-level reusable Workflow references and
-inputs, executes inline jobs as sequential step Runs, derives step and job
-status, aggregates settled jobs into a terminal WorkflowRun phase, and
-propagates cancellation to active child Runs. Reusable job calls, Action
-expansion, and output propagation remain in the roadmap.
+The controller resolves top-level and job-level reusable Workflow references,
+validates their declared inputs, and stores the complete resolved call tree in
+an immutable execution snapshot. It executes inline jobs as sequential step
+Runs. A job-level `uses` call becomes an owned child `WorkflowRun`; the child
+has its own local jobs status and the caller job completes when that child
+settles. The controller derives step and job status, aggregates settled jobs
+into a terminal WorkflowRun phase, and propagates cancellation to direct child
+Runs and child WorkflowRuns. Action expansion, expression evaluation, and
+output propagation remain in the roadmap.
 
 Before initializing the status graph or creating child Runs, the controller
 rejects inline and resolved reusable Workflow job graphs with unknown
@@ -204,7 +209,7 @@ Current spec shape:
 | `spec.jobs` | Inline jobs to execute. Exactly one of `spec.jobs` or `spec.uses` must be set. |
 | `spec.uses` | Namespace-local reusable Workflow name to execute. Exactly one of `spec.jobs` or `spec.uses` must be set. |
 | `spec.with` | String inputs passed to the reusable Workflow named by `spec.uses`. |
-| `spec.cancelRequested` | Requests cancellation. It may transition only from `false` to `true`. The controller stops creating child Runs, sets `cancelRequested` on every active child Run, and waits for them to settle. |
+| `spec.cancelRequested` | Requests cancellation. It may transition only from `false` to `true`. The controller stops creating children, sets `cancelRequested` on every active direct child Run and WorkflowRun, and waits for them to settle. |
 
 After creation, `spec.jobs`, `spec.uses`, and `spec.with` are immutable execution
 inputs. This prevents an accepted WorkflowRun from observing a different
@@ -214,9 +219,9 @@ Current status fields:
 
 | Field | Description |
 | --- | --- |
-| `status.phase` | `Pending`, `Running`, `Succeeded`, `Failed`, or `Cancelled`. After all jobs settle, the controller sets `Failed` if any job failed and `Succeeded` otherwise. A cancellation request results in `Cancelled` after active child Runs settle. |
+| `status.phase` | `Pending`, `Running`, `Succeeded`, `Failed`, or `Cancelled`. After all jobs settle, the controller sets `Failed` if any job failed and `Succeeded` otherwise. A cancellation request results in `Cancelled` after active child Runs and child WorkflowRuns settle. |
 | `status.jobs` | Lightweight resolved job status keyed by job name. Each job records `pre`, ordered step statuses, and, for a reusable call, its child `workflowRunName`. |
-| `status.snapshotName` | Immutable ControllerRevision index for the resolved execution tree. The snapshot resolver is tracked in the roadmap. |
+| `status.snapshotName` | Immutable ControllerRevision index for the complete resolved execution tree. |
 | `status.conditions` | Lifecycle conditions. The skeleton controller records `Accepted=True`. |
 
 Job phases are `Pending`, `Waiting`, `Running`, `Succeeded`, `Failed`, and

--- a/docs/api.zh.md
+++ b/docs/api.zh.md
@@ -174,16 +174,19 @@ references 和 cleanup 仍在 roadmap 中跟踪。
 | --- | --- |
 | `status.conditions` | Definition-level readiness 和 validation conditions。skeleton controller 会记录 `Ready=True`。 |
 
-Workflow execution 已迁移到 `WorkflowRun` API。Namespace-local `uses` resolution、
-input binding、output propagation 和 WorkflowRun execution 仍在 roadmap 中跟踪。
+Workflow execution 由 `WorkflowRun` controller 提供。任何 child execution 开始前，
+controller 会将 namespace-local reference 解析为 immutable execution snapshot。
+Expression evaluation 和 output propagation 仍在 roadmap 中跟踪。
 
 ### WorkflowRun
 
-`WorkflowRun` 是 reusable workflow model 的 execution-instance API。controller 当前支持
-解析 top-level reusable Workflow references 和 inputs，将 inline jobs 执行为顺序 step Runs，
-并推导 step 与 job status、将 settled jobs 聚合为 WorkflowRun 终态，并把 cancellation
-传播到 active child Runs。Reusable job calls、Action expansion 和 output propagation
-仍在 roadmap 中。
+`WorkflowRun` 是 reusable workflow model 的 execution-instance API。controller 支持解析
+top-level 和 job-level reusable Workflow references、校验其声明的 inputs，并将完整 resolved
+call tree 写入 immutable execution snapshot。它将 inline jobs 执行为顺序 step Runs。一个
+job-level `uses` call 会成为 owned child `WorkflowRun`；child 有自己的 local jobs status，
+caller job 在该 child settled 后完成。controller 推导 step 与 job status，将 settled jobs
+聚合为 WorkflowRun 终态，并把 cancellation 传播到 direct child Runs 和 child WorkflowRuns。
+Action expansion、expression evaluation 和 output propagation 仍在 roadmap 中。
 
 在初始化 status graph 或创建 child Runs 前，controller 会拒绝包含 unknown dependency 或
 dependency cycle 的 inline 和 resolved reusable Workflow job graph。rejection message 会包含
@@ -196,7 +199,7 @@ dependency cycle 的 inline 和 resolved reusable Workflow job graph。rejection
 | `spec.jobs` | Inline jobs。`spec.jobs` 和 `spec.uses` 必须且只能设置一个。 |
 | `spec.uses` | 要执行的 namespace-local reusable Workflow 名称。`spec.jobs` 和 `spec.uses` 必须且只能设置一个。 |
 | `spec.with` | 传给 `spec.uses` 引用的 reusable Workflow 的 string inputs。 |
-| `spec.cancelRequested` | 请求取消 WorkflowRun。它只能从 `false` 变为 `true`。controller 会停止创建 child Runs，为所有 active child Runs 设置 `cancelRequested`，并等待它们 settled。 |
+| `spec.cancelRequested` | 请求取消 WorkflowRun。它只能从 `false` 变为 `true`。controller 会停止创建 children，为所有 active direct child Run 和 WorkflowRun 设置 `cancelRequested`，并等待它们 settled。 |
 
 创建后，`spec.jobs`、`spec.uses` 与 `spec.with` 都是 immutable execution inputs。这样可防止
 已 accepted 的 WorkflowRun 在运行中观察到不同 definition。
@@ -205,9 +208,9 @@ dependency cycle 的 inline 和 resolved reusable Workflow job graph。rejection
 
 | Field | Description |
 | --- | --- |
-| `status.phase` | `Pending`、`Running`、`Succeeded`、`Failed` 或 `Cancelled`。所有 jobs settled 后，任一 job failed 则 controller 设置为 `Failed`，否则设置为 `Succeeded`。收到 cancellation request 后，active child Runs settled 时设置为 `Cancelled`。 |
+| `status.phase` | `Pending`、`Running`、`Succeeded`、`Failed` 或 `Cancelled`。所有 jobs settled 后，任一 job failed 则 controller 设置为 `Failed`，否则设置为 `Succeeded`。收到 cancellation request 后，active child Runs 和 child WorkflowRuns settled 时设置为 `Cancelled`。 |
 | `status.jobs` | 按 job name 记录轻量 resolved job status。每个 job 记录 `pre`、有序 step statuses，以及 reusable call 对应的 child `workflowRunName`。 |
-| `status.snapshotName` | resolved execution tree 的 immutable ControllerRevision index。snapshot resolver 仍在 roadmap 中跟踪。 |
+| `status.snapshotName` | 完整 resolved execution tree 的 immutable ControllerRevision index。 |
 | `status.conditions` | Lifecycle conditions。skeleton controller 会记录 `Accepted=True`。 |
 
 Job phases 包括 `Pending`、`Waiting`、`Running`、`Succeeded`、`Failed` 和 `Skipped`。

--- a/docs/design/workflow-job-reuse.md
+++ b/docs/design/workflow-job-reuse.md
@@ -1,6 +1,6 @@
 # Job-Level Reusable Workflow Execution
 
-Status: **Proposed for review**
+Status: **Implemented in PR #301; output propagation remains proposed**
 
 This document refines the job-level `uses` model introduced in
 [Workflow Reuse](../workflow-reuse/). It defines an execution boundary that is
@@ -74,7 +74,7 @@ spec:
 - its child WorkflowRun may execute multiple jobs in parallel;
 - it succeeds only when the child WorkflowRun succeeds;
 - `notify` waits for the complete child WorkflowRun, not one internal leaf;
-- called Workflow outputs become outputs of the `deploy` job;
+- output promotion from the called Workflow to the `deploy` job is deferred;
 - called jobs do not share a workspace with caller jobs.
 
 This follows the useful part of the
@@ -338,7 +338,7 @@ Only job-level calls create child WorkflowRuns.
 
 A call job supports `needs`, `uses`, and `with`. It does not support `runs-on`,
 `steps`, or caller-defined `outputs` in v0.x. The called Workflow selects
-runtimes for its own jobs and exposes outputs through `Workflow.spec.outputs`.
+runtimes for its own jobs. `Workflow.spec.outputs` is not evaluated yet.
 
 Input expressions are evaluated only when the call job becomes runnable, using
 the caller's completed dependency outputs. The resulting concrete values are
@@ -346,9 +346,8 @@ placed in the child WorkflowRun's immutable `with` map. Secret inputs remain
 out of scope until a separate secret-handling design is reviewed.
 
 Output evaluation remains part of the existing expression/output propagation
-story. This design only fixes the boundary: child Workflow outputs are promoted
-to caller job outputs, and downstream jobs access them through the normal jobs
-context.
+story. The future boundary is that child Workflow outputs become caller job
+outputs, and downstream jobs access them through the normal jobs context.
 
 ## Component Boundaries
 

--- a/docs/design/workflow-job-reuse.zh.md
+++ b/docs/design/workflow-job-reuse.zh.md
@@ -1,6 +1,6 @@
 # Job-Level Reusable Workflow Execution
 
-状态：**提案，等待 review**
+状态：**已在 PR #301 实现；output propagation 仍是提案**
 
 本文细化 [Workflow Reuse](../workflow-reuse/) 中的 job-level `uses` 模型，定义一个在
 controller restart 和 reusable `Workflow` 更新后仍保持确定性的 execution boundary。
@@ -65,7 +65,7 @@ spec:
 - child WorkflowRun 内可以并行执行多个 jobs；
 - 只有 child WorkflowRun succeeded 时它才 succeeded；
 - `notify` 等待完整 child WorkflowRun，而不是某个内部 leaf；
-- called Workflow outputs 成为 `deploy` job outputs；
+- 将 called Workflow outputs 提升为 `deploy` job outputs 的能力暂缓；
 - called jobs 不与 caller jobs 共享 workspace。
 
 该语义保留了
@@ -302,15 +302,14 @@ snapshot 初始化并执行 root jobs。只有 job-level calls 创建 child Work
 ## Job Shape 和 Outputs
 
 call job 支持 `needs`、`uses` 和 `with`。v0.x 不支持 `runs-on`、`steps` 或 caller-defined
-`outputs`。called Workflow 为其内部 jobs 选择 runtimes，并通过 `Workflow.spec.outputs` 暴露
-outputs。
+`outputs`。called Workflow 为其内部 jobs 选择 runtimes。`Workflow.spec.outputs` 尚不求值。
 
 input expressions 只在 call job ready 时求值，并使用 caller 已完成 dependency outputs。求值后
 的具体值放入 child WorkflowRun 的 immutable `with` map。Secret inputs 继续保持 out of scope，
 直到单独的 secret-handling design 完成 review。
 
-output evaluation 仍属于现有 expression/output propagation story。本文只确定 boundary：child
-Workflow outputs 会提升为 caller job outputs，downstream jobs 通过普通 jobs context 访问。
+output evaluation 仍属于现有 expression/output propagation story。未来的 boundary 是：child
+Workflow outputs 成为 caller job outputs，downstream jobs 通过普通 jobs context 访问。
 
 ## Component Boundaries
 

--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -1,6 +1,9 @@
 # Workflow Reuse
 
-This document describes a target v0.x design. It is not implemented yet.
+This document describes the target v0.x model. The `WorkflowRun`, immutable
+snapshot, top-level reuse, and job-level reusable Workflow execution portions
+are implemented incrementally; Action expansion and output propagation remain
+future work.
 
 The goal is to split workflow execution instances from reusable workflow and
 step definitions before the Workflow API stabilizes. The current experimental
@@ -140,9 +143,10 @@ spec:
 
 Validation must enforce that job `uses` and job `steps` are mutually exclusive.
 
-Reusable Workflow jobs have their own job/workspace/artifact boundary. They
-communicate with callers through inputs, outputs, and artifacts. The concrete
-parent/child execution boundary and immutable snapshot model are defined in
+Reusable Workflow jobs execute as child WorkflowRuns with their own local job
+status boundary. Input validation and immutable snapshot binding are available;
+workspace sharing, output propagation, and artifact transfer remain future
+work. The concrete parent/child execution boundary and immutable snapshot model are defined in
 [Job-Level Reusable Workflow Execution](../workflow-job-reuse/).
 
 ## Action
@@ -602,6 +606,12 @@ Current implementation status:
 - WorkflowRun cancellation stops new child Run creation, idempotently requests
   cancellation for active child Runs, and finalizes as `Cancelled` after they
   settle. Jobs that never started retain their `Pending` or `Waiting` phase.
+- Job-level reusable Workflow calls create owned child WorkflowRuns for ready
+  `uses` jobs. The complete call tree is resolved into the root immutable
+  ControllerRevision before execution; child controllers use their call path to
+  execute only their snapshot-bound local jobs. A direct child terminal phase
+  is projected into the caller job, and cancellation propagates by direct
+  ownership. Expression values and outputs are still not propagated.
 - Restart recovery is verified across the create-before-status-patch failure
   window: a replacement controller discovers child Runs through durable labels,
   repairs step status, and continues terminal observation without duplicates.

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -1,6 +1,8 @@
 # Workflow Reuse
 
-本文描述 v0.x 的目标设计，当前尚未实现。
+本文描述 target v0.x model。`WorkflowRun`、immutable snapshot、top-level reuse 以及
+job-level reusable Workflow execution 已逐步实现；Action expansion 和 output propagation
+仍是未来工作。
 
 目标是在 Workflow API 稳定前拆分 workflow execution instances 和 reusable workflow/step
 definitions。当前 experimental `Workflow` CRD 表示 execution instance。这个形态对 CI/CD
@@ -134,9 +136,10 @@ spec:
 
 Validation 必须保证 job `uses` 和 job `steps` 互斥。
 
-Reusable Workflow jobs 拥有自己的 job/workspace/artifact boundary。它们通过 inputs、
-outputs 和 artifacts 与 caller 通信。具体的 parent/child execution boundary 和 immutable
-snapshot model 见 [Job-Level Reusable Workflow Execution](../workflow-job-reuse/)。
+Reusable Workflow jobs 作为 child WorkflowRuns 执行，并拥有自己的 local job status boundary。
+input validation 和 immutable snapshot binding 已支持；workspace sharing、output propagation 和
+artifact transfer 仍是未来工作。具体的 parent/child execution boundary 和 immutable snapshot
+model 见 [Job-Level Reusable Workflow Execution](../workflow-job-reuse/)。
 
 ## Action
 
@@ -550,6 +553,10 @@ status:
 - WorkflowRun cancellation 会停止创建新的 child Runs，幂等地请求取消 active child Runs，
   并在它们 settled 后 finalize 为 `Cancelled`。从未启动的 jobs 保留 `Pending` 或
   `Waiting` phase。
+- Ready 的 `uses` job 会创建 owned child WorkflowRun。完整 call tree 会在执行前解析到
+  root immutable ControllerRevision；child controller 根据 call path 只执行 snapshot-bound
+  local jobs。direct child 的 terminal phase 会投影到 caller job，cancellation 通过 direct
+  ownership 传播。expression values 和 outputs 仍不会传播。
 - Restart recovery 已覆盖 create-before-status-patch 故障窗口：replacement controller
   通过 durable labels 发现 child Runs、修复 step status，并继续观察 terminal state，且
   不会重复创建 Runs。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -266,10 +266,10 @@ wiring from accumulating avoidable conflicts.
       capture, call limits, input validation, and cycle detection;
     - [x] execute top-level `WorkflowRun.spec.uses` from its snapshot instead of
       only initializing status;
-    - [ ] create and observe child WorkflowRuns for ready job-level calls;
-    - [ ] verify definition mutation isolation, restart recovery, nested calls,
+    - [x] create and observe child WorkflowRuns for ready job-level calls;
+    - [x] verify definition mutation isolation, restart recovery, nested calls,
       cancellation, and invalid graphs;
-    - [ ] integrate call inputs and outputs with expression/output propagation;
+    - [ ] integrate call input values and outputs with expression/output propagation;
   - implement step-level Action expansion;
   - implement expression evaluation for `inputs`, `steps`, and `jobs` contexts;
   - promote child Run outputs into WorkflowRun step/job/workflow outputs;

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -231,10 +231,10 @@ controller wiring 累积不必要的冲突。
     - [x] 增加 immutable ControllerRevision snapshot storage 和 recursive resolution，包括 version capture、
       call limits、input validation 和 cycle detection；
     - [x] 从 snapshot 执行 top-level `WorkflowRun.spec.uses`，而不是只初始化 status；
-    - [ ] 为 ready job-level calls 创建并观察 child WorkflowRuns；
-    - [ ] 验证 definition mutation isolation、restart recovery、nested calls、cancellation 和
+    - [x] 为 ready job-level calls 创建并观察 child WorkflowRuns；
+    - [x] 验证 definition mutation isolation、restart recovery、nested calls、cancellation 和
       invalid graphs；
-    - [ ] 将 call inputs 和 outputs 接入 expression/output propagation；
+    - [ ] 将 call input values 和 outputs 接入 expression/output propagation；
   - 实现 step-level Action expansion；
   - 实现 `inputs`、`steps` 和 `jobs` contexts 的 expression evaluation；
   - 将 child Run outputs 提升为 WorkflowRun step/job/workflow outputs；

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -250,6 +250,45 @@ spec:
 `krt wf run -f` also accepts a small GitHub Actions style workflow file and
 converts it to an inline `WorkflowRun`.
 
+To call a reusable Workflow from one job, create the definition first, then
+use its name from a caller job. The `deploy` job below becomes a child
+`WorkflowRun`; `notify` waits for that complete child execution.
+
+```yaml
+apiVersion: kruntimes.io/v1alpha1
+kind: Workflow
+metadata:
+  name: deploy
+spec:
+  jobs:
+    apply:
+      runs-on: bash
+      steps:
+        - name: deploy
+          run: ./deploy.sh
+---
+apiVersion: kruntimes.io/v1alpha1
+kind: WorkflowRun
+metadata:
+  name: release
+spec:
+  jobs:
+    package:
+      runs-on: bash
+      steps:
+        - name: build
+          run: make package
+    deploy:
+      needs: [package]
+      uses: deploy
+    notify:
+      needs: [deploy]
+      runs-on: bash
+      steps:
+        - name: announce
+          run: ./notify.sh
+```
+
 For reusable Workflow definitions:
 
 ```bash

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -201,11 +201,13 @@ delivery deterministic and safe.
 Full stdout and stderr are exposed through structured runtimed logs keyed by
 Run UID. They are not copied wholesale into `status.message`.
 
-## WorkflowRun Skeleton
+## WorkflowRun
 
-`WorkflowRun` is the target execution-instance API for the reusable workflow
-model. The current v0.x skeleton accepts inline jobs or a namespace-local
-reusable Workflow reference, but execution is not implemented yet.
+`WorkflowRun` executes inline jobs or a namespace-local reusable `Workflow`.
+Jobs without dependencies start in parallel; steps inside one job run
+sequentially. A job may instead use another `Workflow`, which the controller
+executes as an owned child `WorkflowRun`. The child must finish successfully
+before dependent caller jobs can start.
 
 Create an inline WorkflowRun manifest:
 
@@ -258,8 +260,7 @@ krt wf delete build-and-test -n default
 ```
 
 `krt wf trigger` creates a `WorkflowRun` with `spec.uses` pointing at the
-reusable Workflow. The created `WorkflowRun` remains pending until WorkflowRun
-execution is implemented.
+reusable Workflow.
 
 `krt wf run cancel` is reserved for the future cancellation API and currently
 returns a clear unsupported error.

--- a/docs/usage.zh.md
+++ b/docs/usage.zh.md
@@ -195,11 +195,12 @@ Retry 语义是 at-least-once。Runtime Servers 必须让重复 `Execute` delive
 完整 stdout 和 stderr 通过带 Run UID 的结构化 runtimed logs 暴露。它们不会被完整复制到
 `status.message`。
 
-## WorkflowRun Skeleton
+## WorkflowRun
 
-`WorkflowRun` 是 reusable workflow model 的目标 execution-instance API。当前 v0.x
-skeleton 接受 inline jobs，或 namespace-local reusable Workflow reference，但尚未实现
-执行逻辑。
+`WorkflowRun` 执行 inline jobs 或 namespace-local reusable `Workflow`。没有 dependency 的
+jobs 会并行启动，一个 job 内的 steps 顺序执行。一个 job 也可以使用另一个 `Workflow`；
+controller 会将它作为 owned child `WorkflowRun` 执行。该 child 必须成功结束，依赖它的 caller
+jobs 才能开始。
 
 创建一个 inline WorkflowRun manifest：
 
@@ -251,8 +252,7 @@ krt wf trigger build-and-test --set ref=main -n default
 krt wf delete build-and-test -n default
 ```
 
-`krt wf trigger` 会创建一个 `spec.uses` 指向 reusable Workflow 的 `WorkflowRun`。在
-WorkflowRun execution 实现前，创建出来的 `WorkflowRun` 会保持 pending。
+`krt wf trigger` 会创建一个 `spec.uses` 指向 reusable Workflow 的 `WorkflowRun`。
 
 `krt wf run cancel` 是为未来 cancellation API 预留的命令；当前会返回明确的 unsupported
 error。

--- a/docs/usage.zh.md
+++ b/docs/usage.zh.md
@@ -243,6 +243,44 @@ spec:
 `krt wf run -f` 也接受一个小型 GitHub Actions 风格 workflow file，并将其转换为 inline
 `WorkflowRun`。
 
+如需从一个 job 调用 reusable Workflow，先创建 definition，再从 caller job 中使用它的名称。
+下面的 `deploy` job 会成为 child `WorkflowRun`；`notify` 会等待完整的 child execution。
+
+```yaml
+apiVersion: kruntimes.io/v1alpha1
+kind: Workflow
+metadata:
+  name: deploy
+spec:
+  jobs:
+    apply:
+      runs-on: bash
+      steps:
+        - name: deploy
+          run: ./deploy.sh
+---
+apiVersion: kruntimes.io/v1alpha1
+kind: WorkflowRun
+metadata:
+  name: release
+spec:
+  jobs:
+    package:
+      runs-on: bash
+      steps:
+        - name: build
+          run: make package
+    deploy:
+      needs: [package]
+      uses: deploy
+    notify:
+      needs: [deploy]
+      runs-on: bash
+      steps:
+        - name: announce
+          run: ./notify.sh
+```
+
 对于 reusable Workflow definitions：
 
 ```bash

--- a/internal/controller/workflow_snapshot.go
+++ b/internal/controller/workflow_snapshot.go
@@ -47,6 +47,17 @@ func (s *workflowExecutionSnapshot) rootJobs() map[string]v1alpha1.JobSpec {
 	return s.Root.Spec.Jobs
 }
 
+func (s *workflowExecutionSnapshot) jobsAt(callPath string) (map[string]v1alpha1.JobSpec, bool) {
+	if callPath == "" || callPath == "root" {
+		return s.rootJobs(), true
+	}
+	workflow, ok := s.Workflows[callPath]
+	if !ok {
+		return nil, false
+	}
+	return workflow.Jobs, true
+}
+
 type workflowSnapshotResolutionError struct {
 	err error
 }

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"strings"
@@ -50,26 +51,38 @@ const (
 type workflowRunAction string
 
 const (
-	workflowRunActionNone                        workflowRunAction = "None"
-	workflowRunActionInitialize                  workflowRunAction = "Initialize"
-	workflowRunActionStartRunnableSteps          workflowRunAction = "StartRunnableSteps"
-	workflowRunActionRequestChildRunCancellation workflowRunAction = "RequestChildRunCancellation"
+	workflowRunActionNone                     workflowRunAction = "None"
+	workflowRunActionInitialize               workflowRunAction = "Initialize"
+	workflowRunActionStartRunnableTargets     workflowRunAction = "StartRunnableTargets"
+	workflowRunActionRequestChildCancellation workflowRunAction = "RequestChildCancellation"
 )
 
 type workflowRunResources struct {
-	workflowRun *v1alpha1.WorkflowRun
-	childRuns   map[string]*v1alpha1.Run
-	snapshot    *workflowExecutionSnapshot
+	workflowRun       *v1alpha1.WorkflowRun
+	childRuns         map[string]*v1alpha1.Run
+	childWorkflowRuns map[string]*v1alpha1.WorkflowRun
+	snapshot          *workflowExecutionSnapshot
+	snapshotName      string
+	callPath          string
 }
 
 type workflowRunPlan struct {
-	state    workflowRunState
-	action   workflowRunAction
-	targets  []workflowRunStepTarget
-	runNames []string
+	state            workflowRunState
+	action           workflowRunAction
+	targets          []workflowRunTarget
+	runNames         []string
+	workflowRunNames []string
 }
 
-type workflowRunStepTarget struct {
+type workflowRunTargetKind string
+
+const (
+	workflowRunTargetStep workflowRunTargetKind = ""
+	workflowRunTargetCall workflowRunTargetKind = "Call"
+)
+
+type workflowRunTarget struct {
+	kind      workflowRunTargetKind
 	jobName   string
 	stepIndex int
 }
@@ -123,14 +136,14 @@ func (r *WorkflowRunReconciler) loadWorkflowRunResources(ctx context.Context, ke
 		return nil, err
 	}
 
-	resources := &workflowRunResources{workflowRun: workflowRun}
-	snapshotName := workflowRun.Status.SnapshotName
-	if snapshotName == "" {
-		snapshotName = workflowSnapshotName(workflowRun)
+	resources := &workflowRunResources{
+		workflowRun:  workflowRun,
+		snapshotName: workflowRunSnapshotName(workflowRun),
+		callPath:     workflowRunCallPath(workflowRun),
 	}
 	revision := &appsv1.ControllerRevision{}
-	if err := r.Get(ctx, client.ObjectKey{Namespace: workflowRun.Namespace, Name: snapshotName}, revision); err == nil {
-		if revision.Labels[v1alpha1.WorkflowRootRunUIDLabel] != string(workflowRun.UID) {
+	if err := r.Get(ctx, client.ObjectKey{Namespace: workflowRun.Namespace, Name: resources.snapshotName}, revision); err == nil {
+		if revision.Labels[v1alpha1.WorkflowRootRunUIDLabel] != workflowRunRootUID(workflowRun) {
 			return nil, fmt.Errorf("workflow snapshot %s/%s belongs to another workflowrun", revision.Namespace, revision.Name)
 		}
 		snapshot, err := loadWorkflowSnapshot(revision)
@@ -139,9 +152,11 @@ func (r *WorkflowRunReconciler) loadWorkflowRunResources(ctx context.Context, ke
 		}
 		resources.snapshot = snapshot
 	} else if !apierrors.IsNotFound(err) {
-		return nil, fmt.Errorf("get workflow snapshot %s/%s: %w", workflowRun.Namespace, snapshotName, err)
+		return nil, fmt.Errorf("get workflow snapshot %s/%s: %w", workflowRun.Namespace, resources.snapshotName, err)
 	} else if workflowRun.Status.SnapshotName != "" {
-		return nil, fmt.Errorf("get workflow snapshot %s/%s: %w", workflowRun.Namespace, snapshotName, err)
+		return nil, fmt.Errorf("get workflow snapshot %s/%s: %w", workflowRun.Namespace, resources.snapshotName, err)
+	} else if workflowRun.Annotations[v1alpha1.WorkflowSnapshotNameAnnotation] != "" {
+		return nil, fmt.Errorf("get workflow snapshot %s/%s: %w", workflowRun.Namespace, resources.snapshotName, err)
 	}
 	if resources.snapshot == nil && workflowRun.Status.Jobs != nil {
 		return nil, fmt.Errorf("workflowrun %s/%s has initialized jobs without an execution snapshot", workflowRun.Namespace, workflowRun.Name)
@@ -161,7 +176,25 @@ func (r *WorkflowRunReconciler) loadWorkflowRunResources(ctx context.Context, ke
 		}
 	}
 
+	var workflowRuns v1alpha1.WorkflowRunList
+	labels = client.MatchingLabels{v1alpha1.WorkflowRootRunUIDLabel: workflowRunRootUID(workflowRun)}
+	if err := r.List(ctx, &workflowRuns, client.InNamespace(workflowRun.Namespace), labels); err != nil {
+		return nil, fmt.Errorf("list child workflowruns for workflowrun %s/%s: %w", workflowRun.Namespace, workflowRun.Name, err)
+	}
+	childWorkflowRuns := make(map[string]*v1alpha1.WorkflowRun)
+	for i := range workflowRuns.Items {
+		child := &workflowRuns.Items[i]
+		jobName, ok := workflowRunChildJobName(workflowRun, child)
+		if !ok {
+			continue
+		}
+		if existing, ok := childWorkflowRuns[jobName]; !ok || child.Name < existing.Name {
+			childWorkflowRuns[jobName] = child.DeepCopy()
+		}
+	}
+
 	resources.childRuns = childRuns
+	resources.childWorkflowRuns = childWorkflowRuns
 	return resources, nil
 }
 
@@ -177,8 +210,15 @@ func calculateWorkflowRunPlan(resources *workflowRunResources) workflowRunPlan {
 	if workflowRun.Spec.CancelRequested {
 		if runNames := childRunsToCancel(resources.childRuns); len(runNames) > 0 {
 			plan.state = workflowRunStateCancelling
-			plan.action = workflowRunActionRequestChildRunCancellation
+			plan.action = workflowRunActionRequestChildCancellation
 			plan.runNames = runNames
+			plan.workflowRunNames = childWorkflowRunsToCancel(resources.childWorkflowRuns)
+			return plan
+		}
+		if workflowRunNames := childWorkflowRunsToCancel(resources.childWorkflowRuns); len(workflowRunNames) > 0 {
+			plan.state = workflowRunStateCancelling
+			plan.action = workflowRunActionRequestChildCancellation
+			plan.workflowRunNames = workflowRunNames
 			return plan
 		}
 	}
@@ -188,12 +228,18 @@ func calculateWorkflowRunPlan(resources *workflowRunResources) workflowRunPlan {
 	if state == workflowRunStateCancelling {
 		return plan
 	}
-	jobs := resources.snapshot.rootJobs()
+	if resources.snapshot == nil {
+		return plan
+	}
+	jobs, ok := resources.snapshot.jobsAt(resources.callPath)
+	if !ok {
+		return plan
+	}
 	if len(jobs) == 0 || len(workflowRun.Status.Jobs) == 0 {
 		return plan
 	}
-	if targets := runnableStepTargets(workflowRun.Status.Jobs, jobs); len(targets) > 0 {
-		plan.action = workflowRunActionStartRunnableSteps
+	if targets := runnableTargets(workflowRun.Status.Jobs, jobs); len(targets) > 0 {
+		plan.action = workflowRunActionStartRunnableTargets
 		plan.targets = targets
 		return plan
 	}
@@ -219,8 +265,11 @@ func workflowRunStateFor(workflowRun *v1alpha1.WorkflowRun) workflowRunState {
 func (r *WorkflowRunReconciler) applyInitializeWorkflowRun(ctx context.Context, resources *workflowRunResources) error {
 	workflowRun := resources.workflowRun
 	snapshot := resources.snapshot
-	snapshotName := workflowRun.Status.SnapshotName
+	snapshotName := resources.snapshotName
 	if snapshot == nil {
+		if workflowRun.Annotations[v1alpha1.WorkflowSnapshotNameAnnotation] != "" {
+			return fmt.Errorf("child workflowrun %s/%s is missing referenced execution snapshot %q", workflowRun.Namespace, workflowRun.Name, snapshotName)
+		}
 		var err error
 		snapshot, err = r.resolveWorkflowRunSnapshot(ctx, workflowRun)
 		if err != nil {
@@ -243,9 +292,16 @@ func (r *WorkflowRunReconciler) applyInitializeWorkflowRun(ctx context.Context, 
 		snapshot = persistedSnapshot
 		resources.snapshot = snapshot
 	}
+	jobs, ok := snapshot.jobsAt(resources.callPath)
+	if !ok {
+		return fmt.Errorf("workflow snapshot %s/%s has no definition at call path %q", workflowRun.Namespace, snapshotName, resources.callPath)
+	}
+	if err := validateResolvedWorkflowJobs(jobs); err != nil {
+		return rejectWorkflowRun(workflowRun, "WorkflowValidationFailed", err.Error())
+	}
 	workflowRun.Status.Phase = v1alpha1.WorkflowPending
 	workflowRun.Status.Message = ""
-	workflowRun.Status.Jobs = resolvedJobStatuses(snapshot.rootJobs())
+	workflowRun.Status.Jobs = resolvedJobStatuses(jobs)
 	workflowRun.Status.SnapshotName = snapshotName
 	setWorkflowRunAcceptedCondition(workflowRun, metav1.ConditionTrue, "Accepted", "WorkflowRun accepted and initialized")
 	return nil
@@ -255,10 +311,10 @@ func (r *WorkflowRunReconciler) applyWorkflowRunAction(ctx context.Context, reso
 	switch plan.action {
 	case workflowRunActionInitialize:
 		return r.applyInitializeWorkflowRun(ctx, resources)
-	case workflowRunActionStartRunnableSteps:
-		return r.applyStartRunnableSteps(ctx, resources, plan.targets)
-	case workflowRunActionRequestChildRunCancellation:
-		return r.applyRequestChildRunCancellation(ctx, resources, plan.runNames)
+	case workflowRunActionStartRunnableTargets:
+		return r.applyStartRunnableTargets(ctx, resources, plan.targets)
+	case workflowRunActionRequestChildCancellation:
+		return r.applyRequestChildCancellation(ctx, resources, plan.runNames, plan.workflowRunNames)
 	}
 	return nil
 }
@@ -268,6 +324,7 @@ func (r *WorkflowRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.WorkflowRun{}).
 		Owns(&v1alpha1.Run{}).
+		Owns(&v1alpha1.WorkflowRun{}).
 		Owns(&appsv1.ControllerRevision{}).
 		Complete(r)
 }
@@ -296,7 +353,10 @@ func validateResolvedWorkflowJobs(jobs map[string]v1alpha1.JobSpec) error {
 	for _, jobName := range jobNames {
 		job := jobs[jobName]
 		if job.Uses != "" {
-			return fmt.Errorf("job %q uses reusable workflow %q, but job-level uses is not implemented yet", jobName, job.Uses)
+			if job.RunsOn != "" || len(job.Steps) > 0 || len(job.Outputs) > 0 {
+				return fmt.Errorf("job %q uses reusable workflow %q and may only set needs, uses, and with", jobName, job.Uses)
+			}
+			continue
 		}
 		if job.RunsOn == "" {
 			return fmt.Errorf("job %q must set runs-on before creating child Runs", jobName)
@@ -421,15 +481,28 @@ func resolvedJobStatuses(jobs map[string]v1alpha1.JobSpec) map[string]v1alpha1.J
 	return statuses
 }
 
-func (r *WorkflowRunReconciler) applyStartRunnableSteps(ctx context.Context, resources *workflowRunResources, targets []workflowRunStepTarget) error {
+func (r *WorkflowRunReconciler) applyStartRunnableTargets(ctx context.Context, resources *workflowRunResources, targets []workflowRunTarget) error {
 	workflowRun := resources.workflowRun
+	jobs, ok := resources.snapshot.jobsAt(resources.callPath)
+	if !ok {
+		return fmt.Errorf("workflow snapshot %s/%s has no definition at call path %q", workflowRun.Namespace, resources.snapshotName, resources.callPath)
+	}
 	for _, target := range targets {
-		job := resources.snapshot.rootJobs()[target.jobName]
-		run, err := r.createOrReuseStepRun(ctx, resources, target.jobName, job, target.stepIndex)
-		if err != nil {
-			return err
+		job := jobs[target.jobName]
+		switch target.kind {
+		case workflowRunTargetStep:
+			run, err := r.createOrReuseStepRun(ctx, resources, target.jobName, job, target.stepIndex)
+			if err != nil {
+				return err
+			}
+			recordStepRun(workflowRun, target.jobName, target.stepIndex, run.Name)
+		case workflowRunTargetCall:
+			child, err := r.createOrReuseChildWorkflowRun(ctx, resources, target.jobName, job)
+			if err != nil {
+				return err
+			}
+			recordChildWorkflowRun(workflowRun, target.jobName, child.Name)
 		}
-		recordStepRun(workflowRun, target.jobName, target.stepIndex, run.Name)
 	}
 	return nil
 }
@@ -459,6 +532,103 @@ func (r *WorkflowRunReconciler) createOrReuseStepRun(ctx context.Context, resour
 	return run, nil
 }
 
+func (r *WorkflowRunReconciler) createOrReuseChildWorkflowRun(ctx context.Context, resources *workflowRunResources, jobName string, job v1alpha1.JobSpec) (*v1alpha1.WorkflowRun, error) {
+	if child := resources.childWorkflowRuns[jobName]; child != nil {
+		return child, nil
+	}
+	parent := resources.workflowRun
+	child := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      workflowChildWorkflowRunName(parent, jobName),
+			Namespace: parent.Namespace,
+			Labels: map[string]string{
+				v1alpha1.WorkflowRootRunUIDLabel: workflowRunRootUID(parent),
+			},
+			Annotations: map[string]string{
+				v1alpha1.WorkflowSnapshotNameAnnotation: resources.snapshotName,
+				v1alpha1.WorkflowCallPathAnnotation:     resources.callPath + "/jobs/" + jobName,
+			},
+		},
+		Spec: v1alpha1.WorkflowRunSpec{
+			Uses: job.Uses,
+			With: maps.Clone(job.With),
+		},
+	}
+	if err := controllerutil.SetControllerReference(parent, child, r.Scheme); err != nil {
+		return nil, fmt.Errorf("set workflowrun owner reference on child workflowrun %s/%s: %w", child.Namespace, child.Name, err)
+	}
+	if err := r.Create(ctx, child); err == nil {
+		return child, nil
+	} else if !apierrors.IsAlreadyExists(err) {
+		return nil, fmt.Errorf("create child workflowrun %s/%s: %w", child.Namespace, child.Name, err)
+	}
+
+	existing := &v1alpha1.WorkflowRun{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(child), existing); err != nil {
+		return nil, fmt.Errorf("get existing child workflowrun %s/%s after create conflict: %w", child.Namespace, child.Name, err)
+	}
+	if _, ok := workflowRunChildJobName(parent, existing); !ok {
+		return nil, fmt.Errorf("existing workflowrun %s/%s does not match child call %q", existing.Namespace, existing.Name, jobName)
+	}
+	return existing, nil
+}
+
+func workflowChildWorkflowRunName(parent *v1alpha1.WorkflowRun, jobName string) string {
+	sum := sha256.Sum256([]byte(string(parent.UID) + "/" + jobName))
+	suffix := hex.EncodeToString(sum[:])[:10]
+	const separator = "-call-"
+	const maxNameLength = 253
+	maxPrefixLength := maxNameLength - len(separator) - len(suffix)
+	prefix := parent.Name
+	if len(prefix) > maxPrefixLength {
+		prefix = strings.TrimRight(prefix[:maxPrefixLength], "-.")
+	}
+	if prefix == "" {
+		return "call-" + suffix
+	}
+	return prefix + separator + suffix
+}
+
+func workflowRunRootUID(workflowRun *v1alpha1.WorkflowRun) string {
+	if rootUID := workflowRun.Labels[v1alpha1.WorkflowRootRunUIDLabel]; rootUID != "" {
+		return rootUID
+	}
+	return string(workflowRun.UID)
+}
+
+func workflowRunSnapshotName(workflowRun *v1alpha1.WorkflowRun) string {
+	if snapshotName := workflowRun.Annotations[v1alpha1.WorkflowSnapshotNameAnnotation]; snapshotName != "" {
+		return snapshotName
+	}
+	if workflowRun.Status.SnapshotName != "" {
+		return workflowRun.Status.SnapshotName
+	}
+	return workflowSnapshotName(workflowRun)
+}
+
+func workflowRunCallPath(workflowRun *v1alpha1.WorkflowRun) string {
+	if callPath := workflowRun.Annotations[v1alpha1.WorkflowCallPathAnnotation]; callPath != "" {
+		return callPath
+	}
+	return "root"
+}
+
+func workflowRunChildJobName(parent *v1alpha1.WorkflowRun, child *v1alpha1.WorkflowRun) (string, bool) {
+	if !metav1.IsControlledBy(child, parent) {
+		return "", false
+	}
+	prefix := workflowRunCallPath(parent) + "/jobs/"
+	callPath := child.Annotations[v1alpha1.WorkflowCallPathAnnotation]
+	if !strings.HasPrefix(callPath, prefix) {
+		return "", false
+	}
+	jobName := strings.TrimPrefix(callPath, prefix)
+	if jobName == "" || strings.Contains(jobName, "/") {
+		return "", false
+	}
+	return jobName, true
+}
+
 func recordStepRun(workflowRun *v1alpha1.WorkflowRun, jobName string, stepIndex int, runName string) {
 	status := workflowRun.Status.Jobs[jobName]
 	status.Phase = v1alpha1.JobRunning
@@ -468,26 +638,43 @@ func recordStepRun(workflowRun *v1alpha1.WorkflowRun, jobName string, stepIndex 
 	workflowRun.Status.Phase = v1alpha1.WorkflowRunning
 }
 
-func runnableStepTargets(statuses map[string]v1alpha1.JobStatus, jobs map[string]v1alpha1.JobSpec) []workflowRunStepTarget {
+func recordChildWorkflowRun(workflowRun *v1alpha1.WorkflowRun, jobName string, workflowRunName string) {
+	status := workflowRun.Status.Jobs[jobName]
+	status.Phase = v1alpha1.JobRunning
+	status.WorkflowRunName = workflowRunName
+	workflowRun.Status.Jobs[jobName] = status
+	workflowRun.Status.Phase = v1alpha1.WorkflowRunning
+}
+
+func runnableTargets(statuses map[string]v1alpha1.JobStatus, jobs map[string]v1alpha1.JobSpec) []workflowRunTarget {
 	jobNames := make([]string, 0, len(jobs))
 	for jobName := range jobs {
 		jobNames = append(jobNames, jobName)
 	}
 	sort.Strings(jobNames)
 
-	targets := make([]workflowRunStepTarget, 0, len(jobNames))
+	targets := make([]workflowRunTarget, 0, len(jobNames))
 	for _, jobName := range jobNames {
 		job := jobs[jobName]
 		status, ok := statuses[jobName]
-		if !ok || len(status.Steps) != len(job.Steps) {
+		if !ok {
+			continue
+		}
+		if job.Uses != "" {
+			if jobReadyToStart(status, statuses) && status.WorkflowRunName == "" {
+				targets = append(targets, workflowRunTarget{kind: workflowRunTargetCall, jobName: jobName})
+			}
+			continue
+		}
+		if len(status.Steps) != len(job.Steps) {
 			continue
 		}
 		if jobReadyToStart(status, statuses) && status.Steps[0].RunName == "" {
-			targets = append(targets, workflowRunStepTarget{jobName: jobName, stepIndex: 0})
+			targets = append(targets, workflowRunTarget{kind: workflowRunTargetStep, jobName: jobName, stepIndex: 0})
 			continue
 		}
 		if stepIndex, ok := nextStepToStart(status); ok {
-			targets = append(targets, workflowRunStepTarget{jobName: jobName, stepIndex: stepIndex})
+			targets = append(targets, workflowRunTarget{kind: workflowRunTargetStep, jobName: jobName, stepIndex: stepIndex})
 		}
 	}
 	return targets
@@ -529,6 +716,7 @@ func terminalJobPhase(status v1alpha1.JobStatus) (v1alpha1.JobPhase, bool) {
 func deriveWorkflowRunStatus(resources *workflowRunResources) {
 	deriveStepStatusesFromChildRuns(resources)
 	deriveJobStatuses(resources.workflowRun)
+	deriveCallJobStatuses(resources)
 	if resources.workflowRun.Spec.CancelRequested {
 		deriveCancelledWorkflowRunStatus(resources)
 		return
@@ -544,6 +732,11 @@ func deriveCancelledWorkflowRunStatus(resources *workflowRunResources) {
 	}
 	for _, run := range resources.childRuns {
 		if !isTerminalRunPhase(run.Status.Phase) {
+			return
+		}
+	}
+	for _, workflowRun := range resources.childWorkflowRuns {
+		if !isTerminalWorkflowPhase(workflowRun.Status.Phase) {
 			return
 		}
 	}
@@ -570,7 +763,18 @@ func childRunsToCancel(childRuns map[string]*v1alpha1.Run) []string {
 	return runNames
 }
 
-func (r *WorkflowRunReconciler) applyRequestChildRunCancellation(ctx context.Context, resources *workflowRunResources, runNames []string) error {
+func childWorkflowRunsToCancel(childWorkflowRuns map[string]*v1alpha1.WorkflowRun) []string {
+	workflowRunNames := make([]string, 0, len(childWorkflowRuns))
+	for _, workflowRun := range childWorkflowRuns {
+		if !isTerminalWorkflowPhase(workflowRun.Status.Phase) && !workflowRun.Spec.CancelRequested {
+			workflowRunNames = append(workflowRunNames, workflowRun.Name)
+		}
+	}
+	sort.Strings(workflowRunNames)
+	return workflowRunNames
+}
+
+func (r *WorkflowRunReconciler) applyRequestChildCancellation(ctx context.Context, resources *workflowRunResources, runNames []string, workflowRunNames []string) error {
 	childRuns := make(map[string]*v1alpha1.Run, len(resources.childRuns))
 	for _, run := range resources.childRuns {
 		childRuns[run.Name] = run
@@ -584,6 +788,21 @@ func (r *WorkflowRunReconciler) applyRequestChildRunCancellation(ctx context.Con
 		run.Spec.CancelRequested = true
 		if err := r.Patch(ctx, run, client.MergeFrom(base)); err != nil {
 			return fmt.Errorf("request cancellation of child run %s/%s: %w", run.Namespace, run.Name, err)
+		}
+	}
+	childWorkflowRuns := make(map[string]*v1alpha1.WorkflowRun, len(resources.childWorkflowRuns))
+	for _, workflowRun := range resources.childWorkflowRuns {
+		childWorkflowRuns[workflowRun.Name] = workflowRun
+	}
+	for _, workflowRunName := range workflowRunNames {
+		workflowRun := childWorkflowRuns[workflowRunName]
+		if workflowRun == nil || workflowRun.Spec.CancelRequested || isTerminalWorkflowPhase(workflowRun.Status.Phase) {
+			continue
+		}
+		base := workflowRun.DeepCopy()
+		workflowRun.Spec.CancelRequested = true
+		if err := r.Patch(ctx, workflowRun, client.MergeFrom(base)); err != nil {
+			return fmt.Errorf("request cancellation of child workflowrun %s/%s: %w", workflowRun.Namespace, workflowRun.Name, err)
 		}
 	}
 	return nil
@@ -617,6 +836,26 @@ func deriveJobStatuses(workflowRun *v1alpha1.WorkflowRun) {
 			continue
 		}
 		status.Phase = phase
+		workflowRun.Status.Jobs[jobName] = status
+	}
+}
+
+func deriveCallJobStatuses(resources *workflowRunResources) {
+	workflowRun := resources.workflowRun
+	for jobName, child := range resources.childWorkflowRuns {
+		status, ok := workflowRun.Status.Jobs[jobName]
+		if !ok || status.WorkflowRunName != "" && status.WorkflowRunName != child.Name {
+			continue
+		}
+		status.WorkflowRunName = child.Name
+		switch child.Status.Phase {
+		case v1alpha1.WorkflowSucceeded:
+			status.Phase = v1alpha1.JobSucceeded
+		case v1alpha1.WorkflowFailed, v1alpha1.WorkflowCancelled:
+			status.Phase = v1alpha1.JobFailed
+		default:
+			status.Phase = v1alpha1.JobRunning
+		}
 		workflowRun.Status.Jobs[jobName] = status
 	}
 }

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -94,7 +94,7 @@ type WorkflowRunReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=kruntimes.io,resources=workflowruns,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=kruntimes.io,resources=workflowruns,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=kruntimes.io,resources=workflowruns/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=kruntimes.io,resources=workflows,verbs=get;list;watch
 // +kubebuilder:rbac:groups=kruntimes.io,resources=runs,verbs=get;list;watch;create;patch

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 )
@@ -153,7 +154,7 @@ func TestWorkflowRunReconcilerStartsAllIndependentReadyJobs(t *testing.T) {
 	reconcileWorkflowRun(t, reconciler, req, 1)
 	assertChildRunCount(t, c, workflowRun.Namespace, 0)
 
-	// A single StartRunnableSteps transition creates all independent ready jobs.
+	// A single StartRunnableTargets transition creates all independent ready jobs.
 	reconcileWorkflowRun(t, reconciler, req, 1)
 	assertChildRunCount(t, c, workflowRun.Namespace, 2)
 	// A subsequent reconcile sees the next step as running and creates nothing.
@@ -178,8 +179,8 @@ func TestCalculateWorkflowRunPlanSeparatesCurrentStateFromAction(t *testing.T) {
 		},
 	}
 	plan = calculateWorkflowRunPlan(&workflowRunResources{workflowRun: pending, snapshot: snapshotForWorkflowRun(pending)})
-	if plan.state != workflowRunStatePending || plan.action != workflowRunActionStartRunnableSteps || len(plan.targets) != 1 || plan.targets[0] != (workflowRunStepTarget{jobName: "build", stepIndex: 0}) {
-		t.Fatalf("pending plan = %#v, want Pending + StartRunnableSteps(build[0])", plan)
+	if plan.state != workflowRunStatePending || plan.action != workflowRunActionStartRunnableTargets || len(plan.targets) != 1 || plan.targets[0] != (workflowRunTarget{jobName: "build", stepIndex: 0}) {
+		t.Fatalf("pending plan = %#v, want Pending + StartRunnableTargets(build[0])", plan)
 	}
 
 	cancelled := pending.DeepCopy()
@@ -197,8 +198,8 @@ func TestCalculateWorkflowRunPlanSeparatesCurrentStateFromAction(t *testing.T) {
 		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): activeRun},
 		snapshot:    snapshotForWorkflowRun(cancelling),
 	})
-	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildRunCancellation || !slices.Equal(plan.runNames, []string{"build-run"}) {
-		t.Fatalf("cancelling plan = %#v, want Cancelling + RequestChildRunCancellation(build-run)", plan)
+	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildCancellation || !slices.Equal(plan.runNames, []string{"build-run"}) {
+		t.Fatalf("cancelling plan = %#v, want Cancelling + RequestChildCancellation(build-run)", plan)
 	}
 
 	// A late child Run watch must repair an early Cancelled projection caused by
@@ -209,7 +210,7 @@ func TestCalculateWorkflowRunPlanSeparatesCurrentStateFromAction(t *testing.T) {
 		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): activeRun},
 		snapshot:    snapshotForWorkflowRun(cancelling),
 	})
-	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildRunCancellation || !slices.Equal(plan.runNames, []string{"build-run"}) {
+	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildCancellation || !slices.Equal(plan.runNames, []string{"build-run"}) {
 		t.Fatalf("late child plan = %#v, want cancellation repair", plan)
 	}
 }
@@ -241,9 +242,9 @@ func TestCalculateWorkflowRunPlanProjectsStatusBeforeStartingReadyJobs(t *testin
 		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): buildRun},
 		snapshot:    snapshotForWorkflowRun(workflowRun),
 	})
-	want := []workflowRunStepTarget{{jobName: "lint", stepIndex: 0}}
-	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableSteps || !slices.Equal(plan.targets, want) {
-		t.Fatalf("plan = %#v, want Running + StartRunnableSteps(%#v)", plan, want)
+	want := []workflowRunTarget{{jobName: "lint", stepIndex: 0}}
+	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableTargets || !slices.Equal(plan.targets, want) {
+		t.Fatalf("plan = %#v, want Running + StartRunnableTargets(%#v)", plan, want)
 	}
 	if workflowRun.Status.Jobs["build"].Phase != v1alpha1.JobSucceeded {
 		t.Fatalf("build status = %#v, want derived succeeded job", workflowRun.Status.Jobs["build"])
@@ -266,9 +267,9 @@ func TestPlanWorkflowRunStartsAllRunnableSteps(t *testing.T) {
 	}
 
 	plan := calculateWorkflowRunPlan(&workflowRunResources{workflowRun: workflowRun, snapshot: snapshotForWorkflowRun(workflowRun)})
-	want := []workflowRunStepTarget{{jobName: "build", stepIndex: 1}, {jobName: "lint", stepIndex: 0}}
-	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableSteps || !slices.Equal(plan.targets, want) {
-		t.Fatalf("plan = %#v, want Running + StartRunnableSteps(%#v)", plan, want)
+	want := []workflowRunTarget{{jobName: "build", stepIndex: 1}, {jobName: "lint", stepIndex: 0}}
+	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableTargets || !slices.Equal(plan.targets, want) {
+		t.Fatalf("plan = %#v, want Running + StartRunnableTargets(%#v)", plan, want)
 	}
 }
 
@@ -288,9 +289,9 @@ func TestCalculateWorkflowRunPlanFinalizesJobsBeforeStartingReadyJobs(t *testing
 	}
 
 	plan := calculateWorkflowRunPlan(&workflowRunResources{workflowRun: workflowRun, snapshot: snapshotForWorkflowRun(workflowRun)})
-	want := []workflowRunStepTarget{{jobName: "lint", stepIndex: 0}}
-	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableSteps || !slices.Equal(plan.targets, want) {
-		t.Fatalf("plan = %#v, want Running + StartRunnableSteps(%#v)", plan, want)
+	want := []workflowRunTarget{{jobName: "lint", stepIndex: 0}}
+	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableTargets || !slices.Equal(plan.targets, want) {
+		t.Fatalf("plan = %#v, want Running + StartRunnableTargets(%#v)", plan, want)
 	}
 	if workflowRun.Status.Jobs["build"].Phase != v1alpha1.JobSucceeded {
 		t.Fatalf("build status = %#v, want derived succeeded job", workflowRun.Status.Jobs["build"])
@@ -364,7 +365,7 @@ func TestWorkflowRunReconcilerSkipsBlockedJobsAndStartsIndependentJobs(t *testin
 	}
 }
 
-func TestWorkflowRunReconcilerRejectsUnsupportedJobLevelUsesDuringInitialization(t *testing.T) {
+func TestWorkflowRunReconcilerCreatesChildWorkflowRunForJobLevelUses(t *testing.T) {
 	scheme := workflowRunTestScheme(t)
 
 	workflowRun := &v1alpha1.WorkflowRun{
@@ -400,18 +401,262 @@ func TestWorkflowRunReconcilerRejectsUnsupportedJobLevelUsesDuringInitialization
 	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
 		t.Fatalf("get workflowrun: %v", err)
 	}
-	if updated.Status.Phase != v1alpha1.WorkflowFailed {
-		t.Fatalf("phase = %q, want %q", updated.Status.Phase, v1alpha1.WorkflowFailed)
+	if updated.Status.Phase != v1alpha1.WorkflowRunning {
+		t.Fatalf("phase = %q, want %q", updated.Status.Phase, v1alpha1.WorkflowRunning)
 	}
-	if !strings.Contains(updated.Status.Message, "job-level uses is not implemented yet") {
-		t.Fatalf("message = %q, want job-level uses not implemented", updated.Status.Message)
+	job := updated.Status.Jobs["release"]
+	if job.Phase != v1alpha1.JobRunning || job.WorkflowRunName == "" || len(job.Steps) != 0 {
+		t.Fatalf("job = %#v, want running call job with child workflowrun", job)
 	}
-	if updated.Status.Jobs != nil {
-		t.Fatalf("jobs = %#v, want nil for rejected workflowrun", updated.Status.Jobs)
+	var children v1alpha1.WorkflowRunList
+	if err := c.List(context.Background(), &children, client.InNamespace(workflowRun.Namespace)); err != nil {
+		t.Fatalf("list child workflowruns: %v", err)
 	}
-	cond := apimeta.FindStatusCondition(updated.Status.Conditions, v1alpha1.WorkflowRunAcceptedCondition)
-	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WorkflowValidationFailed" {
-		t.Fatalf("condition = %#v, want validation rejection", cond)
+	if len(children.Items) != 2 {
+		t.Fatalf("workflowruns = %#v, want parent and child", children.Items)
+	}
+	var child *v1alpha1.WorkflowRun
+	for i := range children.Items {
+		if children.Items[i].Name == updated.Name {
+			continue
+		}
+		child = &children.Items[i]
+	}
+	if child == nil || child.Name != job.WorkflowRunName || child.Spec.Uses != workflow.Name || child.Annotations[v1alpha1.WorkflowSnapshotNameAnnotation] != updated.Status.SnapshotName || child.Annotations[v1alpha1.WorkflowCallPathAnnotation] != "root/jobs/release" {
+		t.Fatalf("child = %#v, want snapshot-bound release child", child)
+	}
+	if !metav1.IsControlledBy(child, &updated) {
+		t.Fatalf("child owner = %#v, want parent workflowrun", child.OwnerReferences)
+	}
+}
+
+func TestWorkflowRunReconcilerInitializesChildWorkflowRunFromParentSnapshot(t *testing.T) {
+	scheme := workflowRunTestScheme(t)
+	workflow := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "deploy", Namespace: "default"},
+		Spec: v1alpha1.WorkflowSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"apply": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "run", Run: "echo snapshot"}}},
+		}},
+	}
+	parent := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default", UID: "release-uid"},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"deploy": {Uses: workflow.Name},
+		}},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(workflow, parent).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	parentRequest := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(parent)}
+	reconcileWorkflowRun(t, reconciler, parentRequest, 2)
+
+	var parentUpdated v1alpha1.WorkflowRun
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(parent), &parentUpdated); err != nil {
+		t.Fatalf("get parent workflowrun: %v", err)
+	}
+	childName := parentUpdated.Status.Jobs["deploy"].WorkflowRunName
+	child := &v1alpha1.WorkflowRun{}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: parent.Namespace, Name: childName}, child); err != nil {
+		t.Fatalf("get child workflowrun: %v", err)
+	}
+
+	workflow.Spec.Jobs["apply"] = v1alpha1.JobSpec{RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "run", Run: "echo mutable"}}}
+	if err := c.Update(context.Background(), workflow); err != nil {
+		t.Fatalf("mutate reusable workflow: %v", err)
+	}
+	reconcileWorkflowRun(t, reconciler, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(child)}, 2)
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(child), child); err != nil {
+		t.Fatalf("refresh child workflowrun: %v", err)
+	}
+
+	var runs v1alpha1.RunList
+	if err := c.List(context.Background(), &runs, client.InNamespace(parent.Namespace)); err != nil {
+		t.Fatalf("list child runs: %v", err)
+	}
+	if len(runs.Items) != 1 || runs.Items[0].Spec.Source == nil || runs.Items[0].Spec.Source.Inline == nil || *runs.Items[0].Spec.Source.Inline != "echo snapshot" {
+		t.Fatalf("child runs = %#v, want execution from parent snapshot", runs.Items)
+	}
+	if child.Status.SnapshotName != parentUpdated.Status.SnapshotName {
+		t.Fatalf("child snapshotName = %q, want %q", child.Status.SnapshotName, parentUpdated.Status.SnapshotName)
+	}
+}
+
+func TestCalculateWorkflowRunPlanProjectsChildWorkflowRunTerminalState(t *testing.T) {
+	parent := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", UID: "release-uid"},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"deploy": {Uses: "deploy-workflow"},
+			"notify": {RunsOn: "bash", Needs: []string{"deploy"}, Steps: []v1alpha1.StepSpec{{Name: "send", Run: "notify"}}},
+		}},
+		Status: v1alpha1.WorkflowRunStatus{
+			Phase: v1alpha1.WorkflowRunning,
+			Jobs: map[string]v1alpha1.JobStatus{
+				"deploy": {Phase: v1alpha1.JobRunning, WorkflowRunName: "release-call"},
+				"notify": {Phase: v1alpha1.JobWaiting, Pre: []string{"deploy"}, Steps: []v1alpha1.StepStatus{{Name: "send", Phase: v1alpha1.StepPending}}},
+			},
+		},
+	}
+	child := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release-call"},
+		Status:     v1alpha1.WorkflowRunStatus{Phase: v1alpha1.WorkflowSucceeded},
+	}
+	plan := calculateWorkflowRunPlan(&workflowRunResources{
+		workflowRun:       parent,
+		childWorkflowRuns: map[string]*v1alpha1.WorkflowRun{"deploy": child},
+		snapshot:          snapshotForWorkflowRun(parent),
+	})
+	want := []workflowRunTarget{{jobName: "notify", stepIndex: 0}}
+	if plan.action != workflowRunActionStartRunnableTargets || !slices.Equal(plan.targets, want) {
+		t.Fatalf("plan = %#v, want runnable notify step", plan)
+	}
+	if parent.Status.Jobs["deploy"].Phase != v1alpha1.JobSucceeded {
+		t.Fatalf("deploy = %#v, want succeeded from child workflowrun", parent.Status.Jobs["deploy"])
+	}
+}
+
+func TestCalculateWorkflowRunPlanCancelsActiveChildWorkflowRun(t *testing.T) {
+	parent := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", UID: "release-uid"},
+		Spec:       v1alpha1.WorkflowRunSpec{CancelRequested: true},
+		Status:     v1alpha1.WorkflowRunStatus{Phase: v1alpha1.WorkflowRunning, Jobs: map[string]v1alpha1.JobStatus{}},
+	}
+	child := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release-call"},
+		Status:     v1alpha1.WorkflowRunStatus{Phase: v1alpha1.WorkflowRunning},
+	}
+	plan := calculateWorkflowRunPlan(&workflowRunResources{
+		workflowRun:       parent,
+		childWorkflowRuns: map[string]*v1alpha1.WorkflowRun{"deploy": child},
+		snapshot:          snapshotForWorkflowRun(parent),
+	})
+	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildCancellation || !slices.Equal(plan.workflowRunNames, []string{"release-call"}) {
+		t.Fatalf("plan = %#v, want cancellation of active child workflowrun", plan)
+	}
+}
+
+func TestWorkflowRunReconcilerReusesChildWorkflowRunCreatedBeforeParentStatus(t *testing.T) {
+	scheme := workflowRunTestScheme(t)
+	workflow := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "deploy", Namespace: "default"},
+		Spec: v1alpha1.WorkflowSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"apply": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "run", Run: "deploy"}}},
+		}},
+	}
+	parent := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default", UID: "release-uid"},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"deploy": {Uses: workflow.Name},
+		}},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(workflow, parent).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	snapshot, err := reconciler.resolveWorkflowRunSnapshot(context.Background(), parent)
+	if err != nil {
+		t.Fatalf("resolve parent snapshot: %v", err)
+	}
+	snapshotName, _, err := reconciler.ensureWorkflowSnapshot(context.Background(), parent, snapshot)
+	if err != nil {
+		t.Fatalf("persist parent snapshot: %v", err)
+	}
+	child := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      workflowChildWorkflowRunName(parent, "deploy"),
+			Namespace: parent.Namespace,
+			Labels: map[string]string{
+				v1alpha1.WorkflowRootRunUIDLabel: string(parent.UID),
+			},
+			Annotations: map[string]string{
+				v1alpha1.WorkflowSnapshotNameAnnotation: snapshotName,
+				v1alpha1.WorkflowCallPathAnnotation:     "root/jobs/deploy",
+			},
+		},
+		Spec: v1alpha1.WorkflowRunSpec{Uses: workflow.Name},
+	}
+	if err := controllerutil.SetControllerReference(parent, child, scheme); err != nil {
+		t.Fatalf("set child owner: %v", err)
+	}
+	if err := c.Create(context.Background(), child); err != nil {
+		t.Fatalf("create child workflowrun: %v", err)
+	}
+
+	request := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(parent)}
+	reconcileWorkflowRun(t, reconciler, request, 2)
+
+	var updated v1alpha1.WorkflowRun
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(parent), &updated); err != nil {
+		t.Fatalf("get parent workflowrun: %v", err)
+	}
+	if updated.Status.Jobs["deploy"].WorkflowRunName != child.Name {
+		t.Fatalf("deploy = %#v, want existing child %q", updated.Status.Jobs["deploy"], child.Name)
+	}
+	var children v1alpha1.WorkflowRunList
+	if err := c.List(context.Background(), &children, client.InNamespace(parent.Namespace)); err != nil {
+		t.Fatalf("list workflowruns: %v", err)
+	}
+	if len(children.Items) != 2 {
+		t.Fatalf("workflowruns = %#v, want parent and existing child only", children.Items)
+	}
+}
+
+func TestWorkflowRunReconcilerRequestsCancellationOfChildWorkflowRun(t *testing.T) {
+	scheme := workflowRunTestScheme(t)
+	workflow := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "deploy", Namespace: "default"},
+		Spec: v1alpha1.WorkflowSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"apply": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "run", Run: "deploy"}}},
+		}},
+	}
+	parent := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default", UID: "release-uid"},
+		Spec: v1alpha1.WorkflowRunSpec{
+			Jobs:            map[string]v1alpha1.JobSpec{"deploy": {Uses: workflow.Name}},
+			CancelRequested: true,
+		},
+		Status: v1alpha1.WorkflowRunStatus{
+			Phase: v1alpha1.WorkflowRunning,
+			Jobs: map[string]v1alpha1.JobStatus{
+				"deploy": {Phase: v1alpha1.JobRunning, WorkflowRunName: "release-call"},
+			},
+		},
+	}
+	child := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "release-call",
+			Namespace: parent.Namespace,
+			Labels: map[string]string{
+				v1alpha1.WorkflowRootRunUIDLabel: string(parent.UID),
+			},
+			Annotations: map[string]string{
+				v1alpha1.WorkflowCallPathAnnotation: "root/jobs/deploy",
+			},
+		},
+		Spec:   v1alpha1.WorkflowRunSpec{Uses: workflow.Name},
+		Status: v1alpha1.WorkflowRunStatus{Phase: v1alpha1.WorkflowRunning},
+	}
+	if err := controllerutil.SetControllerReference(parent, child, scheme); err != nil {
+		t.Fatalf("set child owner: %v", err)
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(workflow, parent, child).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	reconcileWorkflowRun(t, reconciler, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(parent)}, 1)
+
+	var updated v1alpha1.WorkflowRun
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(child), &updated); err != nil {
+		t.Fatalf("get child workflowrun: %v", err)
+	}
+	if !updated.Spec.CancelRequested {
+		t.Fatalf("child spec = %#v, want cancellation request", updated.Spec)
 	}
 }
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -437,6 +437,36 @@ func waitForAnyTerminalRunPhase(t *testing.T, run *v1alpha1.Run, timeout time.Du
 	}
 }
 
+func waitForWorkflowRunPhase(t *testing.T, workflowRun *v1alpha1.WorkflowRun, timeout time.Duration, expected v1alpha1.WorkflowPhase) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var lastPhase v1alpha1.WorkflowPhase
+	for {
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(workflowRun), workflowRun); err != nil {
+			t.Fatalf("get workflowrun: %v", err)
+		}
+		if workflowRun.Status.Phase != lastPhase {
+			t.Logf("WorkflowRun %s: phase=%s", workflowRun.Name, workflowRun.Status.Phase)
+			lastPhase = workflowRun.Status.Phase
+		}
+
+		switch workflowRun.Status.Phase {
+		case expected:
+			return
+		case v1alpha1.WorkflowSucceeded, v1alpha1.WorkflowFailed, v1alpha1.WorkflowCancelled:
+			t.Fatalf("expected phase=%s, got phase=%s, message=%s", expected, workflowRun.Status.Phase, workflowRun.Status.Message)
+		}
+
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for WorkflowRun %s, last phase=%s, message=%s", workflowRun.Name, workflowRun.Status.Phase, workflowRun.Status.Message)
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
 func findRunCondition(run *v1alpha1.Run, typ string) *metav1.Condition {
 	for i := range run.Status.Conditions {
 		if run.Status.Conditions[i].Type == typ {
@@ -539,6 +569,70 @@ func TestFullRunLifecycle(t *testing.T) {
 		t.Fatalf("success message contains stdout: %q", run.Status.Message)
 	}
 	t.Logf("Run completed successfully: %s", run.Status.Message)
+}
+
+func TestWorkflowRunCallsReusableWorkflow(t *testing.T) {
+	ensureRuntime(t, "bash", bashRuntimeImage(), 9091)
+
+	workflow := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "e2e-reusable-workflow-",
+			Namespace:    testNamespace,
+		},
+		Spec: v1alpha1.WorkflowSpec{
+			Jobs: map[string]v1alpha1.JobSpec{
+				"build": {
+					RunsOn: "bash",
+					Steps: []v1alpha1.StepSpec{{
+						Name: "package",
+						Run:  "echo reusable-workflow",
+					}},
+				},
+			},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), workflow); err != nil {
+		t.Fatalf("create reusable workflow: %v", err)
+	}
+
+	parent := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "e2e-workflow-call-",
+			Namespace:    testNamespace,
+		},
+		Spec: v1alpha1.WorkflowRunSpec{
+			Jobs: map[string]v1alpha1.JobSpec{
+				"release": {Uses: workflow.Name},
+			},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), parent); err != nil {
+		t.Fatalf("create parent workflowrun: %v", err)
+	}
+
+	waitForWorkflowRunPhase(t, parent, 60*time.Second, v1alpha1.WorkflowSucceeded)
+	job, ok := parent.Status.Jobs["release"]
+	if !ok {
+		t.Fatal("parent WorkflowRun does not report the release job")
+	}
+	if job.Phase != v1alpha1.JobSucceeded {
+		t.Fatalf("parent release job phase=%s, want Succeeded", job.Phase)
+	}
+	if job.WorkflowRunName == "" {
+		t.Fatal("parent release job does not reference its child WorkflowRun")
+	}
+
+	child := &v1alpha1.WorkflowRun{}
+	if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: testNamespace, Name: job.WorkflowRunName}, child); err != nil {
+		t.Fatalf("get child workflowrun: %v", err)
+	}
+	if child.Status.Phase != v1alpha1.WorkflowSucceeded {
+		t.Fatalf("child WorkflowRun phase=%s, want Succeeded", child.Status.Phase)
+	}
+	childJob, ok := child.Status.Jobs["build"]
+	if !ok || len(childJob.Steps) != 1 || childJob.Steps[0].RunName == "" {
+		t.Fatalf("child WorkflowRun build status=%#v, want one executed step", childJob)
+	}
 }
 
 func TestFilesystemArtifacts(t *testing.T) {


### PR DESCRIPTION
## Summary
- execute a job-level `uses` call as an owned child WorkflowRun
- bind nested calls to the root immutable execution snapshot and reuse existing children after controller recovery
- project child terminal state into the caller Job and propagate cancellation
- reject unsupported outputs on reusable workflow call jobs

## Tests
- `make test`
- `make test-integration`
- `make test-helm`