### PR TITLE
feat(scheduler): honor Run affinity constraints

### DIFF
--- a/internal/scheduler/affinity.go
+++ b/internal/scheduler/affinity.go
@@ -15,78 +15,111 @@ func filterCandidatesByRequiredRunAffinity(run *v1alpha1.Run, candidates []corev
 		return candidates, nil
 	}
 
+	requiredMatches, antiMatches, err := requiredRunAffinityMatchSets(run, runs)
+	if err != nil {
+		return nil, err
+	}
+
 	filtered := make([]corev1.Pod, 0, len(candidates))
 	for i := range candidates {
 		pod := &candidates[i]
-		matches, err := satisfiesRequiredRunAffinity(run, pod, runs)
-		if err != nil {
-			return nil, err
-		}
-		if matches {
+		if satisfiesRequiredRunAffinity(pod, requiredMatches, antiMatches) {
 			filtered = append(filtered, *pod)
 		}
 	}
 	return filtered, nil
 }
 
-func satisfiesRequiredRunAffinity(run *v1alpha1.Run, pod *corev1.Pod, runs []v1alpha1.Run) (bool, error) {
+func requiredRunAffinityMatchSets(run *v1alpha1.Run, runs []v1alpha1.Run) ([]map[string]bool, []map[string]bool, error) {
 	if run == nil || run.Spec.Affinity == nil {
-		return true, nil
+		return nil, nil, nil
 	}
+
+	var requiredMatches, antiMatches []map[string]bool
 	if rules := run.Spec.Affinity.RunAffinity; rules != nil {
+		requiredMatches = make([]map[string]bool, 0, len(rules.RequiredDuringSchedulingIgnoredDuringExecution))
 		for _, term := range rules.RequiredDuringSchedulingIgnoredDuringExecution {
 			matches, err := matchingRunPods(run, term, runs)
 			if err != nil {
-				return false, err
+				return nil, nil, err
 			}
-			if !matches[pod.Name] {
-				return false, nil
-			}
+			requiredMatches = append(requiredMatches, matches)
 		}
 	}
 	if rules := run.Spec.Affinity.RunAntiAffinity; rules != nil {
+		antiMatches = make([]map[string]bool, 0, len(rules.RequiredDuringSchedulingIgnoredDuringExecution))
 		for _, term := range rules.RequiredDuringSchedulingIgnoredDuringExecution {
 			matches, err := matchingRunPods(run, term, runs)
 			if err != nil {
-				return false, err
+				return nil, nil, err
 			}
-			if matches[pod.Name] {
-				return false, nil
-			}
+			antiMatches = append(antiMatches, matches)
 		}
 	}
-	return true, nil
+	return requiredMatches, antiMatches, nil
 }
 
-func preferredRunAffinityScore(run *v1alpha1.Run, pod *corev1.Pod, runs []v1alpha1.Run) (int32, error) {
+func satisfiesRequiredRunAffinity(pod *corev1.Pod, requiredMatches, antiMatches []map[string]bool) bool {
+	for _, matches := range requiredMatches {
+		if !matches[pod.Name] {
+			return false
+		}
+	}
+	for _, matches := range antiMatches {
+		if matches[pod.Name] {
+			return false
+		}
+	}
+	return true
+}
+
+type weightedRunAffinityMatches struct {
+	weight int32
+	pods   map[string]bool
+}
+
+func preferredRunAffinityMatchSets(run *v1alpha1.Run, runs []v1alpha1.Run) ([]weightedRunAffinityMatches, []weightedRunAffinityMatches, error) {
 	if run == nil || run.Spec.Affinity == nil {
-		return 0, nil
+		return nil, nil, nil
 	}
 
-	var score int32
+	var preferredMatches, antiMatches []weightedRunAffinityMatches
 	if rules := run.Spec.Affinity.RunAffinity; rules != nil {
+		preferredMatches = make([]weightedRunAffinityMatches, 0, len(rules.PreferredDuringSchedulingIgnoredDuringExecution))
 		for _, weighted := range rules.PreferredDuringSchedulingIgnoredDuringExecution {
 			matches, err := matchingRunPods(run, weighted.RunAffinityTerm, runs)
 			if err != nil {
-				return 0, err
+				return nil, nil, err
 			}
-			if matches[pod.Name] {
-				score += weighted.Weight
-			}
+			preferredMatches = append(preferredMatches, weightedRunAffinityMatches{weight: weighted.Weight, pods: matches})
 		}
 	}
 	if rules := run.Spec.Affinity.RunAntiAffinity; rules != nil {
+		antiMatches = make([]weightedRunAffinityMatches, 0, len(rules.PreferredDuringSchedulingIgnoredDuringExecution))
 		for _, weighted := range rules.PreferredDuringSchedulingIgnoredDuringExecution {
 			matches, err := matchingRunPods(run, weighted.RunAffinityTerm, runs)
 			if err != nil {
-				return 0, err
+				return nil, nil, err
 			}
-			if !matches[pod.Name] {
-				score += weighted.Weight
-			}
+			antiMatches = append(antiMatches, weightedRunAffinityMatches{weight: weighted.Weight, pods: matches})
 		}
 	}
-	return score, nil
+	return preferredMatches, antiMatches, nil
+}
+
+func preferredRunAffinityScoreForMatches(pod *corev1.Pod, preferredMatches, antiMatches []weightedRunAffinityMatches) int32 {
+	var score int32
+	for _, matches := range preferredMatches {
+		if matches.pods[pod.Name] {
+			score += matches.weight
+		}
+	}
+	for _, matches := range antiMatches {
+		if !matches.pods[pod.Name] {
+			score += matches.weight
+		}
+	}
+	return score
 }
 
 func matchingRunPods(run *v1alpha1.Run, term v1alpha1.RunAffinityTerm, runs []v1alpha1.Run) (map[string]bool, error) {

--- a/internal/scheduler/affinity.go
+++ b/internal/scheduler/affinity.go
@@ -1,0 +1,123 @@
+package scheduler
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+func filterCandidatesByRequiredRunAffinity(run *v1alpha1.Run, candidates []corev1.Pod, runs []v1alpha1.Run) ([]corev1.Pod, error) {
+	if run == nil || run.Spec.Affinity == nil {
+		return candidates, nil
+	}
+
+	filtered := make([]corev1.Pod, 0, len(candidates))
+	for i := range candidates {
+		pod := &candidates[i]
+		matches, err := satisfiesRequiredRunAffinity(run, pod, runs)
+		if err != nil {
+			return nil, err
+		}
+		if matches {
+			filtered = append(filtered, *pod)
+		}
+	}
+	return filtered, nil
+}
+
+func satisfiesRequiredRunAffinity(run *v1alpha1.Run, pod *corev1.Pod, runs []v1alpha1.Run) (bool, error) {
+	if run == nil || run.Spec.Affinity == nil {
+		return true, nil
+	}
+	if rules := run.Spec.Affinity.RunAffinity; rules != nil {
+		for _, term := range rules.RequiredDuringSchedulingIgnoredDuringExecution {
+			matches, err := matchingRunPods(run, term, runs)
+			if err != nil {
+				return false, err
+			}
+			if !matches[pod.Name] {
+				return false, nil
+			}
+		}
+	}
+	if rules := run.Spec.Affinity.RunAntiAffinity; rules != nil {
+		for _, term := range rules.RequiredDuringSchedulingIgnoredDuringExecution {
+			matches, err := matchingRunPods(run, term, runs)
+			if err != nil {
+				return false, err
+			}
+			if matches[pod.Name] {
+				return false, nil
+			}
+		}
+	}
+	return true, nil
+}
+
+func preferredRunAffinityScore(run *v1alpha1.Run, pod *corev1.Pod, runs []v1alpha1.Run) (int32, error) {
+	if run == nil || run.Spec.Affinity == nil {
+		return 0, nil
+	}
+
+	var score int32
+	if rules := run.Spec.Affinity.RunAffinity; rules != nil {
+		for _, weighted := range rules.PreferredDuringSchedulingIgnoredDuringExecution {
+			matches, err := matchingRunPods(run, weighted.RunAffinityTerm, runs)
+			if err != nil {
+				return 0, err
+			}
+			if matches[pod.Name] {
+				score += weighted.Weight
+			}
+		}
+	}
+	if rules := run.Spec.Affinity.RunAntiAffinity; rules != nil {
+		for _, weighted := range rules.PreferredDuringSchedulingIgnoredDuringExecution {
+			matches, err := matchingRunPods(run, weighted.RunAffinityTerm, runs)
+			if err != nil {
+				return 0, err
+			}
+			if !matches[pod.Name] {
+				score += weighted.Weight
+			}
+		}
+	}
+	return score, nil
+}
+
+func matchingRunPods(run *v1alpha1.Run, term v1alpha1.RunAffinityTerm, runs []v1alpha1.Run) (map[string]bool, error) {
+	if term.TopologyKey != v1alpha1.RunAffinityTopologyRuntimePod {
+		return nil, fmt.Errorf("unsupported run affinity topology key %q", term.TopologyKey)
+	}
+	if term.LabelSelector == nil {
+		return nil, fmt.Errorf("run affinity term has no label selector")
+	}
+	selector, err := metav1.LabelSelectorAsSelector(term.LabelSelector)
+	if err != nil {
+		return nil, fmt.Errorf("parse run affinity label selector: %w", err)
+	}
+
+	matches := make(map[string]bool)
+	for i := range runs {
+		target := &runs[i]
+		if target.Namespace != run.Namespace || isSameRun(run, target) || !isActiveAffinityTarget(target) {
+			continue
+		}
+		if selector.Matches(labels.Set(target.Labels)) {
+			matches[target.Status.AssignedPod] = true
+		}
+	}
+	return matches, nil
+}
+
+func isSameRun(left, right *v1alpha1.Run) bool {
+	return left.Namespace == right.Namespace && left.Name == right.Name
+}
+
+func isActiveAffinityTarget(run *v1alpha1.Run) bool {
+	return run.Status.AssignedPod != "" && consumesRuntimeCapacity(run.Status.Phase)
+}

--- a/internal/scheduler/affinity_test.go
+++ b/internal/scheduler/affinity_test.go
@@ -1,0 +1,112 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+func TestFilterCandidatesByRequiredRunAffinity(t *testing.T) {
+	run := affinityRun("next", v1alpha1.RunAffinity{
+		RunAffinity: &v1alpha1.RunAffinityRules{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1alpha1.RunAffinityTerm{affinityTerm("stage", "build")},
+		},
+	})
+	runs := []v1alpha1.Run{
+		activeAffinityRun("build", "pod-a", map[string]string{"stage": "build"}),
+		activeAffinityRun("other", "pod-b", map[string]string{"stage": "other"}),
+	}
+	candidates, err := filterCandidatesByRequiredRunAffinity(run, affinityPods(), runs)
+	if err != nil {
+		t.Fatalf("filter candidates: %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].Name != "pod-a" {
+		t.Fatalf("candidates = %#v, want pod-a only", candidates)
+	}
+}
+
+func TestFilterCandidatesByRequiredRunAntiAffinity(t *testing.T) {
+	run := affinityRun("next", v1alpha1.RunAffinity{
+		RunAntiAffinity: &v1alpha1.RunAffinityRules{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1alpha1.RunAffinityTerm{affinityTerm("stage", "build")},
+		},
+	})
+	runs := []v1alpha1.Run{activeAffinityRun("build", "pod-a", map[string]string{"stage": "build"})}
+	candidates, err := filterCandidatesByRequiredRunAffinity(run, affinityPods(), runs)
+	if err != nil {
+		t.Fatalf("filter candidates: %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].Name != "pod-b" {
+		t.Fatalf("candidates = %#v, want pod-b only", candidates)
+	}
+}
+
+func TestPreferredRunAffinityScoresBeforeLeastLoaded(t *testing.T) {
+	run := affinityRun("next", v1alpha1.RunAffinity{
+		RunAffinity: &v1alpha1.RunAffinityRules{
+			PreferredDuringSchedulingIgnoredDuringExecution: []v1alpha1.WeightedRunAffinityTerm{{
+				Weight:          100,
+				RunAffinityTerm: affinityTerm("stage", "build"),
+			}},
+		},
+	})
+	runs := []v1alpha1.Run{activeAffinityRun("build", "pod-a", map[string]string{"stage": "build"})}
+	pod, err := (&LeastLoaded{}).Select(context.Background(), affinityPods(), run, runs)
+	if err != nil {
+		t.Fatalf("select pod: %v", err)
+	}
+	if pod.Name != "pod-a" {
+		t.Fatalf("selected pod = %q, want preferred affinity pod-a", pod.Name)
+	}
+}
+
+func TestMatchingRunPodsIgnoresTerminalAndSelfRuns(t *testing.T) {
+	run := affinityRun("next", v1alpha1.RunAffinity{})
+	term := affinityTerm("stage", "build")
+	runs := []v1alpha1.Run{
+		activeAffinityRun("next", "pod-a", map[string]string{"stage": "build"}),
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "finished", Namespace: "default", Labels: map[string]string{"stage": "build"}},
+			Status:     v1alpha1.RunStatus{Phase: v1alpha1.RunSucceeded, AssignedPod: "pod-b"},
+		},
+	}
+	matches, err := matchingRunPods(run, term, runs)
+	if err != nil {
+		t.Fatalf("matching run pods: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("matches = %#v, want no terminal or self targets", matches)
+	}
+}
+
+func affinityRun(name string, affinity v1alpha1.RunAffinity) *v1alpha1.Run {
+	return &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       v1alpha1.RunSpec{Affinity: &affinity},
+	}
+}
+
+func activeAffinityRun(name, pod string, labels map[string]string) v1alpha1.Run {
+	return v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", Labels: labels},
+		Status:     v1alpha1.RunStatus{Phase: v1alpha1.RunRunning, AssignedPod: pod},
+	}
+}
+
+func affinityTerm(label, value string) v1alpha1.RunAffinityTerm {
+	return v1alpha1.RunAffinityTerm{
+		LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{label: value}},
+		TopologyKey:   v1alpha1.RunAffinityTopologyRuntimePod,
+	}
+}
+
+func affinityPods() []corev1.Pod {
+	return []corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "default"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: "default"}},
+	}
+}

