### PR TITLE
docs(workflow): define call-cycle detection

### DIFF
--- a/docs/design/workflow-job-reuse.md
+++ b/docs/design/workflow-job-reuse.md
@@ -141,46 +141,33 @@ different parent output values after a template edit.
 
 A snapshot is owned and used only by its own WorkflowRun.
 
-## Call Provenance and Cycle Detection
+## Workflow Call Graph Validation
 
-Workflow reuse must not create an unbounded chain such as `A -> B -> A`. The
-controller detects a cycle before it creates a child WorkflowRun; it never
-relies on later cleanup to stop recursive creation.
+Workflow reuse must not create an unbounded chain such as `A -> B -> A`. Cycle
+validation happens while resolving reusable Workflow definitions, before any
+WorkflowRun is created for the selected template or call job.
 
-`krt wf trigger` and the WorkflowRun controller use the reserved
-`kruntimes.io/workflow-source` annotation only when they create a materialized
-WorkflowRun. During that WorkflowRun's first reconciliation, the controller
-validates the namespace-local Workflow name and freezes it in the local
-snapshot:
+`krt wf trigger A` recursively reads every namespace-local Workflow reachable
+from `A` through job-level `uses`. It validates missing references, cycles, and
+the initial maximum nesting depth of 8 before rendering inputs and creating the
+inline root WorkflowRun. For `A -> B -> A`, triggering fails with a
+deterministic `workflow call cycle: A -> B -> A` error and creates no
+WorkflowRun.
 
-```yaml
-data:
-  spec: { ... }
-  source:
-    workflow: build-and-test
-```
+The WorkflowRun controller applies the same graph validation when a ready
+inline job references `uses: A`. It validates the graph rooted at `A` before
+rendering inputs or creating the direct child WorkflowRun. A deterministic
+validation failure marks only that call job `Failed`; it creates no child and
+is not retried. Normal failed-dependency propagation then marks dependent jobs
+`Skipped`, and ordinary WorkflowRun terminal aggregation determines the parent
+phase.
 
-The annotation is not an execution input and is not a user-facing
-`WorkflowRun.spec` field. A directly created inline WorkflowRun has no source.
-After the snapshot exists, planning reads only the snapshot, not the mutable
-annotation or the current Workflow definition.
-
-Before creating a `uses: <target>` child, the controller follows the current
-WorkflowRun's owner chain and reads each ancestor's frozen `source.workflow`.
-It appends the target to that ordered ancestry:
-
-- if the target is already present, the call job becomes `Failed` with a
-  deterministic message such as `workflow call cycle: A -> B -> A`; no child
-  is created;
-- if the resulting template depth exceeds 8, the call job becomes `Failed`
-  with a depth-limit message; no child is created;
-- a missing or invalid parent provenance is a deterministic call-resolution
-  failure, not a retryable controller error.
-
-Normal failed-dependency propagation then marks dependent jobs `Skipped`, and
-ordinary WorkflowRun terminal aggregation determines the parent phase. This is
-local to each WorkflowRun: no scheduler or runtimed behavior changes, and no
-root-wide execution-tree object is introduced.
+The CLI and controller must share one graph-validation implementation and
+error format so both paths make the same decision for the same Workflow graph.
+The shared logic loads namespace-local Workflow definitions, performs a
+depth-first traversal with the current name stack, and does not persist
+provenance annotations, owner-chain metadata, or a root-wide execution tree.
+Scheduler and runtimed behavior is unchanged.
 
 ## Inputs and Outputs
 
@@ -261,9 +248,9 @@ They have no Workflow reuse, snapshot, or output-contract behavior.
 - A call job has `needs`, `uses`, and optional `with`; it cannot contain
   `runs-on` or `steps`.
 - Inputs and expression references are validated before creating a child.
-- Workflow cycles are detected from frozen call provenance along the active
-  parent/child owner chain before a child is created. The initial maximum
-  nesting depth is 8.
+- Workflow cycles are detected while resolving the referenced Workflow graph
+  before a root or child WorkflowRun is created. The initial maximum nesting
+  depth is 8.
 - Job and step outputs are bounded by CRD limits; artifacts are not outputs.
 
 ## Reusable Actions

--- a/docs/design/workflow-job-reuse.md
+++ b/docs/design/workflow-job-reuse.md
@@ -141,6 +141,47 @@ different parent output values after a template edit.
 
 A snapshot is owned and used only by its own WorkflowRun.
 
