### PR TITLE
docs(workflow): simplify reusable workflow execution model

### DIFF
--- a/docs/design/workflow-job-reuse.md
+++ b/docs/design/workflow-job-reuse.md
@@ -107,9 +107,9 @@ its own UID and recorded in `status.snapshotName`. Its data contains exactly:
 
 - `spec`: the accepted inline `WorkflowRun.spec`, including its local job
   topology;
-- `outputContract`: only for a child materialized from a reusable Workflow,
-  the source Workflow's declared `spec.outputs` and optional source identity
-  for diagnostics.
+- `outputContract`: only for a child materialized from a reusable Workflow, a
+  single-entry map keyed by the source Workflow name. Its value is that
+  Workflow's declared `spec.outputs`.
 
 ```yaml
 apiVersion: apps/v1
@@ -127,10 +127,10 @@ data:
         runs-on: bash
         steps: [{ name: deploy, run: deploy --environment=staging }]
   outputContract:
-    workflowName: deploy-workflow
-    outputs:
-      endpoint:
-        value: ${{ jobs.apply.outputs.endpoint }}
+    deploy-workflow:
+      outputs:
+        endpoint:
+          value: ${{ jobs.apply.outputs.endpoint }}
 ```
 
 The output contract is the only source-template data retained after child

--- a/docs/design/workflow-job-reuse.md
+++ b/docs/design/workflow-job-reuse.md
@@ -3,8 +3,7 @@
 Status: **Proposed for review**
 
 This document defines the v0.x execution boundary for job-level reusable
-Workflows. It intentionally replaces the earlier whole-tree snapshot and
-`callPath` proposal.
+Workflows.
 
 ## Decision
 
@@ -23,16 +22,9 @@ This makes nested reuse recursive without requiring one controller to carry a
 root-wide execution tree. A parent sees each reusable call as one job. The
 child owns all jobs that were expanded from that call.
 
-## Why This Model
+## Execution Topology
 
-The former model resolved every nested Workflow before execution and stored one
-large ControllerRevision shared by the root and all descendants. It required
-reserved snapshot/call-path annotations and made each child retrieve its job
-topology from an ancestor's snapshot. That is difficult to explain, makes
-Action reuse inherit the same global-tree mechanism, and couples unrelated
-controller reconciliations.
-
-The local model has simple ownership:
+The model has simple ownership:
 
 ```text
 WorkflowRun release
@@ -106,8 +98,7 @@ Calls are deliberately **late-bound**: a referenced Workflow is read when its
 caller job becomes runnable. A template update before that point affects a
 child that has not yet been created. Once the child exists, its rendered jobs
 and snapshot are immutable. Explicit template versioning can provide earlier
-binding in a future API; this design does not hide late binding behind a global
-snapshot.
+binding in a future API.
 
 ## Local Snapshot and Output Contract
 
@@ -148,8 +139,7 @@ definition that accompanied the jobs which ran. Reading a mutable current
 Workflow after a child completes would make the same execution produce
 different parent output values after a template edit.
 
-There is no shared snapshot, no `callPath`, and no snapshot annotation on a
-child WorkflowRun. A snapshot is owned and used only by its own WorkflowRun.
+A snapshot is owned and used only by its own WorkflowRun.
 
 ## Inputs and Outputs
 
@@ -243,9 +233,8 @@ being added to a root-wide Workflow snapshot or controller traversal tree.
 
 ## Implementation Plan
 
-1. Replace the current whole-tree snapshot and `callPath` API with the local
-   WorkflowRun snapshot envelope and `JobStatus.outputs`.
-2. Remove root `WorkflowRun.spec.uses`/`with`; implement `krt workflow
+1. Add the local WorkflowRun snapshot envelope and `JobStatus.outputs`.
+2. Implement `krt workflow
    trigger` as template input validation, rendering, and inline WorkflowRun
    creation.
 3. Implement direct child WorkflowRun creation with input rendering and frozen

--- a/docs/design/workflow-job-reuse.md
+++ b/docs/design/workflow-job-reuse.md
@@ -2,46 +2,58 @@
 
 Status: **Proposed for review**
 
-This document refines the job-level `uses` model introduced in
-[Workflow Reuse](../workflow-reuse/). It defines an execution boundary that is
-deterministic across controller restarts and reusable `Workflow` updates.
-
-## Problem
-
-The existing design says that a job-level reusable Workflow call expands into
-a nested job group, but it does not define:
-
-- how caller `needs` edges connect to callee roots and leaves;
-- how nested jobs appear in `WorkflowRun.status.jobs`;
-- how nested execution paths fit Kubernetes label limits;
-- how cancellation, failure, outputs, and restart recovery cross the call
-  boundary;
-- how an accepted WorkflowRun avoids observing later changes to a referenced
-  `Workflow`.
-
-The last point is already an implementation gap for top-level
-`WorkflowRun.spec.uses`: the controller initializes status from the referenced
-definition, but execution still reads `WorkflowRun.spec.jobs`, which is empty
-for that shape.
+This document defines the v0.x execution boundary for job-level reusable
+Workflows. It intentionally replaces the earlier whole-tree snapshot and
+`callPath` proposal.
 
 ## Decision
 
-A job-level reusable Workflow call is represented by a child `WorkflowRun`.
-The caller job remains one logical dependency and output node. The called
-Workflow's jobs remain local to the child WorkflowRun instead of being flattened
-into the parent status map.
+`WorkflowRun` is an execution instance with inline jobs only. It never refers
+to a reusable `Workflow` at its root. A reusable `Workflow` is a template:
 
-This choice adds one Kubernetes object and controller transition per call. That
-cost is outside the hot Run scheduling path and buys explicit ownership,
-bounded names, local status, recursive cancellation, and independent
-workspace/artifact boundaries.
+- `krt workflow trigger <name>` reads the template, validates and renders its
+  inputs, then creates an inline `WorkflowRun`;
+- a job with `uses` is a reusable Workflow call;
+- when that call becomes runnable, its parent creates an inline child
+  `WorkflowRun` from the referenced template;
+- every WorkflowRun owns its own immutable execution snapshot and reconciles
+  only its direct jobs and direct child WorkflowRuns.
 
-The first implementation remains namespace-local and does not add a new public
-invocation CRD.
+This makes nested reuse recursive without requiring one controller to carry a
+root-wide execution tree. A parent sees each reusable call as one job. The
+child owns all jobs that were expanded from that call.
 
-## User Model
+## Why This Model
 
-The API shape remains direct:
+The former model resolved every nested Workflow before execution and stored one
+large ControllerRevision shared by the root and all descendants. It required
+reserved snapshot/call-path annotations and made each child retrieve its job
+topology from an ancestor's snapshot. That is difficult to explain, makes
+Action reuse inherit the same global-tree mechanism, and couples unrelated
+controller reconciliations.
+
+The local model has simple ownership:
+
+```text
+WorkflowRun release
+  direct job: build
+  direct call job: deploy
+    WorkflowRun release-call-deploy
+      direct job: apply
+      direct call job: verify
+        WorkflowRun release-call-deploy-call-verify
+          direct job: smoke
+```
+
+Each controller only creates and observes objects directly owned by the
+WorkflowRun it reconciles. Parent/child state propagation, cancellation,
+artifacts, and future PersistentWorkspace boundaries therefore remain local.
+
+## API Shape
+
+`WorkflowRun.spec.jobs` is required. `WorkflowRun.spec.uses` and
+`WorkflowRun.spec.with` are removed. A direct `kubectl create` must provide
+inline jobs.
 
 ```yaml
 apiVersion: kruntimes.io/v1alpha1
@@ -59,352 +71,187 @@ spec:
       needs: [build]
       uses: deploy-workflow
       with:
-        environment: staging
-    notify:
-      needs: [deploy]
-      runs-on: bash
-      steps:
-        - name: send
-          run: send-notification
+        environment: ${{ jobs.build.outputs.environment }}
 ```
 
-`deploy` behaves as one caller job:
-
-- it starts only after `build` succeeds;
-- its child WorkflowRun may execute multiple jobs in parallel;
-- it succeeds only when the child WorkflowRun succeeds;
-- `notify` waits for the complete child WorkflowRun, not one internal leaf;
-- called Workflow outputs become outputs of the `deploy` job;
-- called jobs do not share a workspace with caller jobs.
-
-This follows the useful part of the
-[GitHub Actions reusable-workflow model](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows):
-reusable Workflows are called at job level, while their declared outputs are
-consumed through the caller job. The kruntimes implementation remains
-Kubernetes-native and namespace-local.
-
-### Nested Reuse
-
-Reusable Workflows may call other reusable Workflows. For example,
-`deploy-workflow` can use `smoke-test` after it applies the deployment:
-
-```yaml
-apiVersion: kruntimes.io/v1alpha1
-kind: Workflow
-metadata:
-  name: deploy-workflow
-spec:
-  inputs:
-    environment: { type: string, required: true }
-  jobs:
-    apply:
-      runs-on: bash
-      steps:
-        - name: deploy
-          run: deploy
-    verify:
-      needs: [apply]
-      uses: smoke-test
-      with:
-        endpoint: https://staging.example.com
----
-apiVersion: kruntimes.io/v1alpha1
-kind: Workflow
-metadata:
-  name: smoke-test
-spec:
-  inputs:
-    endpoint: { type: string, required: true }
-  jobs:
-    smoke:
-      runs-on: bash
-      steps:
-        - name: check
-          run: check-service
-```
-
-The accepted `release` execution resolves this tree before it starts work:
+The supported trigger path for a reusable template is:
 
 ```text
-root                         WorkflowRun release
-root/jobs/deploy             Workflow deploy-workflow
-root/jobs/deploy/jobs/verify Workflow smoke-test
+krt workflow trigger deploy-workflow --input environment=staging
+  -> validates template inputs
+  -> renders inputs into inline jobs
+  -> creates WorkflowRun
 ```
 
-The root controller creates and observes only the child WorkflowRun for
-`deploy`. That child executes `apply`, then creates and observes its own child
-WorkflowRun for `verify`. Each WorkflowRun has a local jobs status map; a
-parent call job succeeds only when its direct child WorkflowRun succeeds.
-Consequently, `release.status.jobs.deploy` cannot succeed until the nested
-`smoke-test` WorkflowRun has settled.
+The resulting WorkflowRun contains the rendered jobs, not a template reference.
+This guarantees that later template edits cannot alter an already-created root
+execution.
 
-Cancellation and failure follow the same direct-parent boundary. Cancelling
-`release` requests cancellation of its `deploy` child; that controller then
-requests cancellation of `verify`. Conversely, a failed `smoke-test` makes
-`verify` fail, then makes the `deploy` call fail in `release`. Controllers do
-not need to traverse arbitrary descendants during normal reconciliation.
+## Calling a Reusable Workflow
 
-## Parent and Child Status
+When `deploy` is runnable, the parent controller:
 