--- a/internal/scheduler/reconciler.go
+++ b/internal/scheduler/reconciler.go
@@ -125,10 +125,11 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, fmt.Errorf("list runtime pods: %w", err)
 	}
 
-	usageByPod, err := r.assignedRunUsage(ctx, req.Namespace)
+	runs, err := r.assignedRuns(ctx, req.Namespace)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("list assigned runs: %w", err)
 	}
+	usageByPod := assignedRunUsage(runs)
 
 	now := time.Now()
 	var candidates []corev1.Pod
@@ -137,12 +138,20 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			candidates = append(candidates, pod)
 		}
 	}
+	availableCandidates := len(candidates)
+	candidates, err = filterCandidatesByRequiredRunAffinity(&run, candidates, runs)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("filter candidates by run affinity: %w", err)
+	}
 
 	if len(candidates) == 0 {
 		noPodsTotal.WithLabelValues(run.Spec.Runtime).Inc()
 		log.Info("No available runtime pods", "runtime", run.Spec.Runtime)
 
 		message := fmt.Sprintf("waiting for available runtime pods for runtime %q", run.Spec.Runtime)
+		if availableCandidates > 0 {
+			message = fmt.Sprintf("waiting for runtime pods satisfying affinity constraints for runtime %q", run.Spec.Runtime)
+		}
 		if run.Status.Phase != v1alpha1.RunPending || run.Status.Message != message {
 			run.Status.Phase = v1alpha1.RunPending
 			run.Status.Message = message
@@ -154,7 +163,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
-	selected, err := r.Strategy.Select(ctx, r.Client, candidates, &run)
+	selected, err := r.Strategy.Select(ctx, candidates, &run, runs)
 	if err != nil {
 		noPodsTotal.WithLabelValues(run.Spec.Runtime).Inc()
 
@@ -247,14 +256,17 @@ func (r *RunReconciler) isRuntimePodAvailable(pod *corev1.Pod, now time.Time, us
 	return usage < capacity
 }
 
-func (r *RunReconciler) assignedRunUsage(ctx context.Context, namespace string) (map[string]int32, error) {
+func (r *RunReconciler) assignedRuns(ctx context.Context, namespace string) ([]v1alpha1.Run, error) {
 	var runs v1alpha1.RunList
 	if err := r.List(ctx, &runs, client.InNamespace(namespace)); err != nil {
 		return nil, err
 	}
+	return runs.Items, nil
+}
 
+func assignedRunUsage(runs []v1alpha1.Run) map[string]int32 {
 	usage := make(map[string]int32)
-	for _, run := range runs.Items {
+	for _, run := range runs {
 		if run.Status.AssignedPod == "" {
 			continue
 		}
@@ -263,7 +275,7 @@ func (r *RunReconciler) assignedRunUsage(ctx context.Context, namespace string) 
 			usage[run.Status.AssignedPod]++
 		}
 	}
-	return usage, nil
+	return usage
 }
 
 func pendingRetryDelay(run *v1alpha1.Run) time.Duration {

--- a/internal/scheduler/reconciler.go
+++ b/internal/scheduler/reconciler.go
@@ -141,7 +141,13 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	availableCandidates := len(candidates)
 	candidates, err = filterCandidatesByRequiredRunAffinity(&run, candidates, runs)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("filter candidates by run affinity: %w", err)
+		run.Status.Phase = v1alpha1.RunFailed
+		run.Status.Message = fmt.Sprintf("run affinity evaluation failed: %v", err)
+		if err := r.Status().Update(ctx, &run); err != nil {
+			return ctrl.Result{}, fmt.Errorf("update run status after affinity evaluation: %w", err)
+		}
+		runsScheduled.WithLabelValues(run.Spec.Runtime, "affinity_error").Inc()
+		return ctrl.Result{}, nil
 	}
 
 	if len(candidates) == 0 {

--- a/internal/scheduler/reconciler_test.go
+++ b/internal/scheduler/reconciler_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
@@ -210,6 +211,72 @@ func TestReconcileRecordsScheduledCondition(t *testing.T) {
 	condition := meta.FindStatusCondition(updated.Status.Conditions, runstatus.ConditionScheduled)
 	if condition == nil || condition.Status != metav1.ConditionTrue || condition.Reason != "Assigned" {
 		t.Fatalf("Scheduled condition = %#v, want true/Assigned", condition)
+	}
+}
+
+func TestReconcileSchedulesRunToRequiredAffinityPod(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add kruntimes scheme: %v", err)
+	}
+
+	now := metav1.Now()
+	readyPod := func(name string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels:    map[string]string{"runtime": "bash"},
+				Annotations: map[string]string{
+					runtimepod.CapacityAnnotation(v1alpha1.RuntimeResourceRuns): "2",
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					{Type: v1alpha1.RuntimePodRuntimedReadyCondition, Status: corev1.ConditionTrue, LastProbeTime: now},
+				},
+			},
+		}
+	}
+
+	target := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "build", Namespace: "default", Labels: map[string]string{"stage": "build"}},
+		Spec:       v1alpha1.RunSpec{Runtime: "bash"},
+		Status:     v1alpha1.RunStatus{Phase: v1alpha1.RunRunning, AssignedPod: "runtime-a"},
+	}
+	run := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+		Spec: v1alpha1.RunSpec{
+			Runtime: "bash",
+			Affinity: &v1alpha1.RunAffinity{RunAffinity: &v1alpha1.RunAffinityRules{
+				RequiredDuringSchedulingIgnoredDuringExecution: []v1alpha1.RunAffinityTerm{{
+					LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"stage": "build"}},
+					TopologyKey:   v1alpha1.RunAffinityTopologyRuntimePod,
+				}},
+			}},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.Run{}).
+		WithObjects(run, target, readyPod("runtime-a"), readyPod("runtime-b")).
+		Build()
+	reconciler := &RunReconciler{Client: k8sClient, Log: logr.Discard(), Strategy: &LeastLoaded{}}
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	var updated v1alpha1.Run
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(run), &updated); err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if updated.Status.Phase != v1alpha1.RunScheduled || updated.Status.AssignedPod != "runtime-a" {
+		t.Fatalf("status = %#v, want Scheduled on runtime-a", updated.Status)
 	}
 }
 