+## Call Provenance and Cycle Detection
+
+Workflow reuse must not create an unbounded chain such as `A -> B -> A`. The
+controller detects a cycle before it creates a child WorkflowRun; it never
+relies on later cleanup to stop recursive creation.
+
+`krt wf trigger` and the WorkflowRun controller use the reserved
+`kruntimes.io/workflow-source` annotation only when they create a materialized
+WorkflowRun. During that WorkflowRun's first reconciliation, the controller
+validates the namespace-local Workflow name and freezes it in the local
+snapshot:
+
+```yaml
+data:
+  spec: { ... }
+  source:
+    workflow: build-and-test
+```
+
+The annotation is not an execution input and is not a user-facing
+`WorkflowRun.spec` field. A directly created inline WorkflowRun has no source.
+After the snapshot exists, planning reads only the snapshot, not the mutable
+annotation or the current Workflow definition.
+
+Before creating a `uses: <target>` child, the controller follows the current
+WorkflowRun's owner chain and reads each ancestor's frozen `source.workflow`.
+It appends the target to that ordered ancestry:
+
+- if the target is already present, the call job becomes `Failed` with a
+  deterministic message such as `workflow call cycle: A -> B -> A`; no child
+  is created;
+- if the resulting template depth exceeds 8, the call job becomes `Failed`
+  with a depth-limit message; no child is created;
+- a missing or invalid parent provenance is a deterministic call-resolution
+  failure, not a retryable controller error.
+
+Normal failed-dependency propagation then marks dependent jobs `Skipped`, and
+ordinary WorkflowRun terminal aggregation determines the parent phase. This is
+local to each WorkflowRun: no scheduler or runtimed behavior changes, and no
+root-wide execution-tree object is introduced.
+
 ## Inputs and Outputs
 
 `JobStatus` gains a bounded `outputs` map. All job outputs, whether produced by
@@ -220,8 +261,9 @@ They have no Workflow reuse, snapshot, or output-contract behavior.
 - A call job has `needs`, `uses`, and optional `with`; it cannot contain
   `runs-on` or `steps`.
 - Inputs and expression references are validated before creating a child.
-- Workflow cycles are detected along the active parent/child call chain before
-  a child is created. The initial maximum nesting depth is 8.
+- Workflow cycles are detected from frozen call provenance along the active
+  parent/child owner chain before a child is created. The initial maximum
+  nesting depth is 8.
 - Job and step outputs are bounded by CRD limits; artifacts are not outputs.
 
 ## Reusable Actions
@@ -241,6 +283,7 @@ being added to a root-wide Workflow snapshot or controller traversal tree.
    output contracts.
 4. Implement local job-output evaluation, child-output projection, restart
    recovery, and template-mutation semantics tests.
-5. Add E2E coverage for nested calls, output propagation, cancellation, and
+5. Add E2E coverage for nested calls, including self-references and
+   `A -> B -> A` cycle rejection, output propagation, cancellation, and
    template updates before versus after child creation.
 6. Design Action expansion separately, using the same direct-boundary rule.

--- a/docs/design/workflow-job-reuse.zh.md
+++ b/docs/design/workflow-job-reuse.zh.md
@@ -113,39 +113,26 @@ output contract 是 child 创建后保留的唯一 source-template 数据。pare
 
 一个 snapshot 只由自己的 WorkflowRun 拥有和使用。
 
-## 调用 Provenance 与 Cycle Detection
+## Workflow Call Graph Validation
 
-Workflow reuse 不能创建 `A -> B -> A` 这样的无界调用链。controller 必须在创建 child
-WorkflowRun **之前**检测 cycle，不能依赖之后的 cleanup 来停止递归创建。
+Workflow reuse 不能创建 `A -> B -> A` 这样的无界调用链。cycle validation 在解析 reusable
+Workflow definitions 时完成，且必须在为所选模板或 call job 创建任何 WorkflowRun **之前**完成。
 
-`krt wf trigger` 和 WorkflowRun controller 仅在创建 materialized WorkflowRun 时使用保留的
-`kruntimes.io/workflow-source` annotation。该 WorkflowRun 第一次 reconcile 时，controller
-校验 namespace-local Workflow name，并把它冻结到 local snapshot：
+`krt wf trigger A` 递归读取从 `A` 的 job-level `uses` 可达的所有 namespace-local Workflow。
+它在渲染 inputs 和创建 inline root WorkflowRun 前校验 missing references、cycles 和初始最大
+嵌套深度 8。对于 `A -> B -> A`，trigger 以确定性的
+`workflow call cycle: A -> B -> A` error 失败，且不创建 WorkflowRun。
 