-`JobStatus` gains an optional `workflowRunName`, symmetric with
-`StepStatus.runName`:
+1. Loads `deploy-workflow` from the same namespace.
+2. Renders its `with` values from the caller context and validates the callee
+   inputs.
+3. Renders `inputs.*` into the callee jobs.
+4. Creates a direct child WorkflowRun with those inline jobs.
+5. Sets an owner reference and records the child name in
+   `parent.status.jobs.deploy.workflowRunName`.
+
+The child begins normally and may itself create direct child WorkflowRuns for
+its own `uses` jobs. Its parent does not inspect or own those grandchildren.
+
+Calls are deliberately **late-bound**: a referenced Workflow is read when its
+caller job becomes runnable. A template update before that point affects a
+child that has not yet been created. Once the child exists, its rendered jobs
+and snapshot are immutable. Explicit template versioning can provide earlier
+binding in a future API; this design does not hide late binding behind a global
+snapshot.
+
+## Local Snapshot and Output Contract
+
+Every WorkflowRun owns one `ControllerRevision`, named deterministically from
+its own UID and recorded in `status.snapshotName`. Its data contains exactly:
+
+- `spec`: the accepted inline `WorkflowRun.spec`, including its local job
+  topology;
+- `outputContract`: only for a child materialized from a reusable Workflow,
+  the source Workflow's declared `spec.outputs` and optional source identity
+  for diagnostics.
+
+```yaml
+apiVersion: apps/v1
+kind: ControllerRevision
+metadata:
+  name: release-call-deploy-snapshot-8d91c3f4
+  ownerReferences:
+    - apiVersion: kruntimes.io/v1alpha1
+      kind: WorkflowRun
+      name: release-call-deploy
+data:
+  spec:
+    jobs:
+      apply:
+        runs-on: bash
+        steps: [{ name: deploy, run: deploy --environment=staging }]
+  outputContract:
+    workflowName: deploy-workflow
+    outputs:
+      endpoint:
+        value: ${{ jobs.apply.outputs.endpoint }}
+```
+
+The output contract is the only source-template data retained after child
+creation. It is necessary because the parent must evaluate the exact output
+definition that accompanied the jobs which ran. Reading a mutable current
+Workflow after a child completes would make the same execution produce
+different parent output values after a template edit.
+
+There is no shared snapshot, no `callPath`, and no snapshot annotation on a
+child WorkflowRun. A snapshot is owned and used only by its own WorkflowRun.
+
+## Inputs and Outputs
+
+`JobStatus` gains a bounded `outputs` map. All job outputs, whether produced by
+an inline job or by a reusable Workflow call, are exposed at the same path:
 
 ```yaml
 status:
   jobs:
     deploy:
-      phase: Running
-      pre: [build]
-      workflowRunName: release-deploy-7f6d98c04a
+      phase: Succeeded
+      workflowRunName: release-call-deploy
+      outputs:
+        endpoint: https://staging.example.com
 ```
 
-A call job has `workflowRunName` and no step statuses. The child WorkflowRun
-contains its own local `status.jobs` map. Nested names therefore never need to
-be encoded into a parent map key or a child Run label.
+For an inline job, the controller evaluates `JobSpec.outputs` after its steps
+succeed, using the step outputs in Run status. For a reusable call, after the
+child WorkflowRun succeeds, the parent loads the child's local snapshot,
+evaluates its frozen `outputContract` against `child.status.jobs`, and writes
+the resulting values to the caller job's `JobStatus.outputs`.
 
-The child WorkflowRun has a controller owner reference to its parent. Its name
-is deterministic from the parent UID and caller job name. Reserved labels and
-annotations identify the root WorkflowRun UID, snapshot, and call path for
-recovery and diagnostics.
+Downstream rendering is uniform:
 
-The parent controller watches owned child WorkflowRuns and projects state as
-follows:
+```yaml
+jobs:
+  notify:
+    needs: [deploy]
+    runs-on: bash
+    steps:
+      - name: send
+        run: notify --endpoint '${{ jobs.deploy.outputs.endpoint }}'
+```
+
+Only declared, bounded, structured key-value outputs belong in status. Logs
+and large files remain outside status and use the existing logging and artifact
+mechanisms. Missing references or failed output evaluation fail the affected
+job before its next dependent target starts.
+
+## Status, Failure, and Cancellation
+
+A reusable call job has `workflowRunName` and no step statuses. The parent
+projects its direct child state as follows:
 
 | Child WorkflowRun | Caller job |
 | --- | --- |
 | `Pending` or `Running` | `Running` |
-| `Succeeded` | `Succeeded` |
+| `Succeeded` and output evaluation succeeds | `Succeeded` |
+| `Succeeded` and output evaluation fails | `Failed` |
 | `Failed` | `Failed` |
 | `Cancelled` outside parent cancellation | `Failed` |
 
-During parent cancellation, the controller requests cancellation on active
-child WorkflowRuns and direct child Runs. The parent becomes `Cancelled` only
-after both kinds of children settle. Jobs that never started retain their
-existing `Pending` or `Waiting` phase.
+On cancellation, each WorkflowRun requests cancellation only for its direct
+child Runs and direct child WorkflowRuns. A parent becomes terminal only after
+those direct children settle; recursive cancellation follows naturally through
+owner watches and each child's own reconciliation.
 
-## Immutable Execution Snapshot
+## Controller Responsibilities
 
-Accepted executions must not read mutable `Workflow` definitions again. Before
-initializing `status.jobs` or creating any child, the controller recursively
-resolves the complete namespace-local Workflow call tree and writes an
-immutable execution snapshot.
+For every reconciliation, the WorkflowRun controller:
 
-### Snapshot Storage
+1. Loads the WorkflowRun, its local snapshot, direct child Runs, and direct
+   child WorkflowRuns.
+2. Derives local job and WorkflowRun status from those resources.
+3. Calculates runnable local targets from the snapshot spec and completed
+   dependency outputs.
+4. Creates all independent ready targets: a Run for an inline step or a child
+   WorkflowRun for a `uses` job.
+5. Patches status only when the derived state changed.
 
-Each root WorkflowRun owns exactly one snapshot `ControllerRevision`.
-`ControllerRevision.data` is a small envelope around direct serialized public
-specs, not a second Workflow model:
+The scheduler and runtimed continue to see only independent `Run` resources.
+They have no Workflow reuse, snapshot, or output-contract behavior.
 
-- `root.spec` is always the exact accepted `WorkflowRun.spec`;
-- `root.workflow`, when the root uses a reusable Workflow, is the exact
-  resolved `Workflow.spec` for that reference; it is omitted for an inline
-  root;
-- `workflows[call-path]` is the exact `Workflow.spec` resolved for each
-  job-level call.
+## Validation and Limits
 
-The root revision name is recorded in `WorkflowRun.status.snapshotName`. A
-nested child receives that name and its call path through reserved metadata,
-then reads its definition from the same snapshot. `with` remains in the stored
-caller `JobSpec`, exactly where the user wrote it; it is not copied into a
-controller-specific record.
+- `WorkflowRun.spec.jobs` must be non-empty and is immutable after creation.
+- `WorkflowRun` itself cannot contain `uses` or `with`.
+- A call job has `needs`, `uses`, and optional `with`; it cannot contain
+  `runs-on` or `steps`.
+- Inputs and expression references are validated before creating a child.
+- Workflow cycles are detected along the active parent/child call chain before
+  a child is created. The initial maximum nesting depth is 8.
+- Job and step outputs are bounded by CRD limits; artifacts are not outputs.
 
-For the `release` example above, the following is an abbreviated but complete
-shape of the snapshot ControllerRevision. Its name is illustrative: the
-controller derives it deterministically from the root WorkflowRun UID.
+## Reusable Actions
 
-```yaml
-# The root WorkflowRun owns the single snapshot revision.
-apiVersion: apps/v1
-kind: ControllerRevision
-metadata:
-  name: release-snapshot-root-8d91c3f4
-  namespace: default
-  labels:
-    kruntimes.io/root-workflowrun-uid: 7e4d41cb-69c8-4fa1-8e31-f9135512c22b
-  ownerReferences:
-    - apiVersion: kruntimes.io/v1alpha1
-      kind: WorkflowRun
-      name: release
-      uid: 7e4d41cb-69c8-4fa1-8e31-f9135512c22b
-      controller: true
-      blockOwnerDeletion: true
-revision: 1
-data:
-  root:
-    spec: # exact accepted WorkflowRun.spec
-      jobs:
-        build: { runs-on: bash, steps: [{ name: package, run: make package }] }
-        deploy: { needs: [build], uses: deploy-workflow, with: { environment: staging } }
-        notify: { needs: [deploy], runs-on: bash, steps: [{ name: send, run: send-notification }] }
-  workflows:
-    root/jobs/deploy: # exact Workflow.spec resolved for this call
-      inputs:
-        environment: { type: string, required: true }
-      jobs:
-        apply: { runs-on: bash, steps: [{ name: deploy, run: deploy }] }
-        verify: { needs: [apply], uses: smoke-test, with: { endpoint: https://staging.example.com } }
-    root/jobs/deploy/jobs/verify: # exact Workflow.spec resolved for the nested call
-      inputs:
-        endpoint: { type: string, required: true }
-      jobs:
-        smoke: { runs-on: bash, steps: [{ name: check, run: check-service }] }
-```
-
-The root snapshot always stores the direct `WorkflowRun.spec`. For a root
-`spec.uses`, it also stores that resolved `Workflow.spec` at `root.workflow`.
-It stores the resolved `Workflow.spec` for `root/jobs/deploy`, and the nested
-`Workflow.spec` for `root/jobs/deploy/jobs/verify`. When `deploy` becomes runnable, the controller
-evaluates its stored `with.environment` in the caller context and creates a
-child WorkflowRun with the same snapshot name and the `root/jobs/deploy` call
-path. That child later resolves `verify` from the same snapshot. Neither
-controller reads the current `deploy-workflow` or `smoke-test` object again.
-
-A job-level call path appends `/jobs/<job-name>` to its caller path. Job names
-cannot contain `/`, so this is unambiguous and stable across reconciliation.
-The path is a YAML/JSON map key in `ControllerRevision.data`, where `/` is
-valid; it is not a Kubernetes label, annotation, or object name. JSON Pointer
-would escape `/` as `~1`, but snapshot data is immutable and is never patched
-by path. The resolver rejects a stored spec that exceeds Kubernetes object size
-limits before it creates an execution child.
-
-The snapshot is stored outside status in a WorkflowRun-owned
-`ControllerRevision`. Kubernetes API validation makes a successfully created revision's
-`data` immutable. Revision metadata records the root WorkflowRun UID for
-lookup and garbage collection; child WorkflowRun metadata records its call path.
-Revision data contains no runtime results or secret material.
-
-Snapshot names are deterministic from the root UID. Creation is idempotent:
-after a partial failure, reconciliation verifies and reuses a matching
-immutable revision before accepting the WorkflowRun.
-
-`WorkflowRun.status.snapshotName` records the root ControllerRevision name.
-Status does not copy full job specs, scripts, or environment values. If a
-snapshot exceeds 1 MiB after serialization, resolution fails before execution.
-The explicit limit leaves headroom below etcd's commonly configured 1.5 MiB
-request limit; cluster operators may configure different API server or etcd
-limits.
-
-Once `snapshotName` is persisted, all reconciliation reads the snapshot rather
-than current `Workflow` objects. A child WorkflowRun inherits the root snapshot
-and a call-path annotation, so nested calls use the same immutable tree.
-
-The root WorkflowRun spec is also execution input. After creation, `jobs`,
-`uses`, and `with` are immutable. `cancelRequested` may transition from false to
-true but not back to false. These rules require CRD transition validation.
-
-## Resolution and Cycle Detection
-
-Snapshot resolution happens before any execution child is created:
-
-1. Select inline root jobs or resolve top-level `spec.uses`.
-2. Validate and bind literal top-level inputs.
-3. Recursively resolve every job-level `uses` in the same namespace.
-4. Store the complete resolved tree in one immutable snapshot revision.
-5. Reject missing definitions, invalid inputs, unsupported shapes, and direct
-   or indirect Workflow call cycles.
-6. Persist immutable snapshot ControllerRevisions.
-7. Initialize lightweight status from the snapshot and set `Accepted=True`.
-
-Initial safety limits are a maximum call depth of 8 and at most 64 reusable
-Workflow call nodes per root execution. Exceeding either limit rejects the
-WorkflowRun before child creation. These bounds prevent accidental recursive
-expansion even when the graph is acyclic.
-
-## Reconciliation
-
-The controller keeps the existing load/calculate/apply/patch structure.
-
-Loaded resources add:
-
-- the root snapshot ControllerRevision;
-- direct child WorkflowRuns owned by the reconciled WorkflowRun;
-- direct child Runs for inline jobs.
-
-Planning can produce one of two runnable target kinds:
-
-- an inline step target creates or reuses a child Run;
-- a reusable call target creates or reuses a child WorkflowRun.
-
-One reconcile may start all currently ready targets in parallel, but at most
-one target per caller job. Created child identities are recorded in desired
-status before the single status patch. Deterministic names and owner watches
-repair create-before-status-patch failures after restart.
-
-Top-level `spec.uses` does not create a wrapper child WorkflowRun. The root
-WorkflowRun initializes and executes the root jobs from its immutable snapshot.
-Only job-level calls create child WorkflowRuns.
-
-## Job Shape and Outputs
-
-A call job supports `needs`, `uses`, and `with`. It does not support `runs-on`,
-`steps`, or caller-defined `outputs` in v0.x. The called Workflow selects
-runtimes for its own jobs and exposes outputs through `Workflow.spec.outputs`.
-
-Input expressions are evaluated only when the call job becomes runnable, using
-the caller's completed dependency outputs. The resulting concrete values are
-placed in the child WorkflowRun's immutable `with` map. Secret inputs remain
-out of scope until a separate secret-handling design is reviewed.
-
-Output evaluation remains part of the existing expression/output propagation
-story. This design only fixes the boundary: child Workflow outputs are promoted
-to caller job outputs, and downstream jobs access them through the normal jobs
-context.
-
-## Component Boundaries
-
-- The WorkflowRun controller owns resolution, snapshots, child WorkflowRuns,
-  child Runs, status projection, and cancellation propagation.
-- The Workflow and Action controllers continue to validate definitions only.
-- Scheduler and runtimed continue to see only independent Runs and remain
-  unaware of Workflow calls and snapshots.
-- PersistentWorkspace and ArtifactStore behavior remains attached to the
-  called jobs, not to the synthetic caller job.
-
-## API and RBAC Changes
-
-Implementation requires review of these API and operational changes:
-
-- add `WorkflowRun.status.snapshotName`;
-- add `JobStatus.workflowRunName`;
-- add WorkflowRun spec transition validation for immutable execution inputs and
-  one-way cancellation;
-- reject `runs-on`, `steps`, and caller-defined `outputs` on a `uses` job;
-- reserve snapshot/call-path labels and annotations;
-- grant the WorkflowRun controller namespace-scoped `apps` ControllerRevision
-  get/list/watch/create/delete permissions;
-- watch owned child WorkflowRuns as well as child Runs.
-
-## Rejected Alternatives
-
-### Flatten callee jobs into parent status
-
-Flattening avoids child WorkflowRun objects, but it requires synthetic caller
-nodes, rewrites external dependency edges to callee roots and leaves, leaks
-nested paths into labels, and mixes independent workspace/artifact boundaries
-in one status map. It also makes nested cancellation and output aggregation
-harder to explain.
-
-### Read the current Workflow on every reconcile
-
-This is simple but changes an in-progress execution when a reusable definition
-is edited. It cannot provide deterministic retries or restart recovery.
-
-### Copy resolved definitions into WorkflowRun status
-
-This makes status large and may duplicate scripts and environment values.
-Status should remain lightweight execution state, not an execution-spec store.
+This decision deliberately does not define Action execution. It establishes a
+useful rule for that future work: reuse expands at the direct execution
+boundary. An Action will be resolved into its caller step/Run, rather than
+being added to a root-wide Workflow snapshot or controller traversal tree.
 
 ## Implementation Plan
 
