### PR TITLE
docs(workspace): define RuntimePodLocal binding lifecycle

### DIFF
--- a/docs/design/workflow-data-sharing.md
+++ b/docs/design/workflow-data-sharing.md
@@ -136,6 +136,34 @@ PVC-backed `PersistentWorkspace` behavior. The first implementation can still
 ship `RuntimePodLocal` against the existing `emptyDir` behavior, but the design
 should not bake in emptyDir as the only backing store.
 
+### Proposed RuntimePodLocal Binding Lifecycle
+
+The binding controller should use the following v0.x rules:
+
+1. An unbound workspace waits while its referenced Runtime has no ready Runtime
+   Pods. It does not consume or reserve Run capacity while waiting or after it
+   is bound.
+2. When candidates exist, the controller selects the lexicographically first
+   ready Runtime Pod. The choice is deterministic for a stable Pod set; later
+   scheduling work uses `status.boundPod` rather than trying to repeat this
+   selection.
+3. The controller records `status.phase: Bound`, `status.runtime`,
+   `status.boundPod`, and the planned local path
+   `/workspace/persistent/<workspace-name>`. It does not create the directory
+   itself: runtimed creates it when a referenced Run starts.
+4. A Bound workspace remains bound while its Pod exists, even if that Pod is
+   temporarily not ready. The status conditions make the availability problem
+   visible, and Runs referring to it stay Pending until later scheduler and
+   runtimed work can use that binding safely.
+5. If the bound Pod is deleted or no longer exists, the workspace becomes
+   `Lost`. The controller must not silently bind it to another Pod: for
+   `RuntimePodLocal`, that would make a caller observe a new empty directory as
+   though it contained the original data. Recovery requires an explicit new
+   workspace or a future reviewed recovery API.
+
+Binding is metadata-only in this slice. TTL cleanup, filesystem deletion,
+`lastUsedTime`, and Run admission/preparation remain separate follow-up work.
+
 ## Run Workspace Reference
 
 Runs should be able to reference a workspace through a small typed object
@@ -292,7 +320,8 @@ workspace capacity or failing because its controller-owned workspace was lost.
 ## Failure and Recovery
 
 - If a Runtime Pod disappears, `RuntimePodLocal` workspaces backed by that Pod's
-  workspace volume become unavailable.
+  workspace volume become `Lost`; they are not automatically rebound to another
+  Pod.
 - Runs that require an unavailable workspace should stay Pending or fail with a
   clear workspace condition, depending on retry policy and controller decision.
 - The Workflow controller should surface workspace-related failures in Workflow
@@ -327,10 +356,12 @@ Required safeguards:
 5. Add Kubernetes-style Run affinity/anti-affinity fields.
 6. Update scheduler placement to respect required/preferred Run affinity while
    keeping no-capacity Runs Pending.
-7. Update runtimed workspace preparation and cleanup for referenced
+7. Bind `RuntimePodLocal` PersistentWorkspaces to ready Runtime Pods and record
+   their lifecycle status without touching runtime filesystems.
+8. Update runtimed workspace preparation and cleanup for referenced
    workspaces.
-8. Add Workflow step artifact input fields and job-scoped artifact status.
-9. Promote child Run artifact refs into Workflow status.
-10. Add E2E coverage for Runtime workspace volume sources, job-local workspace
+9. Add Workflow step artifact input fields and job-scoped artifact status.
+10. Promote child Run artifact refs into Workflow status.
+11. Add E2E coverage for Runtime workspace volume sources, job-local workspace
    sharing, job-to-job artifact
    passing, Runtime Pod loss, cleanup, and permission boundaries.

--- a/docs/design/workflow-data-sharing.md
+++ b/docs/design/workflow-data-sharing.md
@@ -143,14 +143,14 @@ The binding controller should use the following v0.x rules:
 1. An unbound workspace waits while its referenced Runtime has no ready Runtime
    Pods. It does not consume or reserve Run capacity while waiting or after it
    is bound.