-```yaml
-data:
-  spec: { ... }
-  source:
-    workflow: build-and-test
-```
+WorkflowRun controller 对 ready inline job 的 `uses: A` 应用相同的 graph validation。它在
+渲染 inputs 或创建直接 child WorkflowRun 前校验以 `A` 为根的图。确定性的 validation failure
+只将对应 call job 标为 `Failed`；不创建 child，也不重试。之后正常的 failed-dependency
+propagation 会将 dependent jobs 标为 `Skipped`，普通的 WorkflowRun terminal aggregation 决定
+parent phase。
 
-该 annotation 不是 execution input，也不是面向用户的 `WorkflowRun.spec` field。直接创建的
-inline WorkflowRun 没有 source。snapshot 创建后，planning 只读取 snapshot，不读取可变的
-annotation 或当前 Workflow definition。
-
-创建 `uses: <target>` child 前，controller 沿当前 WorkflowRun 的 owner chain 向上读取每个
-ancestor snapshot 中冻结的 `source.workflow`，并将 target 加到有序 ancestry：
-
-- target 已出现时，call job 变为 `Failed`，并使用确定性 message，例如
-  `workflow call cycle: A -> B -> A`；不创建 child；
-- 加入 target 后的 template depth 超过 8 时，call job 变为 `Failed` 并记录 depth-limit
-  message；不创建 child；
-- parent provenance 缺失或无效是确定性的 call-resolution failure，不是可 retry 的
-  controller error。
-
-之后正常的 failed-dependency propagation 会把 dependent jobs 标为 `Skipped`，普通的
-WorkflowRun terminal aggregation 决定 parent phase。整个机制局限在每个 WorkflowRun：不修改
-scheduler 或 runtimed，也不引入 root-wide execution-tree object。
+CLI 和 controller 必须共享同一个 graph-validation implementation 和 error format，以便两个
+路径对相同的 Workflow graph 作出相同决定。shared logic 加载 namespace-local Workflow
+definitions，以当前 name stack 做 depth-first traversal，不保存 provenance annotations、
+owner-chain metadata 或 root-wide execution tree。scheduler 和 runtimed 行为不变。
 
 ## Inputs 与 Outputs
 
@@ -203,7 +190,7 @@ Scheduler 和 runtimed 仍然只处理独立 `Run`，不了解 Workflow reuse、
 - WorkflowRun 自身不能包含 `uses` 或 `with`。
 - 调用 job 包含 `needs`、`uses` 和可选 `with`，不能包含 `runs-on` 或 `steps`。
 - 创建 child 前校验 inputs 和 expression references。
-- 在创建 child 前，根据沿 parent/child owner chain 的冻结 call provenance 检测 Workflow cycle；
+- 在创建 root 或 child WorkflowRun 前，在解析被引用的 Workflow graph 时检测 Workflow cycle；
   初始最大嵌套深度为 8。
 - job 与 step outputs 受 CRD 大小限制；artifacts 不是 outputs。
 

--- a/docs/design/workflow-job-reuse.zh.md
+++ b/docs/design/workflow-job-reuse.zh.md
@@ -113,6 +113,40 @@ output contract 是 child 创建后保留的唯一 source-template 数据。pare
 
 一个 snapshot 只由自己的 WorkflowRun 拥有和使用。
 
+## 调用 Provenance 与 Cycle Detection
+
+Workflow reuse 不能创建 `A -> B -> A` 这样的无界调用链。controller 必须在创建 child
+WorkflowRun **之前**检测 cycle，不能依赖之后的 cleanup 来停止递归创建。
+
+`krt wf trigger` 和 WorkflowRun controller 仅在创建 materialized WorkflowRun 时使用保留的
+`kruntimes.io/workflow-source` annotation。该 WorkflowRun 第一次 reconcile 时，controller
+校验 namespace-local Workflow name，并把它冻结到 local snapshot：
+
+```yaml
+data:
+  spec: { ... }
+  source:
+    workflow: build-and-test
+```
+
+该 annotation 不是 execution input，也不是面向用户的 `WorkflowRun.spec` field。直接创建的
+inline WorkflowRun 没有 source。snapshot 创建后，planning 只读取 snapshot，不读取可变的
+annotation 或当前 Workflow definition。
+
+创建 `uses: <target>` child 前，controller 沿当前 WorkflowRun 的 owner chain 向上读取每个
+ancestor snapshot 中冻结的 `source.workflow`，并将 target 加到有序 ancestry：
+
+- target 已出现时，call job 变为 `Failed`，并使用确定性 message，例如
+  `workflow call cycle: A -> B -> A`；不创建 child；
+- 加入 target 后的 template depth 超过 8 时，call job 变为 `Failed` 并记录 depth-limit
+  message；不创建 child；
+- parent provenance 缺失或无效是确定性的 call-resolution failure，不是可 retry 的
+  controller error。
+
+之后正常的 failed-dependency propagation 会把 dependent jobs 标为 `Skipped`，普通的
+WorkflowRun terminal aggregation 决定 parent phase。整个机制局限在每个 WorkflowRun：不修改
+scheduler 或 runtimed，也不引入 root-wide execution-tree object。
+
 ## Inputs 与 Outputs
 
 `JobStatus` 增加有界的 `outputs` map。inline job 和可复用 Workflow 调用的输出都在同一位置暴露：