-1. API prerequisites: status references, transition validation, reserved
-   metadata, generated CRDs, and ControllerRevision/child-WorkflowRun RBAC.
-2. Snapshot storage and recursive resolver with version capture, limits, input
-   validation, and cross-Workflow cycle detection.
-3. Execute top-level `spec.uses` from the immutable snapshot, fixing the current
-   status-only resolution gap.
-4. Create and observe child WorkflowRuns for ready job-level calls, including
-   dependency and terminal propagation.
-5. Add restart, mutation, nested-call, cancellation, and invalid-graph tests.
-6. Integrate expression inputs and child Workflow outputs in the existing
-   output propagation work.
-7. Add E2E coverage, then update the final workflow demo.
+1. Replace the current whole-tree snapshot and `callPath` API with the local
+   WorkflowRun snapshot envelope and `JobStatus.outputs`.
+2. Remove root `WorkflowRun.spec.uses`/`with`; implement `krt workflow
+   trigger` as template input validation, rendering, and inline WorkflowRun
+   creation.
+3. Implement direct child WorkflowRun creation with input rendering and frozen
+   output contracts.
+4. Implement local job-output evaluation, child-output projection, restart
+   recovery, and template-mutation semantics tests.
+5. Add E2E coverage for nested calls, output propagation, cancellation, and
+   template updates before versus after child creation.
+6. Design Action expansion separately, using the same direct-boundary rule.

--- a/docs/design/workflow-job-reuse.zh.md
+++ b/docs/design/workflow-job-reuse.zh.md
@@ -2,7 +2,7 @@
 
 状态：**待评审**
 
-本文定义 v0.x 中 job 级可复用 Workflow 的执行边界，并替代此前的全树 snapshot 与 `callPath` 方案。
+本文定义 v0.x 中 job 级可复用 Workflow 的执行边界。
 
 ## 决策
 
@@ -15,9 +15,7 @@
 
 这使嵌套复用天然递归，而不要求一个 controller 携带 root 范围的执行树。parent 将每次调用视为一个 job；child 拥有该调用展开的全部 jobs。
 
-## 为什么采用这个模型
-
-旧方案在执行前递归解析所有 Workflow，并把整棵树保存在 root 共享的 `ControllerRevision` 中。它要求 snapshot/call-path annotations，并让 child 从祖先 snapshot 中读取自己的 jobs。该模型难以理解，Action 复用也会继承相同的全局树复杂度，并耦合不相关的 controller reconcile。
+## 执行拓扑
 
 本模型的 ownership 很直接：
 
@@ -80,7 +78,7 @@ krt workflow trigger deploy-workflow --input environment=staging
 
 child 正常执行，也可以为其 `uses` jobs 创建自己的直接 child WorkflowRuns。parent 不拥有也不检查 grandchildren。
 
-调用是**延迟绑定**：被引用的 Workflow 在 caller job ready 时读取。此前的模板修改会影响尚未创建的 child；child 创建后，其渲染 jobs 和 snapshot 都是 immutable。未来若需要更早绑定，应引入显式 template versioning，而不是恢复全树 snapshot。
+调用是**延迟绑定**：被引用的 Workflow 在 caller job ready 时读取。模板修改会影响尚未创建的 child；child 创建后，其渲染 jobs 和 snapshot 都是 immutable。未来若需要更早绑定，应引入显式 template versioning。
 
 ## 局部 Snapshot 与 Output Contract
 
@@ -113,7 +111,7 @@ data:
 
 output contract 是 child 创建后保留的唯一 source-template 数据。parent 必须使用与实际执行 jobs 配套的 output 定义；如果 child 完成后读取可变的当前 Workflow，模板变更会让同一执行产生不同的 parent output。
 
-没有共享 snapshot、没有 `callPath`，child WorkflowRun 上也没有 snapshot annotation。一个 snapshot 只由自己的 WorkflowRun 拥有和使用。
+一个 snapshot 只由自己的 WorkflowRun 拥有和使用。
 
 ## Inputs 与 Outputs
 
@@ -180,8 +178,8 @@ Scheduler 和 runtimed 仍然只处理独立 `Run`，不了解 Workflow reuse、
 
 ## 实现计划
 
-1. 以 local WorkflowRun snapshot envelope 与 `JobStatus.outputs` 替换当前全树 snapshot 和 `callPath` API。
-2. 删除 root `WorkflowRun.spec.uses`/`with`；实现 `krt workflow trigger` 的模板 input 校验、渲染和 inline WorkflowRun 创建。
+1. 增加 local WorkflowRun snapshot envelope 与 `JobStatus.outputs`。
+2. 实现 `krt workflow trigger` 的模板 input 校验、渲染和 inline WorkflowRun 创建。
 3. 实现直接 child WorkflowRun 创建、input rendering 和冻结 output contracts。
 4. 实现局部 job-output 求值、child-output projection、restart recovery 和模板变更语义测试。
 5. 添加 nested calls、output propagation、cancellation、child 创建前后模板更新的 E2E coverage。

--- a/docs/design/workflow-job-reuse.zh.md
+++ b/docs/design/workflow-job-reuse.zh.md
@@ -1,38 +1,42 @@
-# Job-Level Reusable Workflow Execution
+# Job 级可复用 Workflow 执行
 
-状态：**提案，等待 review**
+状态：**待评审**
 
-本文细化 [Workflow Reuse](../workflow-reuse/) 中的 job-level `uses` 模型，定义一个在
-controller restart 和 reusable `Workflow` 更新后仍保持确定性的 execution boundary。
-
-## 问题
-
-现有设计提出将 job-level reusable Workflow call 展开为 nested job group，但没有定义：
-
-- caller `needs` 如何连接 callee roots 和 leaves；
-- nested jobs 如何出现在 `WorkflowRun.status.jobs`；
-- nested execution path 如何满足 Kubernetes label 长度限制；
-- cancellation、failure、outputs 和 restart recovery 如何跨越 call boundary；
-- 已 accepted 的 WorkflowRun 如何避免观察到 referenced `Workflow` 的后续修改。
-
-最后一点已经造成 top-level `WorkflowRun.spec.uses` 的实现缺口：controller 会根据 referenced
-definition 初始化 status，但执行仍读取 `WorkflowRun.spec.jobs`；对于该 shape，此字段为空。
+本文定义 v0.x 中 job 级可复用 Workflow 的执行边界，并替代此前的全树 snapshot 与 `callPath` 方案。
 
 ## 决策
 
-job-level reusable Workflow call 使用 child `WorkflowRun` 表示。caller job 仍是一个逻辑
-dependency 和 output 节点。called Workflow 的 jobs 保留在 child WorkflowRun 的本地状态中，
-而不是扁平化到 parent status map。
+`WorkflowRun` 只表示带 inline jobs 的一次执行，不在 root 引用可复用 `Workflow`。`Workflow` 是模板：
 
-该方案会为每次 call 增加一个 Kubernetes object 和 controller transition。这些开销不在 Run
-调度热路径上，换来明确的 ownership、有界命名、本地 status、递归 cancellation，以及独立的
-workspace/artifact boundary。
+- `krt workflow trigger <name>` 读取模板、校验并渲染 inputs，然后创建带 inline jobs 的 `WorkflowRun`；
+- job 的 `uses` 表示一次可复用 Workflow 调用；
+- 该 job ready 后，parent 创建一个带 inline jobs 的 child `WorkflowRun`；
+- 每个 WorkflowRun 都拥有自己的 immutable execution snapshot，只协调直接 jobs 和直接 child WorkflowRuns。
 
-第一版保持 namespace-local，不增加新的 public invocation CRD。
+这使嵌套复用天然递归，而不要求一个 controller 携带 root 范围的执行树。parent 将每次调用视为一个 job；child 拥有该调用展开的全部 jobs。
 