-2. When candidates exist, the controller selects the lexicographically first
-   ready Runtime Pod. The choice is deterministic for a stable Pod set; later
-   scheduling work uses `status.boundPod` rather than trying to repeat this
-   selection.
+2. When candidates exist, the controller sorts ready Runtime Pods by
+   `metadata.name` and selects the lexicographically first Pod. The choice is
+   deterministic for a stable Pod set; later scheduling work uses
+   `status.boundPod` rather than trying to repeat this selection.
 3. The controller records `status.phase: Bound`, `status.runtime`,
-   `status.boundPod`, and the planned local path
-   `/workspace/persistent/<workspace-name>`. It does not create the directory
-   itself: runtimed creates it when a referenced Run starts.
+   `status.boundPod`, and `status.path: /workspace/persistent/<workspace-name>`.
+   It does not create the directory itself: runtimed creates it when a
+   referenced Run starts.
 4. A Bound workspace remains bound while its Pod exists, even if that Pod is
    temporarily not ready. The status conditions make the availability problem
    visible, and Runs referring to it stay Pending until later scheduler and

--- a/docs/design/workflow-data-sharing.zh.md
+++ b/docs/design/workflow-data-sharing.zh.md
@@ -131,11 +131,12 @@ binding controller 在 v0.x 中应遵循以下规则：
 
 1. 未绑定 workspace 在其引用的 Runtime 没有 ready Runtime Pods 时保持等待。无论等待或已经绑定，
    它都不会消耗或预留 Run capacity。
-2. 有候选 Pod 时，controller 选择按名称字典序最小的 ready Runtime Pod。在稳定 Pod 集合下该选择是
-   deterministic 的；后续调度工作使用 `status.boundPod`，而不是试图重复这个选择。
+2. 有候选 Pod 时，controller 先按 `metadata.name` 对 ready Runtime Pod 排序，再选择名称字典序最小的
+   Pod。在稳定 Pod 集合下该选择是 deterministic 的；后续调度工作使用 `status.boundPod`，而不是试图
+   重复这个选择。
 3. controller 记录 `status.phase: Bound`、`status.runtime`、`status.boundPod`，以及计划使用的本地
-   路径 `/workspace/persistent/<workspace-name>`。controller 不会自行创建目录；runtimed 在引用它的
-   Run 启动时创建。
+   `status.path: /workspace/persistent/<workspace-name>`。controller 不会自行创建目录；runtimed 在引用
+   它的 Run 启动时创建。
 4. Bound workspace 在 Pod 仍存在时保持绑定，即使该 Pod 暂时不 ready。status conditions 会让
    availability 问题可见；引用它的 Runs 将保持 Pending，直到后续 scheduler 和 runtimed 工作能够
    安全地使用这个 binding。

