### PR TITLE
fix(benchmark): measure Run lifecycle from status timestamps

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -75,16 +75,20 @@ covers backlog drain after earlier Runs finish.
 
 ### Output Fields
 
-- `latency.schedule`: benchmark-observed time from local create request start
-  until the scheduler assigns a Runtime Pod.
-- `latency.dispatch`: benchmark-observed time from local create request start
-  until runtimed marks the Run started.
-- `latency.execution`: benchmark-observed time from Run start to terminal Run
-  status. This excludes benchmark backlog queueing before runtimed starts the
-  Run, but it is still bounded by the benchmark poll interval.
-- `latency.complete`: benchmark-observed time from local create request start
-  until terminal Run status. This is end-to-end latency and includes time
-  waiting for Runtime capacity when the benchmark is capacity constrained.
+- `latency.schedule`: time from local create request start until the scheduler
+  writes the `Scheduled=True` condition.
+- `latency.dispatch`: time from local create request start until runtimed writes
+  `status.startTime`.
+- `latency.execution`: time from `status.startTime` to
+  `status.completionTime`. This excludes queueing before runtimed starts the
+  Run.
+- `latency.complete`: time from local create request start until
+  `status.completionTime`. This is end-to-end latency and includes time waiting
+  for Runtime capacity when the benchmark is capacity constrained.
+
+The harness polls the Kubernetes API to discover state changes, but it derives
+lifecycle latency from the timestamps written into `Run.status`; the polling
+interval therefore does not inflate a reported transition duration.
 - `throughput.runsPerSecond`: successful terminal Runs divided by benchmark wall
   time.
 - `capacity.maxObservedRunningRuns`: maximum concurrent Running Runs observed

--- a/docs/benchmarks.zh.md
+++ b/docs/benchmarks.zh.md
@@ -72,16 +72,17 @@ drain。
 
 ### 输出字段
 
-- `latency.schedule`：benchmark observer 从本地 create request start 到 scheduler 分配
-  Runtime Pod 的观测时间。
-- `latency.dispatch`：benchmark observer 从本地 create request start 到 runtimed 将 Run
-  标记为 started 的观测时间。
-- `latency.execution`：benchmark observer 从 Run start 到 Run 进入 terminal status 的观测
-  时间。它不包含 runtimed 启动 Run 前的 benchmark backlog queueing，但仍受 benchmark
-  poll interval 影响。
-- `latency.complete`：benchmark observer 从本地 create request start 到 terminal Run status
-  的观测时间。这是端到端 latency；当 benchmark 受 capacity 限制时，它会包含等待 Runtime
-  capacity 的时间。
+- `latency.schedule`：从本地 create request start 到 scheduler 写入
+  `Scheduled=True` condition 的时间。
+- `latency.dispatch`：从本地 create request start 到 runtimed 写入
+  `status.startTime` 的时间。
+- `latency.execution`：从 `status.startTime` 到 `status.completionTime` 的时间。
+  它不包含 runtimed 启动 Run 前的 queueing。
+- `latency.complete`：从本地 create request start 到 `status.completionTime` 的时间。
+  这是端到端 latency；当 benchmark 受 capacity 限制时，它会包含等待 Runtime capacity 的时间。
+
+Harness 会通过轮询 Kubernetes API 发现状态变化，但生命周期延迟取自写入
+`Run.status` 的 timestamps；因此 poll interval 不会放大报告中的 transition duration。
 - `throughput.runsPerSecond`：成功 terminal Runs 除以 benchmark wall time。
 - `capacity.maxObservedRunningRuns`：polling 期间观察到的最大并发 Running Runs 数。
 - `capacity.observedPendingAtCapacity`：当所有配置的 Runtime slots 被占用时，是否观察到

--- a/hack/benchmark/main.go
+++ b/hack/benchmark/main.go
@@ -13,6 +13,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -24,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	"github.com/kruntimes/kruntimes/internal/runstatus"
 	"github.com/kruntimes/kruntimes/internal/runtimepod"
 )
 
@@ -520,7 +522,6 @@ func waitForAllTerminal(ctx context.Context, k8sClient client.Client, opts optio
 		}
 		*listLatencies = append(*listLatencies, time.Since(start))
 