-## 用户模型
+## 为什么采用这个模型
 
-API 保持直接：
+旧方案在执行前递归解析所有 Workflow，并把整棵树保存在 root 共享的 `ControllerRevision` 中。它要求 snapshot/call-path annotations，并让 child 从祖先 snapshot 中读取自己的 jobs。该模型难以理解，Action 复用也会继承相同的全局树复杂度，并耦合不相关的 controller reconcile。
+
+本模型的 ownership 很直接：
+
+```text
+WorkflowRun release
+  直接 job: build
+  直接调用 job: deploy
+    WorkflowRun release-call-deploy
+      直接 job: apply
+      直接调用 job: verify
+        WorkflowRun release-call-deploy-call-verify
+          直接 job: smoke
+```
+
+每个 controller 只创建和观察自己所 reconcile 的 WorkflowRun 直接拥有的对象。parent/child 状态传播、取消、artifacts 以及未来 PersistentWorkspace 的边界因此都是局部的。
+
+## API 形式
+
+`WorkflowRun.spec.jobs` 必填。删除 `WorkflowRun.spec.uses` 和 `WorkflowRun.spec.with`。直接使用 `kubectl create` 时必须提供 inline jobs。
 
 ```yaml
 apiVersion: kruntimes.io/v1alpha1
@@ -50,317 +54,135 @@ spec:
       needs: [build]
       uses: deploy-workflow
       with:
-        environment: staging
-    notify:
-      needs: [deploy]
-      runs-on: bash
-      steps:
-        - name: send
-          run: send-notification
+        environment: ${{ jobs.build.outputs.environment }}
 ```
 
-`deploy` 表现为一个 caller job：
-
-- 只有 `build` 成功后才启动；
-- child WorkflowRun 内可以并行执行多个 jobs；
-- 只有 child WorkflowRun succeeded 时它才 succeeded；
-- `notify` 等待完整 child WorkflowRun，而不是某个内部 leaf；
-- called Workflow outputs 成为 `deploy` job outputs；
-- called jobs 不与 caller jobs 共享 workspace。
-
-该语义保留了
-[GitHub Actions reusable-workflow model](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows)
-中有价值的部分：reusable Workflow 在 job level 调用，并通过 caller job 使用其 outputs。
-kruntimes 的实现仍保持 Kubernetes-native 和 namespace-local。
-
-### 嵌套 Reuse
-
-reusable Workflow 可以继续调用其他 reusable Workflow。例如，`deploy-workflow` 在完成部署后可以
-调用 `smoke-test`：
-
-```yaml
-apiVersion: kruntimes.io/v1alpha1
-kind: Workflow
-metadata:
-  name: deploy-workflow
-spec:
-  inputs:
-    environment: { type: string, required: true }
-  jobs:
-    apply:
-      runs-on: bash
-      steps:
-        - name: deploy
-          run: deploy
-    verify:
-      needs: [apply]
-      uses: smoke-test
-      with:
-        endpoint: https://staging.example.com
----
-apiVersion: kruntimes.io/v1alpha1
-kind: Workflow
-metadata:
-  name: smoke-test
-spec:
-  inputs:
-    endpoint: { type: string, required: true }
-  jobs:
-    smoke:
-      runs-on: bash
-      steps:
-        - name: check
-          run: check-service
-```
-
-accepted 的 `release` execution 会在启动工作前解析整个调用树：
+复用模板的标准触发方式为：
 
 ```text
-root                         WorkflowRun release
-root/jobs/deploy             Workflow deploy-workflow
-root/jobs/deploy/jobs/verify Workflow smoke-test
+krt workflow trigger deploy-workflow --input environment=staging
+  -> 校验模板 inputs
+  -> 将 inputs 渲染到 inline jobs
+  -> 创建 WorkflowRun
 ```
 
-root controller 只创建并观察 `deploy` 对应的 child WorkflowRun。该 child 执行 `apply` 后，会创建并
-观察 `verify` 对应的自己的 child WorkflowRun。每个 WorkflowRun 都有本地 jobs status map；parent
-call job 只有在其 direct child WorkflowRun succeeded 后才会 succeeded。因此，嵌套的
-`smoke-test` WorkflowRun settled 前，`release.status.jobs.deploy` 不会 succeeded。
+最终 WorkflowRun 保存的是渲染后的 jobs，而不是模板引用，因此模板后续修改不会改变已创建的 root execution。
 
-cancellation 和 failure 也遵循相同的 direct-parent boundary。取消 `release` 会请求取消它的
-`deploy` child；该 controller 随后请求取消 `verify`。反过来，`smoke-test` failed 会先让 `verify`
-failed，再让 `release` 中的 `deploy` call failed。controller 在正常 reconciliation 中不需要遍历任意
-depth 的 descendants。
+## 调用可复用 Workflow
 
-## Parent 和 Child Status
+`deploy` ready 后，parent controller：
 
-`JobStatus` 增加可选 `workflowRunName`，与 `StepStatus.runName` 对称：
+1. 从同一 namespace 读取 `deploy-workflow`。
+2. 使用 caller context 渲染 `with`，并校验 callee inputs。
+3. 将 `inputs.*` 渲染到 callee jobs。
+4. 用这些 inline jobs 创建直接 child WorkflowRun。
+5. 设置 owner reference，并将 child 名称写入 `parent.status.jobs.deploy.workflowRunName`。
+
+child 正常执行，也可以为其 `uses` jobs 创建自己的直接 child WorkflowRuns。parent 不拥有也不检查 grandchildren。
+
+调用是**延迟绑定**：被引用的 Workflow 在 caller job ready 时读取。此前的模板修改会影响尚未创建的 child；child 创建后，其渲染 jobs 和 snapshot 都是 immutable。未来若需要更早绑定，应引入显式 template versioning，而不是恢复全树 snapshot。
+
+## 局部 Snapshot 与 Output Contract
+
+每个 WorkflowRun 自己拥有一个 `ControllerRevision`，名称由自身 UID 确定，并记录在 `status.snapshotName`。它只包含：
+
+- `spec`：接受的 inline `WorkflowRun.spec`，包括本地 jobs topology；
+- `outputContract`：仅当该 WorkflowRun 从可复用 Workflow materialize 出来时，保存 source Workflow 声明的 `spec.outputs` 及可选 source identity，用于诊断。
+
+```yaml
+apiVersion: apps/v1
+kind: ControllerRevision
+metadata:
+  name: release-call-deploy-snapshot-8d91c3f4
+  ownerReferences:
+    - apiVersion: kruntimes.io/v1alpha1
+      kind: WorkflowRun
+      name: release-call-deploy
+data:
+  spec:
+    jobs:
+      apply:
+        runs-on: bash
+        steps: [{ name: deploy, run: deploy --environment=staging }]
+  outputContract:
+    workflowName: deploy-workflow
+    outputs:
+      endpoint:
+        value: ${{ jobs.apply.outputs.endpoint }}
+```
+
+output contract 是 child 创建后保留的唯一 source-template 数据。parent 必须使用与实际执行 jobs 配套的 output 定义；如果 child 完成后读取可变的当前 Workflow，模板变更会让同一执行产生不同的 parent output。
+
+没有共享 snapshot、没有 `callPath`，child WorkflowRun 上也没有 snapshot annotation。一个 snapshot 只由自己的 WorkflowRun 拥有和使用。
+
+## Inputs 与 Outputs
+
+`JobStatus` 增加有界的 `outputs` map。inline job 和可复用 Workflow 调用的输出都在同一位置暴露：
 
 ```yaml
 status:
   jobs:
     deploy:
-      phase: Running
-      pre: [build]
-      workflowRunName: release-deploy-7f6d98c04a
+      phase: Succeeded
+      workflowRunName: release-call-deploy
+      outputs:
+        endpoint: https://staging.example.com
 ```
 
-call job 有 `workflowRunName`，没有 step statuses。child WorkflowRun 包含自己的本地
-`status.jobs` map。因此 nested names 不需要编码到 parent map key 或 child Run label 中。
+inline job 的所有 steps 成功后，controller 使用 `JobSpec.outputs` 和 Run status 中的 step outputs 计算 job output。可复用调用的 child WorkflowRun 成功后，parent 读取 child 的局部 snapshot，用冻结的 `outputContract` 对 `child.status.jobs` 求值，并将结果写到 caller job 的 `JobStatus.outputs`。
 
-child WorkflowRun 使用 controller owner reference 指向 parent。其名称由 parent UID 和 caller
-job name 确定性生成。保留的 labels 和 annotations 会记录 root WorkflowRun UID、snapshot 和
-call path，用于 recovery 和诊断。
+下游渲染统一使用：
 
-parent controller watch owned child WorkflowRuns，并按如下规则投影状态：
+```yaml
+${{ jobs.deploy.outputs.endpoint }}
+```
+
+只有显式声明、有界、结构化的键值 outputs 可以进入 status。日志和大文件不进入 status，继续使用 logging 和 artifact 机制。缺失引用或 output 求值失败会在启动下一个 dependent target 前使受影响 job 失败。
+
+## 状态、失败与取消
+
+可复用调用 job 有 `workflowRunName`，没有 step statuses。parent 如下投影其直接 child 的状态：
 
 | Child WorkflowRun | Caller job |
 | --- | --- |
 | `Pending` 或 `Running` | `Running` |
-| `Succeeded` | `Succeeded` |
+| `Succeeded` 且 output 求值成功 | `Succeeded` |
+| `Succeeded` 但 output 求值失败 | `Failed` |
 | `Failed` | `Failed` |
-| 非 parent cancellation 导致的 `Cancelled` | `Failed` |
+| parent 未取消时的 `Cancelled` | `Failed` |
 
-parent cancellation 期间，controller 会请求取消 active child WorkflowRuns 和 direct child
-Runs。两类 children 都 settled 后，parent 才进入 `Cancelled`。从未启动的 jobs 保持原有
-`Pending` 或 `Waiting` phase。
+取消时，每个 WorkflowRun 只请求取消直接 child Runs 和直接 child WorkflowRuns。parent 仅在这些直接 children 都结束后变为 terminal；递归取消通过 owner watches 和每个 child 的自身 reconcile 自然完成。
 
-## Immutable Execution Snapshot
+## Controller 职责
 
-accepted execution 不能再次读取 mutable `Workflow` definitions。在初始化 `status.jobs` 或
-创建任何 child 前，controller 会递归解析完整的 namespace-local Workflow call tree，并写入
-immutable execution snapshot。
+每次 reconcile 中，WorkflowRun controller：
 
-### Snapshot Storage
+1. 加载 WorkflowRun、其局部 snapshot、直接 child Runs 和直接 child WorkflowRuns。
+2. 从这些资源推导本地 job 和 WorkflowRun status。
+3. 根据 snapshot spec 与已完成 dependency outputs 计算可运行的本地 targets。
+4. 创建所有相互独立的 ready targets：inline step 创建 Run，`uses` job 创建 child WorkflowRun。
+5. 仅当推导状态变化时 patch status。
 
-每个 root WorkflowRun 恰好 owner 一个 snapshot `ControllerRevision`。
-`ControllerRevision.data` 是对直接序列化的 public specs 的一个很小的 envelope，不引入第二套
-Workflow model：
+Scheduler 和 runtimed 仍然只处理独立 `Run`，不了解 Workflow reuse、snapshot 或 output contract。
 