--- a/docs/design/workflow-data-sharing.zh.md
+++ b/docs/design/workflow-data-sharing.zh.md
@@ -125,6 +125,27 @@ Runtime workspace volume 的扩展是 durable 或 PVC-backed `PersistentWorkspac
 第一版仍可以基于现有 `emptyDir` 行为实现 `RuntimePodLocal`，但设计上不应把 emptyDir 固化为
 唯一 backing store。
 
+### 建议的 RuntimePodLocal Binding Lifecycle
+
+binding controller 在 v0.x 中应遵循以下规则：
+
+1. 未绑定 workspace 在其引用的 Runtime 没有 ready Runtime Pods 时保持等待。无论等待或已经绑定，
+   它都不会消耗或预留 Run capacity。
+2. 有候选 Pod 时，controller 选择按名称字典序最小的 ready Runtime Pod。在稳定 Pod 集合下该选择是
+   deterministic 的；后续调度工作使用 `status.boundPod`，而不是试图重复这个选择。
+3. controller 记录 `status.phase: Bound`、`status.runtime`、`status.boundPod`，以及计划使用的本地
+   路径 `/workspace/persistent/<workspace-name>`。controller 不会自行创建目录；runtimed 在引用它的
+   Run 启动时创建。
+4. Bound workspace 在 Pod 仍存在时保持绑定，即使该 Pod 暂时不 ready。status conditions 会让
+   availability 问题可见；引用它的 Runs 将保持 Pending，直到后续 scheduler 和 runtimed 工作能够
+   安全地使用这个 binding。
+5. bound Pod 被删除或不再存在时，workspace 变为 `Lost`。controller 不得静默地把它绑定到另一个
+   Pod：对于 `RuntimePodLocal`，那会让调用者把新的空目录误认为原有数据。恢复需要显式创建新的
+   workspace，或等待未来经过 review 的 recovery API。
+
+这个 binding slice 仅写入 metadata。TTL cleanup、filesystem deletion、`lastUsedTime` 和 Run
+admission/preparation 都是独立的后续工作。
+
 ## Run Workspace Reference
 
 Runs 应能通过一个小的 typed object reference 引用 workspace。`PersistentWorkspace` 是这个
@@ -273,7 +294,7 @@ job 正在等待本地 workspace capacity，或者因为 controller-owned worksp
 ## 失败和恢复
 
 - 如果 Runtime Pod 消失，由该 Pod workspace volume 支撑的 `RuntimePodLocal` workspaces 变为
-  不可用。
+  `Lost`；它们不会自动 rebind 到另一个 Pod。
 - 需要不可用 workspace 的 Runs 应保持 Pending，或根据 retry policy/controller decision 以清晰
   workspace condition 失败。
 - Workflow controller 应通过 Workflow conditions 或 messages 暴露 workspace-related
@@ -307,8 +328,10 @@ job 正在等待本地 workspace capacity，或者因为 controller-owned worksp
 5. 增加 Kubernetes-style Run affinity/anti-affinity fields。
 6. 更新 scheduler placement，使其支持 required/preferred Run affinity，同时保持无 capacity
    Runs Pending。
-7. 更新 runtimed workspace preparation 和 cleanup，使其支持 referenced workspaces。
-8. 增加 Workflow step artifact input fields 和 job-scoped artifact status。
-9. 将 child Run artifact refs 提升到 Workflow status。
-10. 增加 E2E 覆盖 Runtime workspace volume sources、job-local workspace sharing、
+7. 将 `RuntimePodLocal` PersistentWorkspaces 绑定到 ready Runtime Pods，并记录 lifecycle
+   status，不修改 runtime filesystems。
+8. 更新 runtimed workspace preparation 和 cleanup，使其支持 referenced workspaces。
+9. 增加 Workflow step artifact input fields 和 job-scoped artifact status。
+10. 将 child Run artifact refs 提升到 Workflow status。
+11. 增加 E2E 覆盖 Runtime workspace volume sources、job-local workspace sharing、
    job-to-job artifact passing、Runtime Pod loss、cleanup 和 permission boundaries。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -189,6 +189,9 @@ wiring from accumulating avoidable conflicts.
   - [x] add Run fields for workspace reference and Kubernetes-style Run affinity;
   - update scheduler placement to respect required/preferred Run affinity while
     keeping no-capacity Runs Pending;
+  - [ ] review and define `RuntimePodLocal` binding semantics: deterministic
+    ready-Pod selection without capacity reservation, planned path ownership,
+    and sticky `Lost` status after bound-Pod deletion;
   - update runtimed workspace preparation and cleanup to support referenced
     persistent workspaces without knowing Workflow semantics;
   - promote child Run artifact refs into Workflow status and add explicit step

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -166,6 +166,8 @@ controller wiring 累积不必要的冲突。
   - [x] 为 Run 增加 workspace reference 和 Kubernetes-style Run affinity 字段；
   - 更新 scheduler placement，使其支持 required/preferred Run affinity，同时在无 capacity
     时继续保持 Run Pending；
+  - [ ] review 并定义 `RuntimePodLocal` binding semantics：不预留 capacity 的 deterministic
+    ready-Pod selection、planned path ownership，以及 bound-Pod deletion 后 sticky `Lost` status；
   - 更新 runtimed workspace preparation 和 cleanup，使其支持被引用的 persistent workspace，
     但不感知 Workflow 语义；
   - 将 child Run artifact refs 提升到 Workflow status，并增加显式 step artifact inputs；


### PR DESCRIPTION
## Summary
- propose deterministic RuntimePodLocal binding to a ready Runtime Pod
- specify that binding does not reserve Run capacity or create runtime files
- make bound-Pod deletion transition the workspace to sticky Lost rather than silently rebinding
- record the controller, runtimed, and cleanup work remaining after binding

This is an architecture/design-only PR. Please review and approve the binding and failure semantics before controller implementation starts.