@@ -169,7 +203,8 @@ Scheduler 和 runtimed 仍然只处理独立 `Run`，不了解 Workflow reuse、
 - WorkflowRun 自身不能包含 `uses` 或 `with`。
 - 调用 job 包含 `needs`、`uses` 和可选 `with`，不能包含 `runs-on` 或 `steps`。
 - 创建 child 前校验 inputs 和 expression references。
-- 在创建 child 前，沿 active parent/child call chain 检测 Workflow cycle；初始最大嵌套深度为 8。
+- 在创建 child 前，根据沿 parent/child owner chain 的冻结 call provenance 检测 Workflow cycle；
+  初始最大嵌套深度为 8。
 - job 与 step outputs 受 CRD 大小限制；artifacts 不是 outputs。
 
 ## 可复用 Actions
@@ -182,5 +217,6 @@ Scheduler 和 runtimed 仍然只处理独立 `Run`，不了解 Workflow reuse、
 2. 实现 `krt workflow trigger` 的模板 input 校验、渲染和 inline WorkflowRun 创建。
 3. 实现直接 child WorkflowRun 创建、input rendering 和冻结 output contracts。
 4. 实现局部 job-output 求值、child-output projection、restart recovery 和模板变更语义测试。
-5. 添加 nested calls、output propagation、cancellation、child 创建前后模板更新的 E2E coverage。
+5. 添加 nested calls E2E coverage，包括 self-reference 和 `A -> B -> A` cycle rejection、
+   output propagation、cancellation，以及 child 创建前后模板更新。
 6. 单独设计 Action expansion，并沿用相同的直接边界原则。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -268,7 +268,8 @@ wiring from accumulating avoidable conflicts.
       `WorkflowRun.status.jobs.<job>.outputs` values;
     - [ ] verify late-binding behavior before child creation, deterministic
       behavior after child creation, restart recovery, nested calls,
-      cancellation, and invalid graphs;
+      cancellation, and invalid graphs, including `A -> B -> A` cycle
+      rejection before child creation;
   - implement step-level Action expansion;
   - implement expression evaluation for `inputs`, `steps`, and `jobs` contexts;
   - promote child Run outputs into WorkflowRun step/job/workflow outputs;

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -234,7 +234,8 @@ controller wiring 累积不必要的冲突。
     - [ ] 将 inline 和 child Workflow outputs 投影到有界的
       `WorkflowRun.status.jobs.<job>.outputs`；
     - [ ] 验证 child 创建前的 late-binding、child 创建后的 deterministic behavior、restart
-      recovery、nested calls、cancellation 和 invalid graphs；
+      recovery、nested calls、cancellation 和 invalid graphs，包括创建 child 前拒绝
+      `A -> B -> A` cycle；
   - 实现 step-level Action expansion；
   - 实现 `inputs`、`steps` 和 `jobs` contexts 的 expression evaluation；
   - 将 child Run outputs 提升为 WorkflowRun step/job/workflow outputs；


### PR DESCRIPTION
## Summary
- define shared reusable Workflow graph validation for krt wf trigger and WorkflowRun child calls
- reject self-references and cycles such as A -> B -> A before creating a root or child WorkflowRun
- define deterministic depth and validation-failure semantics
- add the cycle-rejection E2E requirement to the v0.x roadmap

## Design boundary
WorkflowRun remains inline-only. Graph validation loads same-namespace Workflow definitions with depth-first traversal and shares one error format between the CLI and controller. It persists no provenance annotation, owner-chain metadata, or root-wide execution tree.

Checks: make site-build.