-- `root.spec` 始终是 accepted 时完整的 `WorkflowRun.spec`；
-- root 使用 reusable Workflow 时，`root.workflow` 保存该引用解析到的完整 `Workflow.spec`；
-  inline root 则省略它；
-- `workflows[call-path]` 是每个 job-level call 解析到的完整 `Workflow.spec`。
+## 校验与限制
 
-root revision name 保存在 `WorkflowRun.status.snapshotName`。nested child 通过保留 metadata 接收
-该名称及自身的 call path，并从同一个 snapshot 读取 definition。`with` 保留在存储的 caller
-`JobSpec` 中，和用户提交的内容完全一致；不会复制到 controller-specific record。
+- `WorkflowRun.spec.jobs` 非空，创建后 immutable。
+- WorkflowRun 自身不能包含 `uses` 或 `with`。
+- 调用 job 包含 `needs`、`uses` 和可选 `with`，不能包含 `runs-on` 或 `steps`。
+- 创建 child 前校验 inputs 和 expression references。
+- 在创建 child 前，沿 active parent/child call chain 检测 Workflow cycle；初始最大嵌套深度为 8。
+- job 与 step outputs 受 CRD 大小限制；artifacts 不是 outputs。
 
-以上面的 `release` 为例，下面展示 snapshot ControllerRevision 的完整结构（内容经过必要简化）。
-其名称仅用于示例：controller 会从 root WorkflowRun UID 确定性生成名称。
+## 可复用 Actions
 
-```yaml
-# root WorkflowRun owns 唯一的 snapshot revision。
-apiVersion: apps/v1
-kind: ControllerRevision
-metadata:
-  name: release-snapshot-root-8d91c3f4
-  namespace: default
-  labels:
-    kruntimes.io/root-workflowrun-uid: 7e4d41cb-69c8-4fa1-8e31-f9135512c22b
-  ownerReferences:
-    - apiVersion: kruntimes.io/v1alpha1
-      kind: WorkflowRun
-      name: release
-      uid: 7e4d41cb-69c8-4fa1-8e31-f9135512c22b
-      controller: true
-      blockOwnerDeletion: true
-revision: 1
-data:
-  root:
-    spec: # accepted 时完整的 WorkflowRun.spec
-      jobs:
-        build: { runs-on: bash, steps: [{ name: package, run: make package }] }
-        deploy: { needs: [build], uses: deploy-workflow, with: { environment: staging } }
-        notify: { needs: [deploy], runs-on: bash, steps: [{ name: send, run: send-notification }] }
-  workflows:
-    root/jobs/deploy: # 此 call 解析到的完整 Workflow.spec
-      inputs:
-        environment: { type: string, required: true }
-      jobs:
-        apply: { runs-on: bash, steps: [{ name: deploy, run: deploy }] }
-        verify: { needs: [apply], uses: smoke-test, with: { endpoint: https://staging.example.com } }
-    root/jobs/deploy/jobs/verify: # nested call 解析到的完整 Workflow.spec
-      inputs:
-        endpoint: { type: string, required: true }
-      jobs:
-        smoke: { runs-on: bash, steps: [{ name: check, run: check-service }] }
-```
+本文不定义 Action 的执行机制，但确立一条原则：复用在直接 execution boundary 展开。未来 Action 将在 caller step/Run 中解析，而不加入 root 范围的 Workflow snapshot 或 controller traversal tree。
 
-root snapshot 始终保存 `WorkflowRun.spec`。root 使用 `spec.uses` 时，还会在 `root.workflow`
-保存解析后的 `Workflow.spec`。它还保存 `root/jobs/deploy` 对应的解析后 `Workflow.spec`，以及
-`root/jobs/deploy/jobs/verify` 对应的 nested `Workflow.spec`。当 `deploy` runnable 时，controller
-在 caller context 中求值已存储的 `with.environment`，并使用相同的 snapshot name 与
-`root/jobs/deploy` call path 创建 child WorkflowRun。该 child 后续会从同一份 snapshot 解析
-`verify`。两个 controller 都不会再次读取当前的 `deploy-workflow` 或 `smoke-test` object。
+## 实现计划
 
-job-level call path 在 caller path 后增加 `/jobs/<job-name>`。job name 不允许包含 `/`，因此它在
-reconciliation 间没有歧义且保持稳定。该 path 是 `ControllerRevision.data` 中的 YAML/JSON map key，
-`/` 在这里合法；它不是 Kubernetes label、annotation 或 object name。JSON Pointer 会将 `/` 转义为
-`~1`，但 snapshot data 不可变，controller 不会按 path patch 它。resolver 会在创建 execution child 前
-拒绝超过 Kubernetes object size limit 的存储 spec。
-
-snapshot 不放在 status 中，而是存储在由 WorkflowRun owner 的一个 `ControllerRevision` 中。
-Kubernetes API validation 会使已成功创建 revision 的 `data` 不可变。revision metadata 记录 root
-WorkflowRun UID，用于 lookup 和 garbage collection；child WorkflowRun metadata 记录自身的 call
-path。revision data 不包含 runtime results 或 secret material。
-
-Snapshot name 由 root UID 确定性生成。创建过程保持幂等：发生部分失败后，reconcile 会先校验并
-复用匹配的 immutable revision，再接受 WorkflowRun。
-
-`WorkflowRun.status.snapshotName` 记录 root ControllerRevision 名称。Status 不复制完整 job specs、
-scripts 或 environment values。如果 snapshot 序列化后超过 1 MiB，resolution 会在执行前失败。
-这个显式限制为 etcd 常见的 1.5 MiB request limit 留出余量；cluster operator 可以配置不同的 API
-server 或 etcd limits。
-
-一旦 `snapshotName` 持久化，后续 reconcile 只读取 snapshot，不再读取当前 `Workflow`
-objects。child WorkflowRun 继承 root snapshot 和 call-path annotation，因此 nested calls 使用
-同一份 immutable tree。
-
-root WorkflowRun spec 也是 execution input。创建后，`jobs`、`uses` 和 `with` 不可修改；
-`cancelRequested` 只允许从 false 变成 true，不能恢复为 false。这些规则需要 CRD transition
-validation。
-
-## Resolution 和 Cycle Detection
-
-snapshot resolution 在创建任何 execution child 前完成：
-
-1. 选择 inline root jobs，或者解析 top-level `spec.uses`。
-2. 校验并绑定 literal top-level inputs。
-3. 递归解析同 namespace 中的所有 job-level `uses`。
-4. 将完整的解析树存储到一个 immutable snapshot revision。
-5. 拒绝 missing definitions、invalid inputs、unsupported shapes，以及直接或间接 Workflow
-   call cycles。
-6. 持久化 immutable snapshot ControllerRevisions。
-7. 根据 snapshot 初始化轻量 status，并设置 `Accepted=True`。
-
-初始安全限制为最大 call depth 8，以及每个 root execution 最多 64 个 reusable Workflow call
-nodes。超过任一限制都会在创建 child 前拒绝 WorkflowRun。即使 graph 无环，这些限制也能防止
-意外递归扩张。
-
-## Reconciliation
-
-controller 保持现有 load/calculate/apply/patch 结构。
-
-加载的资源增加：
-
-- root snapshot ControllerRevision；
-- reconciled WorkflowRun owner 的 direct child WorkflowRuns；
-- inline jobs 对应的 direct child Runs。
-
-plan 可以产生两类 runnable target：
-
-- inline step target 创建或复用 child Run；
-- reusable call target 创建或复用 child WorkflowRun。
-
-一次 reconcile 可以并行启动所有当前 ready targets，但每个 caller job 最多一个 target。创建的
-child identities 会在单次 status patch 前记录到 desired status。确定性名称和 owner watches
-能够在 restart 后修复 create-before-status-patch failure。
-
-top-level `spec.uses` 不创建 wrapper child WorkflowRun。root WorkflowRun 会根据 immutable
-snapshot 初始化并执行 root jobs。只有 job-level calls 创建 child WorkflowRuns。
-
-## Job Shape 和 Outputs
-
-call job 支持 `needs`、`uses` 和 `with`。v0.x 不支持 `runs-on`、`steps` 或 caller-defined
-`outputs`。called Workflow 为其内部 jobs 选择 runtimes，并通过 `Workflow.spec.outputs` 暴露
-outputs。
-
-input expressions 只在 call job ready 时求值，并使用 caller 已完成 dependency outputs。求值后
-的具体值放入 child WorkflowRun 的 immutable `with` map。Secret inputs 继续保持 out of scope，
-直到单独的 secret-handling design 完成 review。
-
-output evaluation 仍属于现有 expression/output propagation story。本文只确定 boundary：child
-Workflow outputs 会提升为 caller job outputs，downstream jobs 通过普通 jobs context 访问。
-
-## Component Boundaries
-
-- WorkflowRun controller 负责 resolution、snapshots、child WorkflowRuns、child Runs、status
-  projection 和 cancellation propagation。
-- Workflow 和 Action controllers 继续只校验 definitions。
-- Scheduler 和 runtimed 继续只看到独立 Runs，不感知 Workflow calls 和 snapshots。
-- PersistentWorkspace 和 ArtifactStore 行为属于 called jobs，不属于 synthetic caller job。
-
-## API 和 RBAC Changes
-
-实现前需要 review 以下 API 和运维变更：
-
-- 增加 `WorkflowRun.status.snapshotName`；
-- 增加 `JobStatus.workflowRunName`；
-- 增加 WorkflowRun spec transition validation，保证 execution inputs immutable 且 cancellation
-  单向变化；
-- 拒绝在 `uses` job 中设置 `runs-on`、`steps` 和 caller-defined `outputs`；
-- 保留 snapshot/call-path labels 和 annotations；
-- 授予 WorkflowRun controller namespace-scoped `apps` ControllerRevision
-  get/list/watch/create/delete permissions；
-- 除 child Runs 外，watch owned child WorkflowRuns。
-
-## Rejected Alternatives
-
-### 将 callee jobs 扁平化到 parent status
-
-扁平化可以避免 child WorkflowRun objects，但需要 synthetic caller nodes、将 external dependency
-edges 重写到 callee roots 和 leaves、把 nested paths 泄漏到 labels，并在一个 status map 中混合
-独立的 workspace/artifact boundaries。Nested cancellation 和 output aggregation 也更难解释。
-
-### 每次 reconcile 都读取当前 Workflow
-
-该方案简单，但 reusable definition 被修改时会改变 in-progress execution，无法提供确定性的
-retry 或 restart recovery。
-
-### 将 resolved definitions 复制到 WorkflowRun status
-
-这会扩大 status，并可能复制 scripts 和 environment values。Status 应保持轻量 execution state，
-而不是 execution-spec store。
-
-## Implementation Plan
-
-1. API prerequisites：status references、transition validation、reserved metadata、generated
-   CRDs，以及 ControllerRevision/child-WorkflowRun RBAC。
-2. Snapshot storage 和 recursive resolver：version capture、limits、input validation，以及
-   cross-Workflow cycle detection。
-3. 从 immutable snapshot 执行 top-level `spec.uses`，修复当前只初始化 status 的缺口。
-4. 为 ready job-level calls 创建并观察 child WorkflowRuns，包括 dependency 和 terminal
-   propagation。
-5. 增加 restart、mutation、nested-call、cancellation 和 invalid-graph tests。
-6. 在现有 output propagation work 中集成 expression inputs 和 child Workflow outputs。
-7. 增加 E2E coverage，然后更新最终 workflow demo。
+1. 以 local WorkflowRun snapshot envelope 与 `JobStatus.outputs` 替换当前全树 snapshot 和 `callPath` API。
+2. 删除 root `WorkflowRun.spec.uses`/`with`；实现 `krt workflow trigger` 的模板 input 校验、渲染和 inline WorkflowRun 创建。
+3. 实现直接 child WorkflowRun 创建、input rendering 和冻结 output contracts。
+4. 实现局部 job-output 求值、child-output projection、restart recovery 和模板变更语义测试。
+5. 添加 nested calls、output propagation、cancellation、child 创建前后模板更新的 E2E coverage。
+6. 单独设计 Action expansion，并沿用相同的直接边界原则。