-		now := time.Now()
 		runningByPod := map[string]int{}
 		terminal := 0
 		for i := range list.Items {
@@ -531,15 +532,7 @@ func waitForAllTerminal(ctx context.Context, k8sClient client.Client, opts optio
 			}
 			obs.Phase = run.Status.Phase
 			obs.AssignedPod = run.Status.AssignedPod
-			if obs.ScheduledAt.IsZero() && run.Status.AssignedPod != "" {
-				obs.ScheduledAt = now
-			}
-			if obs.StartedAt.IsZero() && run.Status.StartTime != nil {
-				obs.StartedAt = now
-			}
-			if obs.FinishedAt.IsZero() && isTerminal(run.Status.Phase) {
-				obs.FinishedAt = now
-			}
+			observeRunLifecycle(obs, run)
 			if run.Status.AssignedPod != "" {
 				key := run.Name + "/" + run.Status.AssignedPod
 				if _, ok := assignedSeen[key]; !ok {
@@ -570,6 +563,24 @@ func waitForAllTerminal(ctx context.Context, k8sClient client.Client, opts optio
 		return fmt.Errorf("wait for benchmark Runs to finish: %w", err)
 	}
 	return nil
+}
+
+// observeRunLifecycle records controller-written lifecycle timestamps rather
+// than the benchmark's next polling time. Polling is only used to discover the
+// latest status object.
+func observeRunLifecycle(obs *runObservation, run *v1alpha1.Run) {
+	if obs.ScheduledAt.IsZero() {
+		condition := apimeta.FindStatusCondition(run.Status.Conditions, runstatus.ConditionScheduled)
+		if condition != nil && condition.Status == metav1.ConditionTrue {
+			obs.ScheduledAt = condition.LastTransitionTime.Time
+		}
+	}
+	if obs.StartedAt.IsZero() && run.Status.StartTime != nil {
+		obs.StartedAt = run.Status.StartTime.Time
+	}
+	if obs.FinishedAt.IsZero() && run.Status.CompletionTime != nil {
+		obs.FinishedAt = run.Status.CompletionTime.Time
+	}
 }
 
 func benchmarkRun(opts options, benchID string, index int, sleep time.Duration) *v1alpha1.Run {

--- a/hack/benchmark/main_test.go
+++ b/hack/benchmark/main_test.go
@@ -4,7 +4,10 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	"github.com/kruntimes/kruntimes/internal/runstatus"
 )
 
 func TestSummarize(t *testing.T) {
@@ -73,5 +76,29 @@ func TestBuildReportSeparatesExecutionFromEndToEndLatency(t *testing.T) {
 	}
 	if report.Latency.Complete.Count != 1 || report.Latency.Complete.P50MS != 2500 {
 		t.Fatalf("complete latency = %#v, want one 2500ms sample", report.Latency.Complete)
+	}
+}
+
+func TestObserveRunLifecycleUsesStatusTimestamps(t *testing.T) {
+	createdAt := time.Unix(100, 0)
+	scheduledAt := metav1.NewTime(createdAt.Add(100 * time.Millisecond))
+	startedAt := metav1.NewTime(createdAt.Add(200 * time.Millisecond))
+	completedAt := metav1.NewTime(createdAt.Add(500 * time.Millisecond))
+	obs := &runObservation{CreatedAt: createdAt}
+	run := &v1alpha1.Run{Status: v1alpha1.RunStatus{
+		Phase:          v1alpha1.RunSucceeded,
+		StartTime:      &startedAt,
+		CompletionTime: &completedAt,
+		Conditions: []metav1.Condition{{
+			Type:               runstatus.ConditionScheduled,
+			Status:             metav1.ConditionTrue,
+			LastTransitionTime: scheduledAt,
+		}},
+	}}
+
+	observeRunLifecycle(obs, run)
+
+	if !obs.ScheduledAt.Equal(scheduledAt.Time) || !obs.StartedAt.Equal(startedAt.Time) || !obs.FinishedAt.Equal(completedAt.Time) {
+		t.Fatalf("observation = %#v, want status timestamps", obs)
 	}
 }


### PR DESCRIPTION
## Summary
- derive schedule, start, and completion observations from controller-written Run status timestamps
- keep polling only for status discovery, so the poll interval does not inflate lifecycle latency
- document the corrected metric definitions in English and Chinese

## Tests
- `go test ./hack/benchmark -count=1`
- `make site-build`
- `make test`
- `make test-integration`