--- a/internal/scheduler/reconciler_test.go
+++ b/internal/scheduler/reconciler_test.go
@@ -280,6 +280,61 @@ func TestReconcileSchedulesRunToRequiredAffinityPod(t *testing.T) {
 	}
 }
 
+func TestReconcileFailsRunForInvalidRequiredAffinity(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add kruntimes scheme: %v", err)
+	}
+
+	now := metav1.Now()
+	run := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "invalid-affinity", Namespace: "default"},
+		Spec: v1alpha1.RunSpec{
+			Runtime: "bash",
+			Affinity: &v1alpha1.RunAffinity{RunAffinity: &v1alpha1.RunAffinityRules{
+				RequiredDuringSchedulingIgnoredDuringExecution: []v1alpha1.RunAffinityTerm{{
+					LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"stage": "build"}},
+					TopologyKey:   "invalid.topology",
+				}},
+			}},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "runtime-a", Namespace: "default", Labels: map[string]string{"runtime": "bash"}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				{Type: v1alpha1.RuntimePodRuntimedReadyCondition, Status: corev1.ConditionTrue, LastProbeTime: now},
+			},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&v1alpha1.Run{}).
+		WithObjects(run, pod).
+		Build()
+	reconciler := &RunReconciler{Client: k8sClient, Log: logr.Discard(), Strategy: &LeastLoaded{}}
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	var updated v1alpha1.Run
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(run), &updated); err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if updated.Status.Phase != v1alpha1.RunFailed {
+		t.Fatalf("phase = %s, want Failed", updated.Status.Phase)
+	}
+	if !strings.Contains(updated.Status.Message, "run affinity evaluation failed") {
+		t.Fatalf("message = %q, want affinity failure", updated.Status.Message)
+	}
+}
+
 func TestIsPodSchedulableRequiresReadyRunningPod(t *testing.T) {
 	now := metav1.Now()
 	tests := []struct {

--- a/internal/scheduler/strategy.go
+++ b/internal/scheduler/strategy.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 )
@@ -16,5 +15,5 @@ type Strategy interface {
 
 	// Select returns the most suitable pod for the run.
 	// Returns nil and an error if no pod can be selected.
-	Select(ctx context.Context, c client.Client, candidates []corev1.Pod, run *v1alpha1.Run) (*corev1.Pod, error)
+	Select(ctx context.Context, candidates []corev1.Pod, run *v1alpha1.Run, runs []v1alpha1.Run) (*corev1.Pod, error)
 }

--- a/internal/scheduler/strategy_leastloaded.go
+++ b/internal/scheduler/strategy_leastloaded.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 	"github.com/kruntimes/kruntimes/internal/runtimepod"
@@ -17,7 +16,7 @@ type LeastLoaded struct{}
 
 func (s *LeastLoaded) Name() string { return "least-loaded" }
 
-func (s *LeastLoaded) Select(ctx context.Context, c client.Client, candidates []corev1.Pod, run *v1alpha1.Run) (*corev1.Pod, error) {
+func (s *LeastLoaded) Select(_ context.Context, candidates []corev1.Pod, run *v1alpha1.Run, runs []v1alpha1.Run) (*corev1.Pod, error) {
 	if len(candidates) == 0 {
 		return nil, fmt.Errorf("no candidate pods")
 	}
@@ -26,6 +25,7 @@ func (s *LeastLoaded) Select(ctx context.Context, c client.Client, candidates []
 		pod       *corev1.Pod
 		load      int
 		available int32
+		affinity  int32
 	}
 
 	pods := make([]podLoad, 0, len(candidates))
@@ -35,15 +35,8 @@ func (s *LeastLoaded) Select(ctx context.Context, c client.Client, candidates []
 			continue
 		}
 
-		var tasks v1alpha1.RunList
-		if err := c.List(ctx, &tasks,
-			client.InNamespace(pod.Namespace),
-		); err != nil {
-			continue
-		}
-
 		count := 0
-		for _, t := range tasks.Items {
+		for _, t := range runs {
 			if t.Status.AssignedPod != pod.Name {
 				continue
 			}
@@ -52,7 +45,11 @@ func (s *LeastLoaded) Select(ctx context.Context, c client.Client, candidates []
 			}
 		}
 		capacity := runtimepod.RunsCapacity(pod, v1alpha1.RuntimeDefaultRunsCapacity)
-		pods = append(pods, podLoad{pod: pod, load: count, available: capacity - int32(count)})
+		score, err := preferredRunAffinityScore(run, pod, runs)
+		if err != nil {
+			return nil, err
+		}
+		pods = append(pods, podLoad{pod: pod, load: count, available: capacity - int32(count), affinity: score})
 	}
 
 	if len(pods) == 0 {
@@ -60,6 +57,9 @@ func (s *LeastLoaded) Select(ctx context.Context, c client.Client, candidates []
 	}
 
 	sort.Slice(pods, func(i, j int) bool {
+		if pods[i].affinity != pods[j].affinity {
+			return pods[i].affinity > pods[j].affinity
+		}
 		if pods[i].available != pods[j].available {
 			return pods[i].available > pods[j].available
 		}

--- a/internal/scheduler/strategy_leastloaded.go
+++ b/internal/scheduler/strategy_leastloaded.go
@@ -11,7 +11,8 @@ import (
 	"github.com/kruntimes/kruntimes/internal/runtimepod"
 )
 
-// LeastLoaded selects the pod with the fewest Running tasks.
+// LeastLoaded prefers the highest preferred Run affinity score, then the pod
+// with the most available Run capacity and the fewest assigned active Runs.
 type LeastLoaded struct{}
 
 func (s *LeastLoaded) Name() string { return "least-loaded" }
@@ -19,6 +20,10 @@ func (s *LeastLoaded) Name() string { return "least-loaded" }
 func (s *LeastLoaded) Select(_ context.Context, candidates []corev1.Pod, run *v1alpha1.Run, runs []v1alpha1.Run) (*corev1.Pod, error) {
 	if len(candidates) == 0 {
 		return nil, fmt.Errorf("no candidate pods")
+	}
+	preferredMatches, preferredAntiMatches, err := preferredRunAffinityMatchSets(run, runs)
+	if err != nil {
+		return nil, err
 	}
 
 	type podLoad struct {
@@ -45,10 +50,7 @@ func (s *LeastLoaded) Select(_ context.Context, candidates []corev1.Pod, run *v1
 			}
 		}
 		capacity := runtimepod.RunsCapacity(pod, v1alpha1.RuntimeDefaultRunsCapacity)
-		score, err := preferredRunAffinityScore(run, pod, runs)
-		if err != nil {
-			return nil, err
-		}
+		score := preferredRunAffinityScoreForMatches(pod, preferredMatches, preferredAntiMatches)
 		pods = append(pods, podLoad{pod: pod, load: count, available: capacity - int32(count), affinity: score})
 	}
 

--- a/internal/scheduler/strategy_test.go
+++ b/internal/scheduler/strategy_test.go
@@ -6,18 +6,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 	"github.com/kruntimes/kruntimes/internal/runtimepod"
 )
 
 func TestLeastLoaded_Select(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = v1alpha1.AddToScheme(scheme)
-
 	tests := []struct {
 		name    string
 		pods    []corev1.Pod
@@ -119,18 +113,9 @@ func TestLeastLoaded_Select(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			objs := []runtime.Object{}
-			for i := range tt.pods {
-				objs = append(objs, &tt.pods[i])
-			}
-			for i := range tt.tasks {
-				objs = append(objs, &tt.tasks[i])
-			}
-
-			client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).Build()
 			s := &LeastLoaded{}
 
-			pod, err := s.Select(context.Background(), client, tt.pods, tt.run)
+			pod, err := s.Select(context.Background(), tt.pods, tt.run, tt.tasks)
 			if tt.wantErr {
 				if err == nil {
 					t.Error("expected error, got nil")
@@ -148,19 +133,14 @@ func TestLeastLoaded_Select(t *testing.T) {
 }
 
 func TestLeastLoaded_DeterministicTiebreak(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = v1alpha1.AddToScheme(scheme)
-
 	pods := []corev1.Pod{
 		{ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: "default"}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "default"}},
 	}
 
-	client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects().Build()
 	s := &LeastLoaded{}
 
-	pod, err := s.Select(context.Background(), client, pods, &v1alpha1.Run{})
+	pod, err := s.Select(context.Background(), pods, &v1alpha1.Run{}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/scheduler/strategy_test.go
+++ b/internal/scheduler/strategy_test.go
@@ -15,7 +15,7 @@ func TestLeastLoaded_Select(t *testing.T) {
 	tests := []struct {
 		name    string
 		pods    []corev1.Pod
-		tasks   []v1alpha1.Run
+		runs    []v1alpha1.Run
 		run     *v1alpha1.Run
 		wantPod string
 		wantErr bool
@@ -40,7 +40,7 @@ func TestLeastLoaded_Select(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "default"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: "default"}},
 			},
-			tasks: []v1alpha1.Run{
+			runs: []v1alpha1.Run{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "run-1", Namespace: "default"},
 					Status:     v1alpha1.RunStatus{Phase: v1alpha1.RunRunning, AssignedPod: "pod-a"},
@@ -59,7 +59,7 @@ func TestLeastLoaded_Select(t *testing.T) {
 				{ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "default"}},
 				{ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: "default"}},
 			},
-			tasks: []v1alpha1.Run{
+			runs: []v1alpha1.Run{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "ready-function", Namespace: "default"},
 					Status:     v1alpha1.RunStatus{Phase: v1alpha1.RunReady, AssignedPod: "pod-a"},
@@ -115,7 +115,7 @@ func TestLeastLoaded_Select(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &LeastLoaded{}
 
-			pod, err := s.Select(context.Background(), tt.pods, tt.run, tt.tasks)
+			pod, err := s.Select(context.Background(), tt.pods, tt.run, tt.runs)
 			if tt.wantErr {
 				if err == nil {
 					t.Error("expected error, got nil")


### PR DESCRIPTION
## Summary
- filter Runtime Pod candidates with required Run affinity and anti-affinity
- score preferred affinity before existing capacity/load tie breakers
- keep Runs Pending when no ready capacity candidate satisfies required constraints
- load namespace Runs once for usage, constraints, and scoring
- add focused scheduler and reconciler coverage

The implementation follows the reviewed Run workspace and affinity design without adding or changing any API surface.