--- a/docs/design/workflow-job-reuse.zh.md
+++ b/docs/design/workflow-job-reuse.zh.md
@@ -85,7 +85,7 @@ child 正常执行，也可以为其 `uses` jobs 创建自己的直接 child Wor
 每个 WorkflowRun 自己拥有一个 `ControllerRevision`，名称由自身 UID 确定，并记录在 `status.snapshotName`。它只包含：
 
 - `spec`：接受的 inline `WorkflowRun.spec`，包括本地 jobs topology；
-- `outputContract`：仅当该 WorkflowRun 从可复用 Workflow materialize 出来时，保存 source Workflow 声明的 `spec.outputs` 及可选 source identity，用于诊断。
+- `outputContract`：仅当该 WorkflowRun 从可复用 Workflow materialize 出来时，保存一个以 source Workflow 名称为 key 的单项 map；其 value 是该 Workflow 声明的 `spec.outputs`。
 
 ```yaml
 apiVersion: apps/v1
@@ -103,10 +103,10 @@ data:
         runs-on: bash
         steps: [{ name: deploy, run: deploy --environment=staging }]
   outputContract:
-    workflowName: deploy-workflow
-    outputs:
-      endpoint:
-        value: ${{ jobs.apply.outputs.endpoint }}
+    deploy-workflow:
+      outputs:
+        endpoint:
+          value: ${{ jobs.apply.outputs.endpoint }}
 ```
 
 output contract 是 child 创建后保留的唯一 source-template 数据。parent 必须使用与实际执行 jobs 配套的 output 定义；如果 child 完成后读取可变的当前 Workflow，模板变更会让同一执行产生不同的 parent output。

--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -421,9 +421,8 @@ WorkflowRun controller to patch child Runs for cancellation.
 
 Inline WorkflowRun execution should land in small, reviewable steps:
 
-1. Before changing execution behavior, audit the existing E2E tests. Remove or
-   update stale cases that still exercise the old Workflow execution model so
-   `make e2e` can stay passing throughout the migration.
+1. Before changing execution behavior, audit the existing E2E tests and update
+   affected cases so `make e2e` remains passing throughout the implementation.
 2. Create only the first child Run for each ready inline job, record the child
    Run name on the matching ordered step status, and make creation idempotent
    by discovering existing child Runs through labels.
@@ -574,13 +573,10 @@ Current implementation status:
   child Runs.
 - Inline WorkflowRuns initialize `status.jobs[*].pre` and ordered
   `status.jobs[*].steps`.
-- The earlier top-level `WorkflowRun.spec.uses` prototype is superseded by the
-  rendered inline WorkflowRun trigger model. It must be removed before the
-  Workflow API stabilizes.
-- Inline and resolved reusable Workflow job DAGs reject unknown dependencies
-  and multi-job cycles before status graph initialization or child Run creation.
-- Stale E2E stubs for the old Workflow execution model have been removed so
-  E2E stays focused on behavior that should still pass during the migration.
+- WorkflowRun template triggering and job-level reusable Workflow calls remain
+  pending implementation.
+- Inline WorkflowRun job DAGs reject unknown dependencies and multi-job cycles
+  before status graph initialization or child Run creation.
 - Inline WorkflowRuns create first-step and next-step child Runs for runnable
   jobs and record child Run names in ordered step status.
 - WorkflowRuns observe terminal child Run phases, copy them into matching step
@@ -593,5 +589,3 @@ Current implementation status:
 - Restart recovery is verified across the create-before-status-patch failure
   window: a replacement controller discovers child Runs through durable labels,
   repairs step status, and continues terminal observation without duplicates.
-- Old Workflow execution E2E coverage is skipped until WorkflowRun execution
-  lands.

--- a/docs/design/workflow-reuse.md
+++ b/docs/design/workflow-reuse.md
@@ -54,14 +54,13 @@ The target split is:
 
 | Kind | Role |
 | --- | --- |
-| `WorkflowRun` | Execution instance. Defines jobs inline or calls one reusable `Workflow`. |
-| `Workflow` | Reusable workflow definition. Can be called from a `WorkflowRun` or from a job. |
+| `WorkflowRun` | Execution instance with inline jobs. |
+| `Workflow` | Reusable workflow definition. It is triggered into an inline `WorkflowRun` or called from a job. |
 | `Action` | Reusable step group. Can be called from a step inside a `WorkflowRun` or `Workflow`. |
 
 ## WorkflowRun
 
-`WorkflowRun` is the object users create to start work. It supports either
-inline jobs or a top-level workflow call.
+`WorkflowRun` is the object that executes work. It always contains inline jobs.
 
 Inline form:
 
@@ -80,21 +79,9 @@ spec:
             echo "building"
 ```
 
-Reusable Workflow call form:
-
-```yaml
-apiVersion: kruntimes.io/v1alpha1
-kind: WorkflowRun
-metadata:
-  name: release-demo
-spec:
-  uses: build-and-test
-  with:
-    image: agent:v0.1.0
-```
-
-Validation must enforce that top-level `uses` and inline `jobs` are mutually
-exclusive.
+`krt workflow trigger build-and-test --input image=agent:v0.1.0` resolves the
+template inputs and creates an equivalent inline WorkflowRun. `WorkflowRun`
+does not expose a top-level `uses` or `with` API.
 
 ## Reusable Workflow
 
@@ -141,8 +128,10 @@ spec:
 Validation must enforce that job `uses` and job `steps` are mutually exclusive.
 
 Reusable Workflow jobs have their own job/workspace/artifact boundary. They
-communicate with callers through inputs, outputs, and artifacts. The concrete
-parent/child execution boundary and immutable snapshot model are defined in
+communicate with callers through inputs, outputs, and artifacts. Each call
+creates an inline child WorkflowRun with its own local snapshot; the child
+snapshot retains the source Workflow output contract, but no shared root-wide
+execution tree. The concrete execution boundary is defined in
 [Job-Level Reusable Workflow Execution](../workflow-job-reuse/).
 
 ## Action
@@ -226,32 +215,34 @@ For v0.x, validation should prefer a narrow model:
 - missing required inputs fail validation or reconcile early;
 - unknown input names fail validation or reconcile early.
 
-The WorkflowRun controller should bind inputs before expanding child jobs or
-steps:
+The trigger client binds inputs before creating an inline root WorkflowRun. The
+WorkflowRun controller binds inputs when it creates a ready child call:
 
 1. Start from the callee's declared `inputs`.
 2. Apply each input `default`.
 3. Overlay caller-provided `with` values.
 4. Reject missing required inputs.
 5. Reject unknown `with` keys.
-6. Store the lightweight resolved DAG edges in `WorkflowRun.status.jobs`
-   before creating Runs.
+6. Render inputs into the child WorkflowRun's inline jobs before creating it.
 
-Do not let an already-started WorkflowRun observe mutable changes to a
-referenced `Workflow` or `Action`. Reusable definitions may change over time,
-but each WorkflowRun execution must be deterministic once accepted. Later work
-can add explicit revisioning; the first version should capture enough resolved
-data to make retries and controller restarts stable.
+Once a WorkflowRun exists, its inline jobs and local snapshot are immutable.
+Reusable Workflow calls are late-bound: a template can change before a waiting
+call job becomes runnable, but cannot change a child WorkflowRun after it has
+been created. The child's snapshot retains the source output contract so parent
+output projection remains deterministic after template changes. Later work can
+add explicit template revisioning for earlier binding.
 
 Step outputs come from child Run results. A step writes small key-value outputs
 to `KRUNTIME_OUTPUTS`; runtimed persists them to the child Run status. The
 WorkflowRun controller reads those child Run outputs and promotes them into the
 matching ordered `WorkflowRun.status.jobs.<job>.steps[]` entry.
 
-Job outputs are evaluated after all steps in the job succeed. Workflow outputs
-are evaluated after all jobs in the reusable Workflow succeed. Output
-evaluation must fail the WorkflowRun when an expression references a missing
-job, step, or output key.
+Job outputs are evaluated after all steps in the job succeed and stored in
+`WorkflowRun.status.jobs.<job>.outputs`. A reusable Workflow's declared outputs
+are evaluated from the successful child WorkflowRun's local job status and
+projected into the caller job's same `outputs` map. Output evaluation must fail
+the affected job when an expression references a missing job, step, or output
+key.
 
 ## Reference Resolution
 
@@ -270,17 +261,16 @@ supported long-term before the execution model is stable.
 
 Reference resolution should happen in this order:
 
-1. Resolve a top-level `WorkflowRun.spec.uses` to a `Workflow` in the same
-   namespace.
-2. Expand the referenced Workflow jobs into the WorkflowRun execution graph.
-3. Resolve each job-level `uses` to a same-namespace reusable `Workflow`.
-4. Represent each runnable reusable Workflow call as a child WorkflowRun with
+1. `krt workflow trigger` resolves a selected reusable Workflow and creates an
+   inline root WorkflowRun.
+2. Resolve each ready job-level `uses` to a same-namespace reusable `Workflow`.
+3. Represent each runnable reusable Workflow call as a child WorkflowRun with
    its own job/workspace/artifact boundary, using the immutable execution
    snapshot defined in
    [Job-Level Reusable Workflow Execution](../workflow-job-reuse/).
-5. Resolve each step-level `uses` to a same-namespace `Action`.
-6. Expand Action steps inline inside the caller job context.
-7. Detect cycles before creating any child Runs.
+4. Resolve each step-level `uses` to a same-namespace `Action`.
+5. Expand Action steps inline inside the caller job context.
+6. Detect cycles before creating any child Runs.
 
 Cycles must be rejected across Workflow calls. An Action must not call another
 Action in the first version because nested Action expansion is not needed yet
@@ -546,9 +536,10 @@ the implementation lands.
 4. Add `Action` API types, CRD validation, status, and controller skeleton.
    Namespace-local resolution, input binding, output propagation, and
    WorkflowRun execution are separate follow-up implementation steps.
-5. Implement lightweight DAG edge snapshotting and namespace-local top-level
-   `WorkflowRun.spec.uses` resolution.
-6. Implement input binding for top-level reusable Workflow calls.
+5. Implement `krt workflow trigger` to validate inputs, render a reusable
+   Workflow, and create an inline root WorkflowRun.
+6. Implement per-WorkflowRun snapshots and direct child WorkflowRun creation
+   for ready job-level calls.
 7. Implement inline WorkflowRun first-step Run creation for ready jobs.
 8. Refactor WorkflowRun controller reconciliation into a
    load/calculate/apply/patch structure with default status projection and
@@ -583,12 +574,9 @@ Current implementation status:
   child Runs.
 - Inline WorkflowRuns initialize `status.jobs[*].pre` and ordered
   `status.jobs[*].steps`.
-- Top-level `WorkflowRun.spec.uses` resolves a same-namespace reusable
-  Workflow and initializes `status.jobs` from the referenced Workflow jobs.
-  Missing references fail the WorkflowRun before child Runs are created.
-- Top-level reusable Workflow calls bind string inputs early: defaults are
-  applied, missing required inputs fail, and unknown `with` keys fail. Bound
-  values are not evaluated into child Runs until WorkflowRun execution lands.
+- The earlier top-level `WorkflowRun.spec.uses` prototype is superseded by the
+  rendered inline WorkflowRun trigger model. It must be removed before the
+  Workflow API stabilizes.
 - Inline and resolved reusable Workflow job DAGs reject unknown dependencies
   and multi-job cycles before status graph initialization or child Run creation.
 - Stale E2E stubs for the old Workflow execution model have been removed so

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -387,8 +387,8 @@ API change 需要重新生成 CRDs，并为 WorkflowRun controller 增加 patch 
 
 Inline WorkflowRun execution 应拆成小的、可 review 的步骤落地：
 
-1. 在修改 execution behavior 前，先审计现有 E2E tests。移除或更新仍在测试旧
-   Workflow execution model 的失效 case，保证整个迁移过程中 `make e2e` 始终可以通过。
+1. 在修改 execution behavior 前，先审计现有 E2E tests，并更新受影响的 cases，保证
+   整个实现过程中 `make e2e` 始终可以通过。
 2. 只为 ready inline jobs 创建第一个 child Run，将 child Run name 记录到对应的有序
    step status，并通过 labels 发现已有 child Runs 来保证创建幂等。
 3. 在增加更多 execution states 之前，将 WorkflowRun controller 重构为
@@ -525,12 +525,9 @@ status:
 - `Workflow` 现在是 reusable definition skeleton，不再执行 child Runs。
 - Inline WorkflowRuns 会初始化 `status.jobs[*].pre` 和有序
   `status.jobs[*].steps`。
-- 早期的 top-level `WorkflowRun.spec.uses` prototype 已被 rendered inline
-  WorkflowRun trigger 模型取代，必须在 Workflow API 稳定前删除。
-- Inline 和 resolved reusable Workflow job DAG 会在初始化 status graph 或创建 child Runs
-  前拒绝 unknown dependencies 和 multi-job cycles。
-- 旧 Workflow execution model 的 stale E2E stubs 已删除，保证迁移期间 E2E 聚焦于
-  仍应保持 passing 的行为。
+- WorkflowRun template trigger 和 job-level reusable Workflow calls 仍待实现。
+- Inline WorkflowRun job DAG 会在初始化 status graph 或创建 child Runs 前拒绝 unknown
+  dependencies 和 multi-job cycles。
 - Inline WorkflowRuns 会为 runnable jobs 创建 first-step 和 next-step child Runs，并将
   child Run names 记录到有序 step status 中。
 - WorkflowRuns 会观察 terminal child Run phases、复制到匹配的 step status、聚合
@@ -542,4 +539,3 @@ status:
 - Restart recovery 已覆盖 create-before-status-patch 故障窗口：replacement controller
   通过 durable labels 发现 child Runs、修复 step status，并继续观察 terminal state，且
   不会重复创建 Runs。
-- 旧 Workflow execution E2E coverage 暂时 skip，等待 WorkflowRun execution 实现后恢复。

--- a/docs/design/workflow-reuse.zh.md
+++ b/docs/design/workflow-reuse.zh.md
@@ -51,13 +51,13 @@ definitions。当前 experimental `Workflow` CRD 表示 execution instance。这
 
 | Kind | 角色 |
 | --- | --- |
-| `WorkflowRun` | Execution instance。inline 定义 jobs，或调用一个 reusable `Workflow`。 |
-| `Workflow` | Reusable workflow definition。可被 `WorkflowRun` 或 job 调用。 |
+| `WorkflowRun` | 带 inline jobs 的 execution instance。 |
+| `Workflow` | Reusable workflow definition。可被 trigger 为 inline `WorkflowRun`，或被 job 调用。 |
 | `Action` | Reusable step group。可被 `WorkflowRun` 或 `Workflow` 中的 step 调用。 |
 
 ## WorkflowRun
 
-`WorkflowRun` 是用户用来启动执行的对象。它支持 inline jobs，或 top-level workflow call。
+`WorkflowRun` 是执行工作的对象，始终包含 inline jobs。
 
 Inline 形态：
 
@@ -76,20 +76,8 @@ spec:
             echo "building"
 ```
 
-Reusable Workflow call 形态：
-
-```yaml
-apiVersion: kruntimes.io/v1alpha1
-kind: WorkflowRun
-metadata:
-  name: release-demo
-spec:
-  uses: build-and-test
-  with:
-    image: agent:v0.1.0
-```
-
-Validation 必须保证 top-level `uses` 和 inline `jobs` 互斥。
+`krt workflow trigger build-and-test --input image=agent:v0.1.0` 会解析模板 inputs，
+并创建等价的 inline WorkflowRun。WorkflowRun 不暴露 top-level `uses` 或 `with` API。
 
 ## Reusable Workflow
 
@@ -135,8 +123,10 @@ spec:
 Validation 必须保证 job `uses` 和 job `steps` 互斥。
 
 Reusable Workflow jobs 拥有自己的 job/workspace/artifact boundary。它们通过 inputs、
-outputs 和 artifacts 与 caller 通信。具体的 parent/child execution boundary 和 immutable
-snapshot model 见 [Job-Level Reusable Workflow Execution](../workflow-job-reuse/)。
+outputs 和 artifacts 与 caller 通信。每次调用创建带自身 local snapshot 的 inline child
+WorkflowRun；child snapshot 保留 source Workflow output contract，但不维护 shared root-wide
+execution tree。具体 execution boundary 见
+[Job-Level Reusable Workflow Execution](../workflow-job-reuse/)。
 
 ## Action
 
@@ -219,28 +209,31 @@ outputs:
 - 缺少 required inputs 时 validation 或 reconcile 早期失败；
 - 未知 input names 时 validation 或 reconcile 早期失败。
 
-WorkflowRun controller 应在展开 child jobs 或 steps 之前完成 input binding：
+trigger client 在创建 inline root WorkflowRun 前完成 input binding。WorkflowRun controller
+在创建 ready child call 时完成 input binding：
 
 1. 从 callee 声明的 `inputs` 开始。
 2. 应用每个 input 的 `default`。
 3. 覆盖 caller 通过 `with` 传入的 values。
 4. 拒绝缺少 required inputs 的调用。
 5. 拒绝未知的 `with` keys。
-6. 在创建 Runs 之前，将轻量 resolved DAG edges 存入 `WorkflowRun.status.jobs`。
+6. 在创建 child 前，将 inputs 渲染到 child WorkflowRun 的 inline jobs。
 
-已经启动的 WorkflowRun 不应观察到被引用 `Workflow` 或 `Action` 的后续变更。Reusable
-definitions 可以随时间变化，但每个 WorkflowRun 一旦 accepted，它的执行必须是确定的。后续
-可以增加显式 revisioning；第一版应捕获足够的 resolved data，让 retries 和 controller
-restart 后的恢复保持稳定。
+WorkflowRun 创建后，它的 inline jobs 和 local snapshot 都是 immutable。Reusable Workflow
+calls 是 late-bound：waiting call job 变为 runnable 前模板可以变化，但 child WorkflowRun
+创建后模板不能再改变它。child snapshot 会保留 source output contract，因此模板变化后 parent
+output projection 仍是确定的。后续可以通过显式 template revisioning 支持更早 binding。
 
 Step outputs 来自 child Run 结果。step 将小型 key-value outputs 写入
 `KRUNTIME_OUTPUTS`；runtimed 将其持久化到 child Run status。WorkflowRun controller
 读取这些 child Run outputs，并提升到匹配的有序
 `WorkflowRun.status.jobs.<job>.steps[]` entry。
 
-Job outputs 在 job 内所有 steps 成功后计算。Workflow outputs 在 reusable Workflow 内所有
-jobs 成功后计算。当 expression 引用了不存在的 job、step 或 output key 时，output
-evaluation 必须让 WorkflowRun 失败。
+Job outputs 在 job 内所有 steps 成功后计算，并保存到
+`WorkflowRun.status.jobs.<job>.outputs`。Reusable Workflow 的 declared outputs 根据成功
+child WorkflowRun 的 local job status 求值，再投影到 caller job 相同的 `outputs` map。
+当 expression 引用了不存在的 job、step 或 output key 时，output evaluation 必须使受影响
+job 失败。
 
 ## Reference Resolution
 
@@ -259,15 +252,14 @@ format。
 
 Reference resolution 应按以下顺序发生：
 
-1. 将 top-level `WorkflowRun.spec.uses` 解析到同 namespace 下的 `Workflow`。
-2. 将被引用 Workflow 的 jobs 展开到 WorkflowRun execution graph。
-3. 将每个 job-level `uses` 解析到同 namespace 下的 reusable `Workflow`。
-4. 使用 [Job-Level Reusable Workflow Execution](../workflow-job-reuse/) 定义的 immutable
+1. `krt workflow trigger` 解析指定 reusable Workflow 并创建 inline root WorkflowRun。
+2. 将每个 ready job-level `uses` 解析到同 namespace 下的 reusable `Workflow`。
+3. 使用 [Job-Level Reusable Workflow Execution](../workflow-job-reuse/) 定义的 immutable
    execution snapshot，把每个 runnable reusable Workflow call 表示为拥有独立
    job/workspace/artifact boundary 的 child WorkflowRun。
-5. 将每个 step-level `uses` 解析到同 namespace 下的 `Action`。
-6. 将 Action steps inline 展开到 caller job context。
-7. 在创建任何 child Runs 之前检测 cycles。
+4. 将每个 step-level `uses` 解析到同 namespace 下的 `Action`。
+5. 将 Action steps inline 展开到 caller job context。
+6. 在创建任何 child Runs 之前检测 cycles。
 
 Workflow calls 之间的 cycles 必须被拒绝。第一版中 Action 不应再调用另一个 Action，因为
 nested Action expansion 目前不需要，而且会增加 cycle detection 的复杂度。Reusable
@@ -498,9 +490,10 @@ status:
 4. 增加 `Action` API types、CRD validation、status 和 controller skeleton。
    Namespace-local resolution、input binding、output propagation 和 WorkflowRun
    execution 是后续独立实现步骤。
-5. 实现轻量 DAG edge snapshotting 和 top-level `WorkflowRun.spec.uses` 的
-   namespace-local resolution。
-6. 实现 top-level reusable Workflow calls 的 input binding。
+5. 实现 `krt workflow trigger`：校验 inputs、渲染 reusable Workflow，并创建 inline
+   root WorkflowRun。
+6. 为 ready job-level calls 实现 per-WorkflowRun snapshots 和直接 child
+   WorkflowRun 创建。
 7. 实现 ready jobs 的 inline WorkflowRun first-step Run creation。
 8. 将 WorkflowRun controller reconciliation 重构为 load/calculate/apply/patch 结构：
    默认推导 status，并将 external side effects 建模为 actions。
@@ -532,12 +525,8 @@ status:
 - `Workflow` 现在是 reusable definition skeleton，不再执行 child Runs。
 - Inline WorkflowRuns 会初始化 `status.jobs[*].pre` 和有序
   `status.jobs[*].steps`。
-- Top-level `WorkflowRun.spec.uses` 会解析同 namespace 下的 reusable
-  Workflow，并基于被引用 Workflow 的 jobs 初始化 `status.jobs`。Missing
-  references 会在创建 child Runs 前让 WorkflowRun 失败。
-- Top-level reusable Workflow calls 会提前绑定 string inputs：应用 defaults，
-  missing required inputs 会失败，unknown `with` keys 也会失败。Bound values 会等到
-  WorkflowRun execution 实现后再用于 child Runs。
+- 早期的 top-level `WorkflowRun.spec.uses` prototype 已被 rendered inline
+  WorkflowRun trigger 模型取代，必须在 Workflow API 稳定前删除。
 - Inline 和 resolved reusable Workflow job DAG 会在初始化 status graph 或创建 child Runs
   前拒绝 unknown dependencies 和 multi-job cycles。
 - 旧 Workflow execution model 的 stale E2E stubs 已删除，保证迁移期间 E2E 聚焦于

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -199,8 +199,8 @@ wiring from accumulating avoidable conflicts.
 - [ ] Workflow reuse model: split execution instances from reusable
   definitions before Workflow APIs stabilize. Target model:
   - replace the current execution-instance `Workflow` API with `WorkflowRun`;
-  - `WorkflowRun.spec` supports either inline `jobs` or top-level `uses` plus
-    `with` inputs;
+  - `WorkflowRun.spec` contains inline `jobs` only; `krt workflow trigger`
+    renders a reusable Workflow into an inline execution instance;
   - add a reusable `Workflow` CRD whose jobs can be called from a
     `WorkflowRun` job with `uses: <workflow-name>` and optional `with`;
   - add a reusable `Action` CRD whose steps can be called from a
@@ -209,8 +209,8 @@ wiring from accumulating avoidable conflicts.
   - keep names namespace-local in the first version; avoid verbose
     `workflowRef` and `actionRef` fields until cross-namespace or remote
     references are required;
-  - validation must enforce mutually exclusive shapes: top-level `uses` vs
-    inline `jobs`, job `uses` vs `steps`, and step `uses` vs `run`;
+  - validation must enforce clear local shapes: WorkflowRun inline jobs, job
+    `uses` vs `steps`, and step `uses` vs `run`;
   - Actions run inside the caller job context and share that job runtime,
     workspace, artifacts, and environment unless a future API explicitly
     overrides them;
@@ -231,9 +231,8 @@ wiring from accumulating avoidable conflicts.
   - [x] update CLI verbs and docs so execution uses `WorkflowRun`;
   - [x] initialize lightweight `status.jobs[*].pre` and ordered `steps` for
     inline WorkflowRuns;
-  - [x] implement namespace-local top-level `WorkflowRun.spec.uses`
-    resolution;
-  - [x] implement input binding for top-level reusable Workflow calls;
+  - [x] explore top-level `WorkflowRun.spec.uses` resolution and input binding;
+    superseded by rendered inline WorkflowRun triggering;
   - [x] audit existing E2E tests before inline execution changes, and remove or
     update stale cases that still use the old Workflow execution model so
     `make e2e` stays passing during the migration;
@@ -259,17 +258,18 @@ wiring from accumulating avoidable conflicts.
     including child Run creation before status persistence;
   - [ ] implement job-level reusable Workflow calls through the reviewed
     [execution-boundary design](design/workflow-job-reuse.md):
-    - [x] review and approve the child WorkflowRun and immutable snapshot model;
-    - [x] add status references, spec transition validation, reserved metadata,
-      generated CRDs, and controller RBAC prerequisites;
-    - [x] add immutable ControllerRevision snapshot storage and recursive resolution with version
-      capture, call limits, input validation, and cycle detection;
-    - [x] execute top-level `WorkflowRun.spec.uses` from its snapshot instead of
-      only initializing status;
-    - [ ] create and observe child WorkflowRuns for ready job-level calls;
-    - [ ] verify definition mutation isolation, restart recovery, nested calls,
+    - [x] review and approve the direct child WorkflowRun and local snapshot model;
+    - [ ] remove root `WorkflowRun.spec.uses`/`with` and implement template
+      triggering as rendered inline WorkflowRun creation;
+    - [ ] add a per-WorkflowRun immutable snapshot with the local execution
+      spec and a frozen source output contract for materialized children;
+    - [ ] create and observe child WorkflowRuns for ready job-level calls,
+      including input rendering and output-contract capture;
+    - [ ] project inline and child Workflow outputs into bounded
+      `WorkflowRun.status.jobs.<job>.outputs` values;
+    - [ ] verify late-binding behavior before child creation, deterministic
+      behavior after child creation, restart recovery, nested calls,
       cancellation, and invalid graphs;
-    - [ ] integrate call inputs and outputs with expression/output propagation;
   - implement step-level Action expansion;
   - implement expression evaluation for `inputs`, `steps`, and `jobs` contexts;
   - promote child Run outputs into WorkflowRun step/job/workflow outputs;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -231,11 +231,8 @@ wiring from accumulating avoidable conflicts.
   - [x] update CLI verbs and docs so execution uses `WorkflowRun`;
   - [x] initialize lightweight `status.jobs[*].pre` and ordered `steps` for
     inline WorkflowRuns;
-  - [x] explore top-level `WorkflowRun.spec.uses` resolution and input binding;
-    superseded by rendered inline WorkflowRun triggering;
-  - [x] audit existing E2E tests before inline execution changes, and remove or
-    update stale cases that still use the old Workflow execution model so
-    `make e2e` stays passing during the migration;
+  - [x] audit existing E2E tests before inline execution changes and update
+    affected cases so `make e2e` stays passing during implementation;
   - [x] implement inline WorkflowRun first-step Run creation for ready jobs;
   - [x] refactor WorkflowRun controller reconciliation into a
     load/calculate/apply/patch structure where status is derived on every

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -199,10 +199,8 @@ controller wiring 累积不必要的冲突。
     语义的 `krt wf` verbs；
   - [x] 更新 CLI verbs 和 docs，使 execution 使用 `WorkflowRun`；
   - [x] 为 inline WorkflowRuns 初始化轻量 `status.jobs[*].pre` 和有序 `steps`；
-  - [x] 探索 top-level `WorkflowRun.spec.uses` 的 namespace-local resolution 和
-    input binding；该方案已被 rendered inline WorkflowRun trigger 取代；
-  - [x] 在 inline execution changes 开始前审计现有 E2E tests，移除或更新仍使用旧
-    Workflow execution model 的失效 cases，保证迁移过程中 `make e2e` 始终可以通过；
+  - [x] 在 inline execution changes 开始前审计现有 E2E tests，并更新受影响的 cases，
+    保证整个实现过程中 `make e2e` 始终可以通过；
   - [x] 实现 ready jobs 的 inline WorkflowRun first-step Run creation；
   - [x] 将 WorkflowRun controller reconciliation 重构为
     load/calculate/apply/patch 结构：每次 reconciliation 默认推导 status，只有 external

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -173,15 +173,16 @@ controller wiring 累积不必要的冲突。
     job-to-job artifact passing、Runtime Pod loss、cleanup 和权限边界。
 - [ ] Workflow reuse model：在 Workflow API 稳定前拆分执行实例和可复用定义。目标模型：
   - 将当前表示 execution instance 的 `Workflow` API 替换为 `WorkflowRun`；
-  - `WorkflowRun.spec` 支持 inline `jobs`，也支持 top-level `uses` 加 `with` inputs；
+  - `WorkflowRun.spec` 只包含 inline `jobs`；`krt workflow trigger` 将 reusable
+    Workflow 渲染为 inline execution instance；
   - 新增可复用 `Workflow` CRD，`WorkflowRun` 的 job 可以通过 `uses: <workflow-name>`
     和可选 `with` 调用同 namespace 下的 Workflow；
   - 新增可复用 `Action` CRD，`WorkflowRun` 或 `Workflow` 的 step 可以通过
     `uses: <action-name>` 和可选 `with` 调用同 namespace 下的 Action；
   - 第一版保持 namespace-local 名称引用；在需要 cross-namespace 或 remote references 之前，
     不引入冗长的 `workflowRef` 和 `actionRef` 字段；
-  - validation 必须保证互斥 shape：top-level `uses` vs inline `jobs`、job `uses`
-    vs `steps`、step `uses` vs `run`；
+  - validation 必须保证清晰的 local shapes：WorkflowRun inline jobs、job `uses` vs
+    `steps`、step `uses` vs `run`；
   - Action 在 caller job context 内运行，默认共享 caller job 的 runtime、workspace、
     artifacts 和 environment，除非未来 API 显式 override；
   - reusable Workflow job 拥有自己的 job/workspace/artifact boundary，并通过 inputs、
@@ -198,9 +199,8 @@ controller wiring 累积不必要的冲突。
     语义的 `krt wf` verbs；
   - [x] 更新 CLI verbs 和 docs，使 execution 使用 `WorkflowRun`；
   - [x] 为 inline WorkflowRuns 初始化轻量 `status.jobs[*].pre` 和有序 `steps`；
-  - [x] 实现 top-level `WorkflowRun.spec.uses` 的 namespace-local
-    resolution；
-  - [x] 实现 top-level reusable Workflow calls 的 input binding；
+  - [x] 探索 top-level `WorkflowRun.spec.uses` 的 namespace-local resolution 和
+    input binding；该方案已被 rendered inline WorkflowRun trigger 取代；
   - [x] 在 inline execution changes 开始前审计现有 E2E tests，移除或更新仍使用旧
     Workflow execution model 的失效 cases，保证迁移过程中 `make e2e` 始终可以通过；
   - [x] 实现 ready jobs 的 inline WorkflowRun first-step Run creation；
@@ -225,16 +225,17 @@ controller wiring 累积不必要的冲突。
   - [ ] 按照完成 review 的
     [execution-boundary design](design/workflow-job-reuse.md) 实现 job-level reusable
     Workflow calls：
-    - [x] review 并批准 child WorkflowRun 和 immutable snapshot model；
-    - [x] 增加 status references、spec transition validation、reserved metadata、generated
-      CRDs 和 controller RBAC prerequisites；
-    - [x] 增加 immutable ControllerRevision snapshot storage 和 recursive resolution，包括 version capture、
-      call limits、input validation 和 cycle detection；
-    - [x] 从 snapshot 执行 top-level `WorkflowRun.spec.uses`，而不是只初始化 status；
-    - [ ] 为 ready job-level calls 创建并观察 child WorkflowRuns；
-    - [ ] 验证 definition mutation isolation、restart recovery、nested calls、cancellation 和
-      invalid graphs；
-    - [ ] 将 call inputs 和 outputs 接入 expression/output propagation；
+    - [x] review 并批准 direct child WorkflowRun 和 local snapshot model；
+    - [ ] 删除 root `WorkflowRun.spec.uses`/`with`，并实现 template trigger 到 rendered inline
+      WorkflowRun 的创建；
+    - [ ] 为每个 WorkflowRun 增加 immutable snapshot，其中包含 local execution spec，以及
+      materialized child 的 frozen source output contract；
+    - [ ] 为 ready job-level calls 创建并观察 child WorkflowRuns，包括 input rendering 和
+      output-contract capture；
+    - [ ] 将 inline 和 child Workflow outputs 投影到有界的
+      `WorkflowRun.status.jobs.<job>.outputs`；
+    - [ ] 验证 child 创建前的 late-binding、child 创建后的 deterministic behavior、restart
+      recovery、nested calls、cancellation 和 invalid graphs；
   - 实现 step-level Action expansion；
   - 实现 `inputs`、`steps` 和 `jobs` contexts 的 expression evaluation；
   - 将 child Run outputs 提升为 WorkflowRun step/job/workflow outputs；


### PR DESCRIPTION
## Summary
- replace the root-wide Workflow snapshot and call-path model with per-WorkflowRun snapshots
- require inline WorkflowRun jobs and define template triggering through krt workflow trigger
- freeze only the reusable Workflow output contract in each materialized child snapshot
- document uniform job outputs, late-binding semantics, and the revised implementation roadmap

## Verification
- GOBIN=/tmp/kruntimes-bin make site-build

This is an architecture-design PR. It intentionally does not implement the new API or controller behavior.