### PR TITLE
feat(workflow): snapshot reusable output contracts

### DIFF
--- a/api/v1alpha1/workflowrun_types.go
+++ b/api/v1alpha1/workflowrun_types.go
@@ -42,7 +42,7 @@ const (
 	// WorkflowRunAcceptedCondition reports whether the WorkflowRun was accepted by the controller.
 	WorkflowRunAcceptedCondition = "Accepted"
 
-	// WorkflowRunUIDLabel identifies child Runs owned by a WorkflowRun.
+	// WorkflowRunUIDLabel identifies direct child resources owned by a WorkflowRun.
 	WorkflowRunUIDLabel = "kruntimes.io/workflowrun-uid"
 	// WorkflowJobLabel identifies the workflow job that owns a child Run.
 	WorkflowJobLabel = "kruntimes.io/workflow-job"

--- a/api/v1alpha1/workflowrun_types.go
+++ b/api/v1alpha1/workflowrun_types.go
@@ -48,6 +48,10 @@ const (
 	WorkflowJobLabel = "kruntimes.io/workflow-job"
 	// WorkflowStepLabel identifies the workflow step that owns a child Run.
 	WorkflowStepLabel = "kruntimes.io/workflow-step"
+	// WorkflowOutputAnnotationPrefix identifies frozen reusable Workflow output
+	// expressions on a materialized child WorkflowRun. The suffix is the output
+	// name from the source Workflow.
+	WorkflowOutputAnnotationPrefix = "kruntimes.io/workflow-output."
 )
 
 // +kubebuilder:object:generate=true

--- a/charts/kruntimes/templates/controller-rbac.yaml
+++ b/charts/kruntimes/templates/controller-rbac.yaml
@@ -81,6 +81,7 @@ rules:
       - get
       - list
       - watch
+      - create
       - update
       - patch
   - apiGroups:

--- a/docs/design/workflow-job-reuse.md
+++ b/docs/design/workflow-job-reuse.md
@@ -1,6 +1,6 @@
 # Job-Level Reusable Workflow Execution
 
-Status: **Proposed for review**
+Status: **Accepted**
 
 This document defines the v0.x execution boundary for job-level reusable
 Workflows.
@@ -260,17 +260,17 @@ useful rule for that future work: reuse expands at the direct execution
 boundary. An Action will be resolved into its caller step/Run, rather than
 being added to a root-wide Workflow snapshot or controller traversal tree.
 
-## Implementation Plan
+## Implementation Status
 
-1. Add the local WorkflowRun snapshot envelope and `JobStatus.outputs`.
-2. Implement `krt workflow
+1. [x] Add the local WorkflowRun snapshot envelope and `JobStatus.outputs`.
+2. [x] Implement `krt workflow
    trigger` as template input validation, rendering, and inline WorkflowRun
    creation.
-3. Implement direct child WorkflowRun creation with input rendering and frozen
+3. [x] Implement direct child WorkflowRun creation with input rendering and frozen
    output contracts.
-4. Implement local job-output evaluation, child-output projection, restart
+4. [x] Implement local job-output evaluation, child-output projection, restart
    recovery, and template-mutation semantics tests.
-5. Add E2E coverage for nested calls, including self-references and
-   `A -> B -> A` cycle rejection, output propagation, cancellation, and
-   template updates before versus after child creation.
-6. Design Action expansion separately, using the same direct-boundary rule.
+5. [x] Add E2E coverage for nested calls, `A -> B -> A` cycle rejection,
+   output propagation, cancellation, and template updates before versus after
+   child creation; add unit coverage for self-reference rejection.
+6. [ ] Design Action expansion separately, using the same direct-boundary rule.

--- a/docs/design/workflow-job-reuse.md
+++ b/docs/design/workflow-job-reuse.md
@@ -87,7 +87,9 @@ When `deploy` is runnable, the parent controller:
 2. Renders its `with` values from the caller context and validates the callee
    inputs.
 3. Renders `inputs.*` into the callee jobs.
-4. Creates a direct child WorkflowRun with those inline jobs.
+4. Creates a direct child WorkflowRun with those inline jobs and one
+   `kruntimes.io/workflow-output.<name>` annotation for each frozen source
+   Workflow output expression.
 5. Sets an owner reference and records the child name in
    `parent.status.jobs.deploy.workflowRunName`.
 
@@ -107,9 +109,6 @@ its own UID and recorded in `status.snapshotName`. Its data contains exactly:
 
 - `spec`: the accepted inline `WorkflowRun.spec`, including its local job
   topology;
-- `outputContract`: only for a child materialized from a reusable Workflow, a
-  single-entry map keyed by the source Workflow name. Its value is that
-  Workflow's declared `spec.outputs`.
 
 ```yaml
 apiVersion: apps/v1
@@ -126,18 +125,23 @@ data:
       apply:
         runs-on: bash
         steps: [{ name: deploy, run: deploy --environment=staging }]
-  outputContract:
-    deploy-workflow:
-      outputs:
-        endpoint:
-          value: ${{ jobs.apply.outputs.endpoint }}
 ```
 
-The output contract is the only source-template data retained after child
-creation. It is necessary because the parent must evaluate the exact output
-definition that accompanied the jobs which ran. Reading a mutable current
-Workflow after a child completes would make the same execution produce
-different parent output values after a template edit.
+For a child materialized from a reusable Workflow, the controller writes the
+frozen source output contract to the child at creation time:
+
+```yaml
+metadata:
+  annotations:
+    kruntimes.io/workflow-output.endpoint: ${{ jobs.apply.outputs.endpoint }}
+```
+
+The child initializes its own snapshot during its own reconciliation. The
+output annotations remain the contract accompanying its inline jobs, so the
+parent can evaluate them against `child.status.jobs` without loading or owning
+the child's ControllerRevision. Reading a mutable current Workflow after a
+child completes would make the same execution produce different parent output
+values after a template edit.
 
 A snapshot is owned and used only by its own WorkflowRun.
 
@@ -186,9 +190,10 @@ status:
 
 For an inline job, the controller evaluates `JobSpec.outputs` after its steps
 succeed, using the step outputs in Run status. For a reusable call, after the
-child WorkflowRun succeeds, the parent loads the child's local snapshot,
-evaluates its frozen `outputContract` against `child.status.jobs`, and writes
-the resulting values to the caller job's `JobStatus.outputs`.
+child WorkflowRun succeeds, the parent reads the child's frozen
+`kruntimes.io/workflow-output.<name>` annotations, evaluates them against
+`child.status.jobs`, and writes the resulting values to the caller job's
+`JobStatus.outputs`. It never reads the child's private snapshot.
 
 Downstream rendering is uniform:
 
@@ -248,6 +253,8 @@ They have no Workflow reuse, snapshot, or output-contract behavior.
 - A call job has `needs`, `uses`, and optional `with`; it cannot contain
   `runs-on` or `steps`.
 - Inputs and expression references are validated before creating a child.
+- Reusable Workflow output names must be valid annotation suffixes, and their
+  frozen output contract must fit within the Kubernetes annotation budget.
 - Workflow cycles are detected while resolving the referenced Workflow graph
   before a root or child WorkflowRun is created. The initial maximum nesting
   depth is 8.

--- a/docs/design/workflow-job-reuse.zh.md
+++ b/docs/design/workflow-job-reuse.zh.md
@@ -73,7 +73,8 @@ krt workflow trigger deploy-workflow --input environment=staging
 1. 从同一 namespace 读取 `deploy-workflow`。
 2. 使用 caller context 渲染 `with`，并校验 callee inputs。
 3. 将 `inputs.*` 渲染到 callee jobs。
-4. 用这些 inline jobs 创建直接 child WorkflowRun。
+4. 用这些 inline jobs 创建直接 child WorkflowRun，并为 source Workflow 的每个冻结
+   output expression 写入一个 `kruntimes.io/workflow-output.<name>` annotation。
 5. 设置 owner reference，并将 child 名称写入 `parent.status.jobs.deploy.workflowRunName`。
 
 child 正常执行，也可以为其 `uses` jobs 创建自己的直接 child WorkflowRuns。parent 不拥有也不检查 grandchildren。
@@ -84,8 +85,7 @@ child 正常执行，也可以为其 `uses` jobs 创建自己的直接 child Wor
 
 每个 WorkflowRun 自己拥有一个 `ControllerRevision`，名称由自身 UID 确定，并记录在 `status.snapshotName`。它只包含：
 
-- `spec`：接受的 inline `WorkflowRun.spec`，包括本地 jobs topology；
-- `outputContract`：仅当该 WorkflowRun 从可复用 Workflow materialize 出来时，保存一个以 source Workflow 名称为 key 的单项 map；其 value 是该 Workflow 声明的 `spec.outputs`。
+- `spec`：接受的 inline `WorkflowRun.spec`，包括本地 jobs topology。
 
 ```yaml
 apiVersion: apps/v1
@@ -102,14 +102,21 @@ data:
       apply:
         runs-on: bash
         steps: [{ name: deploy, run: deploy --environment=staging }]
-  outputContract:
-    deploy-workflow:
-      outputs:
-        endpoint:
-          value: ${{ jobs.apply.outputs.endpoint }}
 ```
 
-output contract 是 child 创建后保留的唯一 source-template 数据。parent 必须使用与实际执行 jobs 配套的 output 定义；如果 child 完成后读取可变的当前 Workflow，模板变更会让同一执行产生不同的 parent output。
+对于由 reusable Workflow materialize 的 child，controller 会在 child 创建时将冻结的
+source output contract 写入 child：
+
+```yaml
+metadata:
+  annotations:
+    kruntimes.io/workflow-output.endpoint: ${{ jobs.apply.outputs.endpoint }}
+```
+
+child 在自己的 reconciliation 中初始化自己的 snapshot。output annotations 与它的
+inline jobs 一起构成 contract，因此 parent 可以使用 `child.status.jobs` 计算 outputs，
+而无需加载或拥有 child 的 ControllerRevision。如果 child 完成后读取可变的当前 Workflow，
+模板变更会让同一 execution 产生不同的 parent output。
 
 一个 snapshot 只由自己的 WorkflowRun 拥有和使用。
 
@@ -148,7 +155,7 @@ status:
         endpoint: https://staging.example.com
 ```
 
-inline job 的所有 steps 成功后，controller 使用 `JobSpec.outputs` 和 Run status 中的 step outputs 计算 job output。可复用调用的 child WorkflowRun 成功后，parent 读取 child 的局部 snapshot，用冻结的 `outputContract` 对 `child.status.jobs` 求值，并将结果写到 caller job 的 `JobStatus.outputs`。
+inline job 的所有 steps 成功后，controller 使用 `JobSpec.outputs` 和 Run status 中的 step outputs 计算 job output。可复用调用的 child WorkflowRun 成功后，parent 读取 child 冻结的 `kruntimes.io/workflow-output.<name>` annotations，使用 `child.status.jobs` 求值，并将结果写到 caller job 的 `JobStatus.outputs`。parent 不读取 child 的 private snapshot。
 
 下游渲染统一使用：
 
@@ -190,6 +197,8 @@ Scheduler 和 runtimed 仍然只处理独立 `Run`，不了解 Workflow reuse、
 - WorkflowRun 自身不能包含 `uses` 或 `with`。
 - 调用 job 包含 `needs`、`uses` 和可选 `with`，不能包含 `runs-on` 或 `steps`。
 - 创建 child 前校验 inputs 和 expression references。
+- reusable Workflow output name 必须是有效 annotation suffix，并且其冻结 output
+  contract 必须满足 Kubernetes annotation budget。
 - 在创建 root 或 child WorkflowRun 前，在解析被引用的 Workflow graph 时检测 Workflow cycle；
   初始最大嵌套深度为 8。
 - job 与 step outputs 受 CRD 大小限制；artifacts 不是 outputs。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -272,20 +272,20 @@ wiring from accumulating avoidable conflicts.
   - [x] implement WorkflowRun cancellation propagation;
   - [x] verify controller restart recovery for in-progress inline WorkflowRuns,
     including child Run creation before status persistence;
-  - [ ] implement job-level reusable Workflow calls through the reviewed
+  - [x] implement job-level reusable Workflow calls through the reviewed
     [execution-boundary design](design/workflow-job-reuse.md):
     - [x] review and approve the direct child WorkflowRun and local snapshot model;
     - [x] remove root `WorkflowRun.spec.uses`/`with` and implement template
       triggering as rendered inline WorkflowRun creation;
     - [x] add a per-WorkflowRun immutable snapshot with the local execution
       spec and bounded `JobStatus.outputs`;
-    - [ ] capture the frozen source output contract in each materialized child
+    - [x] capture the frozen source output contract in each materialized child
       snapshot;
-    - [ ] create and observe child WorkflowRuns for ready job-level calls,
+    - [x] create and observe child WorkflowRuns for ready job-level calls,
       including input rendering and output-contract capture;
-    - [ ] project inline and child Workflow outputs into bounded
+    - [x] project inline and child Workflow outputs into bounded
       `WorkflowRun.status.jobs.<job>.outputs` values;
-    - [ ] verify late-binding behavior before child creation, deterministic
+    - [x] verify late-binding behavior before child creation, deterministic
       behavior after child creation, restart recovery, nested calls,
       cancellation, and invalid graphs, including `A -> B -> A` cycle
       rejection before child creation;

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -280,7 +280,7 @@ wiring from accumulating avoidable conflicts.
     - [x] add a per-WorkflowRun immutable snapshot with the local execution
       spec and bounded `JobStatus.outputs`;
     - [x] capture the frozen source output contract in each materialized child
-      snapshot;
+      WorkflowRun annotation;
     - [x] create and observe child WorkflowRuns for ready job-level calls,
       including input rendering and output-contract capture;
     - [x] project inline and child Workflow outputs into bounded

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -235,7 +235,7 @@ controller wiring 累积不必要的冲突。
   - [x] 实现 WorkflowRun cancellation propagation；
   - [x] 验证 in-progress inline WorkflowRuns 的 controller restart recovery，包括
     child Run 已创建但 status 尚未持久化的故障窗口；
-  - [ ] 按照完成 review 的
+  - [x] 按照完成 review 的
     [execution-boundary design](design/workflow-job-reuse.md) 实现 job-level reusable
     Workflow calls：
     - [x] review 并批准 direct child WorkflowRun 和 local snapshot model；
@@ -243,12 +243,13 @@ controller wiring 累积不必要的冲突。
       WorkflowRun 的创建；
     - [x] 为每个 WorkflowRun 增加包含 local execution spec 和有界 `JobStatus.outputs` 的
       immutable snapshot；
-    - [ ] 在每个 materialized child snapshot 中保存 frozen source output contract；
-    - [ ] 为 ready job-level calls 创建并观察 child WorkflowRuns，包括 input rendering 和
+    - [x] 在每个 materialized child WorkflowRun annotation 中保存 frozen source output
+      contract；
+    - [x] 为 ready job-level calls 创建并观察 child WorkflowRuns，包括 input rendering 和
       output-contract capture；
-    - [ ] 将 inline 和 child Workflow outputs 投影到有界的
+    - [x] 将 inline 和 child Workflow outputs 投影到有界的
       `WorkflowRun.status.jobs.<job>.outputs`；
-    - [ ] 验证 child 创建前的 late-binding、child 创建后的 deterministic behavior、restart
+    - [x] 验证 child 创建前的 late-binding、child 创建后的 deterministic behavior、restart
       recovery、nested calls、cancellation 和 invalid graphs，包括创建 child 前拒绝
       `A -> B -> A` cycle；
   - 实现 step-level Action expansion；

--- a/internal/controller/workflow_snapshot.go
+++ b/internal/controller/workflow_snapshot.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -22,15 +21,9 @@ import (
 const maxWorkflowSnapshotBytes = 1 << 20
 
 // workflowExecutionSnapshot is controller-private storage for one WorkflowRun.
-// It contains that WorkflowRun's accepted inline spec and, for a materialized
-// reusable Workflow child, the output contract that accompanied those jobs.
+// It contains that WorkflowRun's accepted inline spec.
 type workflowExecutionSnapshot struct {
-	Spec           v1alpha1.WorkflowRunSpec          `json:"spec"`
-	OutputContract map[string]workflowOutputContract `json:"outputContract,omitempty"`
-}
-
-type workflowOutputContract struct {
-	Outputs map[string]v1alpha1.WorkflowOutputSpec `json:"outputs,omitempty"`
+	Spec v1alpha1.WorkflowRunSpec `json:"spec"`
 }
 
 type workflowSnapshotError struct {
@@ -42,21 +35,6 @@ func (e *workflowSnapshotError) Unwrap() error { return e.err }
 
 func workflowSnapshotForRun(workflowRun *v1alpha1.WorkflowRun) *workflowExecutionSnapshot {
 	return &workflowExecutionSnapshot{Spec: *workflowRun.Spec.DeepCopy()}
-}
-
-// workflowSnapshotForMaterializedWorkflow records the template output contract
-// alongside the child WorkflowRun's already-rendered local job graph. The
-// parent creates this revision after Kubernetes assigns the child UID and
-// before the child controller initializes it.
-func workflowSnapshotForMaterializedWorkflow(workflowRun *v1alpha1.WorkflowRun, workflow *v1alpha1.Workflow) *workflowExecutionSnapshot {
-	snapshot := workflowSnapshotForRun(workflowRun)
-	if len(workflow.Spec.Outputs) == 0 {
-		return snapshot
-	}
-	snapshot.OutputContract = map[string]workflowOutputContract{
-		workflow.Name: {Outputs: maps.Clone(workflow.Spec.Outputs)},
-	}
-	return snapshot
 }
 
 func (r *WorkflowRunReconciler) ensureWorkflowSnapshot(ctx context.Context, workflowRun *v1alpha1.WorkflowRun, snapshot *workflowExecutionSnapshot) (string, *workflowExecutionSnapshot, error) {

--- a/internal/controller/workflow_snapshot.go
+++ b/internal/controller/workflow_snapshot.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -20,12 +21,16 @@ import (
 
 const maxWorkflowSnapshotBytes = 1 << 20
 
-// workflowExecutionSnapshot is controller-private storage for one
-// WorkflowRun. It contains only that WorkflowRun's accepted inline spec. A
-// materialized reusable Workflow child will additionally store its source
-// output contract in a later implementation step.
+// workflowExecutionSnapshot is controller-private storage for one WorkflowRun.
+// It contains that WorkflowRun's accepted inline spec and, for a materialized
+// reusable Workflow child, the output contract that accompanied those jobs.
 type workflowExecutionSnapshot struct {
-	Spec v1alpha1.WorkflowRunSpec `json:"spec"`
+	Spec           v1alpha1.WorkflowRunSpec          `json:"spec"`
+	OutputContract map[string]workflowOutputContract `json:"outputContract,omitempty"`
+}
+
+type workflowOutputContract struct {
+	Outputs map[string]v1alpha1.WorkflowOutputSpec `json:"outputs,omitempty"`
 }
 
 type workflowSnapshotError struct {
@@ -37,6 +42,21 @@ func (e *workflowSnapshotError) Unwrap() error { return e.err }
 
 func workflowSnapshotForRun(workflowRun *v1alpha1.WorkflowRun) *workflowExecutionSnapshot {
 	return &workflowExecutionSnapshot{Spec: *workflowRun.Spec.DeepCopy()}
+}
+
+// workflowSnapshotForMaterializedWorkflow records the template output contract
+// alongside the child WorkflowRun's already-rendered local job graph. The
+// parent creates this revision after Kubernetes assigns the child UID and
+// before the child controller initializes it.
+func workflowSnapshotForMaterializedWorkflow(workflowRun *v1alpha1.WorkflowRun, workflow *v1alpha1.Workflow) *workflowExecutionSnapshot {
+	snapshot := workflowSnapshotForRun(workflowRun)
+	if len(workflow.Spec.Outputs) == 0 {
+		return snapshot
+	}
+	snapshot.OutputContract = map[string]workflowOutputContract{
+		workflow.Name: {Outputs: maps.Clone(workflow.Spec.Outputs)},
+	}
+	return snapshot
 }
 
 func (r *WorkflowRunReconciler) ensureWorkflowSnapshot(ctx context.Context, workflowRun *v1alpha1.WorkflowRun, snapshot *workflowExecutionSnapshot) (string, *workflowExecutionSnapshot, error) {

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -82,7 +82,7 @@ type WorkflowRunReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=kruntimes.io,resources=workflowruns,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=kruntimes.io,resources=workflowruns,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=kruntimes.io,resources=workflowruns/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=kruntimes.io,resources=runs,verbs=get;list;watch;create;patch
 // +kubebuilder:rbac:groups=apps,resources=controllerrevisions,verbs=get;list;watch;create;delete

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -19,6 +19,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -37,6 +38,8 @@ const (
 	workflowRunStateTerminal   workflowRunState = "Terminal"
 )
 
+const maxWorkflowOutputContractAnnotationBytes = 240 * 1024
+
 type workflowRunAction string
 
 const (
@@ -50,22 +53,30 @@ type workflowRunResources struct {
 	workflowRun    *v1alpha1.WorkflowRun
 	childRuns      map[string]*v1alpha1.Run
 	childWorkflows map[string]*v1alpha1.WorkflowRun
-	childSnapshots map[string]*workflowExecutionSnapshot
 	snapshot       *workflowExecutionSnapshot
 }
 
 type workflowRunPlan struct {
-	state            workflowRunState
-	action           workflowRunAction
-	targets          []workflowRunStepTarget
-	callJobs         []string
-	runNames         []string
-	workflowRunNames []string
+	state   workflowRunState
+	action  workflowRunAction
+	targets []workflowRunTarget
 }
 
-type workflowRunStepTarget struct {
+type workflowRunTargetKind string
+
+const (
+	workflowRunTargetStep              workflowRunTargetKind = "Step"
+	workflowRunTargetWorkflowCall      workflowRunTargetKind = "WorkflowCall"
+	workflowRunTargetCancelRun         workflowRunTargetKind = "CancelRun"
+	workflowRunTargetCancelWorkflowRun workflowRunTargetKind = "CancelWorkflowRun"
+)
+
+// workflowRunTarget identifies one child resource operation within a plan.
+type workflowRunTarget struct {
+	kind      workflowRunTargetKind
 	jobName   string
 	stepIndex int
+	name      string
 }
 
 type workflowCallValidationError struct {
@@ -168,44 +179,13 @@ func (r *WorkflowRunReconciler) loadWorkflowRunResources(ctx context.Context, ke
 		return nil, fmt.Errorf("list child workflowruns for workflowrun %s/%s: %w", workflowRun.Namespace, workflowRun.Name, err)
 	}
 	resources.childWorkflows = make(map[string]*v1alpha1.WorkflowRun)
-	resources.childSnapshots = make(map[string]*workflowExecutionSnapshot)
 	for i := range workflowRuns.Items {
 		child := &workflowRuns.Items[i]
 		if metav1.IsControlledBy(child, workflowRun) {
-			childCopy := child.DeepCopy()
-			resources.childWorkflows[child.Name] = childCopy
-			childSnapshot, err := r.loadExistingWorkflowSnapshot(ctx, childCopy)
-			if err != nil {
-				return nil, err
-			}
-			if childSnapshot != nil {
-				resources.childSnapshots[child.Name] = childSnapshot
-			}
+			resources.childWorkflows[child.Name] = child.DeepCopy()
 		}
 	}
 	return resources, nil
-}
-
-func (r *WorkflowRunReconciler) loadExistingWorkflowSnapshot(ctx context.Context, workflowRun *v1alpha1.WorkflowRun) (*workflowExecutionSnapshot, error) {
-	snapshotName := workflowRun.Status.SnapshotName
-	if snapshotName == "" {
-		snapshotName = workflowSnapshotName(workflowRun)
-	}
-	revision := &appsv1.ControllerRevision{}
-	if err := r.Get(ctx, client.ObjectKey{Namespace: workflowRun.Namespace, Name: snapshotName}, revision); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("get workflow snapshot %s/%s: %w", workflowRun.Namespace, snapshotName, err)
-	}
-	if revision.Labels[v1alpha1.WorkflowRunUIDLabel] != string(workflowRun.UID) {
-		return nil, fmt.Errorf("workflow snapshot %s/%s belongs to another workflowrun", revision.Namespace, revision.Name)
-	}
-	snapshot, err := loadWorkflowSnapshot(revision)
-	if err != nil {
-		return nil, err
-	}
-	return snapshot, nil
 }
 
 func calculateWorkflowRunPlan(resources *workflowRunResources) workflowRunPlan {
@@ -214,20 +194,14 @@ func calculateWorkflowRunPlan(resources *workflowRunResources) workflowRunPlan {
 	state := workflowRunStateFor(workflowRun)
 	plan := workflowRunPlan{state: state, action: workflowRunActionNone}
 	if state == workflowRunStateEmpty {
-		if resources.snapshot == nil && isChildWorkflowRun(workflowRun) {
-			return plan
-		}
 		plan.action = workflowRunActionInitialize
 		return plan
 	}
 	if workflowRun.Spec.CancelRequested {
-		runNames := childRunsToCancel(resources.childRuns)
-		workflowRunNames := childWorkflowRunsToCancel(resources.childWorkflows)
-		if len(runNames) > 0 || len(workflowRunNames) > 0 {
+		plan.targets = append(childRunCancellationTargets(resources.childRuns), childWorkflowRunCancellationTargets(resources.childWorkflows)...)
+		if len(plan.targets) > 0 {
 			plan.state = workflowRunStateCancelling
 			plan.action = workflowRunActionRequestChildCancellation
-			plan.runNames = runNames
-			plan.workflowRunNames = workflowRunNames
 			return plan
 		}
 	}
@@ -244,9 +218,8 @@ func calculateWorkflowRunPlan(resources *workflowRunResources) workflowRunPlan {
 	if len(jobs) == 0 || len(workflowRun.Status.Jobs) == 0 {
 		return plan
 	}
-	plan.targets = runnableStepTargets(workflowRun.Status.Jobs, jobs)
-	plan.callJobs = runnableWorkflowCallJobs(workflowRun.Status.Jobs, jobs)
-	if len(plan.targets) > 0 || len(plan.callJobs) > 0 {
+	plan.targets = append(runnableStepTargets(workflowRun.Status.Jobs, jobs), runnableWorkflowCallTargets(workflowRun.Status.Jobs, jobs)...)
+	if len(plan.targets) > 0 {
 		plan.action = workflowRunActionStartRunnableTargets
 		return plan
 	}
@@ -304,20 +277,11 @@ func (r *WorkflowRunReconciler) applyWorkflowRunAction(ctx context.Context, reso
 	case workflowRunActionInitialize:
 		return r.applyInitializeWorkflowRun(ctx, resources)
 	case workflowRunActionStartRunnableTargets:
-		return r.applyStartRunnableTargets(ctx, resources, plan.targets, plan.callJobs)
+		return r.applyStartRunnableTargets(ctx, resources, plan.targets)
 	case workflowRunActionRequestChildCancellation:
-		return r.applyRequestChildCancellation(ctx, resources, plan.runNames, plan.workflowRunNames)
+		return r.applyRequestChildCancellation(ctx, resources, plan.targets)
 	}
 	return nil
-}
-
-func isChildWorkflowRun(workflowRun *v1alpha1.WorkflowRun) bool {
-	for _, owner := range workflowRun.OwnerReferences {
-		if owner.Controller != nil && *owner.Controller && owner.APIVersion == v1alpha1.GroupVersion.String() && owner.Kind == "WorkflowRun" {
-			return true
-		}
-	}
-	return false
 }
 
 // SetupWithManager registers the WorkflowRun reconciler.
@@ -440,28 +404,32 @@ func resolvedJobStatuses(jobs map[string]v1alpha1.JobSpec) map[string]v1alpha1.J
 	return statuses
 }
 
-func (r *WorkflowRunReconciler) applyStartRunnableTargets(ctx context.Context, resources *workflowRunResources, targets []workflowRunStepTarget, callJobs []string) error {
+func (r *WorkflowRunReconciler) applyStartRunnableTargets(ctx context.Context, resources *workflowRunResources, targets []workflowRunTarget) error {
 	workflowRun := resources.workflowRun
 	for _, target := range targets {
-		job := resources.snapshot.Spec.Jobs[target.jobName]
-		run, err := r.createOrReuseStepRun(ctx, resources, target.jobName, job, target.stepIndex)
-		if err != nil {
-			return err
-		}
-		recordStepRun(workflowRun, target.jobName, target.stepIndex, run.Name)
-	}
-	for _, jobName := range callJobs {
-		job := resources.snapshot.Spec.Jobs[jobName]
-		child, err := r.createWorkflowCall(ctx, workflowRun, jobName, job)
-		if err != nil {
-			var validationErr *workflowCallValidationError
-			if errors.As(err, &validationErr) {
-				recordWorkflowCallFailure(workflowRun, jobName, validationErr.Error())
-				continue
+		switch target.kind {
+		case workflowRunTargetStep:
+			job := resources.snapshot.Spec.Jobs[target.jobName]
+			run, err := r.createOrReuseStepRun(ctx, resources, target.jobName, job, target.stepIndex)
+			if err != nil {
+				return err
 			}
-			return err
+			recordStepRun(workflowRun, target.jobName, target.stepIndex, run.Name)
+		case workflowRunTargetWorkflowCall:
+			job := resources.snapshot.Spec.Jobs[target.jobName]
+			child, err := r.createWorkflowCall(ctx, workflowRun, target.jobName, job)
+			if err != nil {
+				var validationErr *workflowCallValidationError
+				if errors.As(err, &validationErr) {
+					recordWorkflowCallFailure(workflowRun, target.jobName, validationErr.Error())
+					continue
+				}
+				return err
+			}
+			recordWorkflowCall(workflowRun, target.jobName, child.Name)
+		default:
+			return fmt.Errorf("start workflowrun target has unsupported kind %q", target.kind)
 		}
-		recordWorkflowCall(workflowRun, jobName, child.Name)
 	}
 	return nil
 }
@@ -491,6 +459,10 @@ func (r *WorkflowRunReconciler) createWorkflowCall(ctx context.Context, parent *
 	if err != nil {
 		return nil, &workflowCallValidationError{err: fmt.Errorf("materialize reusable workflow %q for job %q: %w", workflow.Name, jobName, err)}
 	}
+	outputAnnotations, err := workflowOutputContractAnnotations(workflow.Spec.Outputs)
+	if err != nil {
+		return nil, &workflowCallValidationError{err: fmt.Errorf("materialize output contract for reusable workflow %q and job %q: %w", workflow.Name, jobName, err)}
+	}
 
 	child := &v1alpha1.WorkflowRun{
 		ObjectMeta: metav1.ObjectMeta{
@@ -499,6 +471,7 @@ func (r *WorkflowRunReconciler) createWorkflowCall(ctx context.Context, parent *
 			Labels: map[string]string{
 				v1alpha1.WorkflowRunUIDLabel: string(parent.UID),
 			},
+			Annotations: outputAnnotations,
 		},
 		Spec: v1alpha1.WorkflowRunSpec{Jobs: jobs},
 	}
@@ -512,9 +485,6 @@ func (r *WorkflowRunReconciler) createWorkflowCall(ctx context.Context, parent *
 		if err := r.Get(ctx, client.ObjectKeyFromObject(child), child); err != nil {
 			return nil, fmt.Errorf("get existing child workflowrun %s/%s: %w", child.Namespace, child.Name, err)
 		}
-	}
-	if _, _, err := r.ensureWorkflowSnapshot(ctx, child, workflowSnapshotForMaterializedWorkflow(child, workflow)); err != nil {
-		return nil, fmt.Errorf("create child workflowrun snapshot %s/%s: %w", child.Namespace, child.Name, err)
 	}
 	return child, nil
 }
@@ -569,14 +539,14 @@ func recordStepRun(workflowRun *v1alpha1.WorkflowRun, jobName string, stepIndex 
 	workflowRun.Status.Phase = v1alpha1.WorkflowRunning
 }
 
-func runnableStepTargets(statuses map[string]v1alpha1.JobStatus, jobs map[string]v1alpha1.JobSpec) []workflowRunStepTarget {
+func runnableStepTargets(statuses map[string]v1alpha1.JobStatus, jobs map[string]v1alpha1.JobSpec) []workflowRunTarget {
 	jobNames := make([]string, 0, len(jobs))
 	for jobName := range jobs {
 		jobNames = append(jobNames, jobName)
 	}
 	sort.Strings(jobNames)
 
-	targets := make([]workflowRunStepTarget, 0, len(jobNames))
+	targets := make([]workflowRunTarget, 0, len(jobNames))
 	for _, jobName := range jobNames {
 		job := jobs[jobName]
 		status, ok := statuses[jobName]
@@ -584,32 +554,32 @@ func runnableStepTargets(statuses map[string]v1alpha1.JobStatus, jobs map[string
 			continue
 		}
 		if jobReadyToStart(status, statuses) && status.Steps[0].RunName == "" {
-			targets = append(targets, workflowRunStepTarget{jobName: jobName, stepIndex: 0})
+			targets = append(targets, workflowRunTarget{kind: workflowRunTargetStep, jobName: jobName, stepIndex: 0})
 			continue
 		}
 		if stepIndex, ok := nextStepToStart(status); ok {
-			targets = append(targets, workflowRunStepTarget{jobName: jobName, stepIndex: stepIndex})
+			targets = append(targets, workflowRunTarget{kind: workflowRunTargetStep, jobName: jobName, stepIndex: stepIndex})
 		}
 	}
 	return targets
 }
 
-func runnableWorkflowCallJobs(statuses map[string]v1alpha1.JobStatus, jobs map[string]v1alpha1.JobSpec) []string {
+func runnableWorkflowCallTargets(statuses map[string]v1alpha1.JobStatus, jobs map[string]v1alpha1.JobSpec) []workflowRunTarget {
 	names := make([]string, 0, len(jobs))
 	for name := range jobs {
 		names = append(names, name)
 	}
 	sort.Strings(names)
-	ready := make([]string, 0, len(names))
+	targets := make([]workflowRunTarget, 0, len(names))
 	for _, name := range names {
 		job := jobs[name]
 		status, ok := statuses[name]
 		if !ok || job.Uses == "" || status.WorkflowRunName != "" || !jobReadyToStart(status, statuses) {
 			continue
 		}
-		ready = append(ready, name)
+		targets = append(targets, workflowRunTarget{kind: workflowRunTargetWorkflowCall, jobName: name})
 	}
-	return ready
+	return targets
 }
 
 func workflowRunJobOutputContext(statuses map[string]v1alpha1.JobStatus) *resolveContext {
@@ -635,6 +605,41 @@ func resolveWorkflowCallInputs(values map[string]string, ctx *resolveContext) (m
 		resolved[name] = result
 	}
 	return resolved, nil
+}
+
+func workflowOutputContractAnnotations(outputs map[string]v1alpha1.WorkflowOutputSpec) (map[string]string, error) {
+	if len(outputs) == 0 {
+		return nil, nil
+	}
+	annotations := make(map[string]string, len(outputs))
+	annotationBytes := 0
+	for name, output := range outputs {
+		key := v1alpha1.WorkflowOutputAnnotationPrefix + name
+		if len(validation.IsQualifiedName(key)) != 0 {
+			return nil, fmt.Errorf("output name %q cannot be represented as a WorkflowRun annotation", name)
+		}
+		annotationBytes += len(key) + len(output.Value)
+		if annotationBytes > maxWorkflowOutputContractAnnotationBytes {
+			return nil, fmt.Errorf("output contract is %d bytes, exceeds %d byte annotation limit", annotationBytes, maxWorkflowOutputContractAnnotationBytes)
+		}
+		annotations[key] = output.Value
+	}
+	return annotations, nil
+}
+
+func workflowOutputContractFromAnnotations(annotations map[string]string) (map[string]v1alpha1.WorkflowOutputSpec, error) {
+	outputs := make(map[string]v1alpha1.WorkflowOutputSpec)
+	for key, value := range annotations {
+		if !strings.HasPrefix(key, v1alpha1.WorkflowOutputAnnotationPrefix) {
+			continue
+		}
+		name := strings.TrimPrefix(key, v1alpha1.WorkflowOutputAnnotationPrefix)
+		if name == "" || len(validation.IsQualifiedName(key)) != 0 {
+			return nil, fmt.Errorf("invalid workflow output annotation %q", key)
+		}
+		outputs[name] = v1alpha1.WorkflowOutputSpec{Value: value}
+	}
+	return outputs, nil
 }
 
 func nextStepToStart(status v1alpha1.JobStatus) (int, bool) {
@@ -693,7 +698,7 @@ func deriveWorkflowCallStatuses(resources *workflowRunResources) {
 		}
 		switch child.Status.Phase {
 		case v1alpha1.WorkflowSucceeded:
-			outputs, err := resolveWorkflowCallOutputs(child, resources.childSnapshots[child.Name])
+			outputs, err := resolveWorkflowCallOutputs(child)
 			if err != nil {
 				status.Phase = v1alpha1.JobFailed
 				resources.workflowRun.Status.Message = fmt.Sprintf("resolve outputs for job %q: %v", jobName, err)
@@ -710,32 +715,23 @@ func deriveWorkflowCallStatuses(resources *workflowRunResources) {
 	}
 }
 
-func resolveWorkflowCallOutputs(child *v1alpha1.WorkflowRun, snapshot *workflowExecutionSnapshot) (map[string]string, error) {
-	if snapshot == nil {
-		return nil, fmt.Errorf("child workflowrun %s/%s has no execution snapshot", child.Namespace, child.Name)
+func resolveWorkflowCallOutputs(child *v1alpha1.WorkflowRun) (map[string]string, error) {
+	contract, err := workflowOutputContractFromAnnotations(child.Annotations)
+	if err != nil {
+		return nil, fmt.Errorf("child workflowrun %s/%s: %w", child.Namespace, child.Name, err)
 	}
-	if len(snapshot.OutputContract) == 0 {
+	if len(contract) == 0 {
 		return nil, nil
 	}
-	if len(snapshot.OutputContract) != 1 {
-		return nil, fmt.Errorf("child workflowrun %s/%s has %d output contracts, want one", child.Namespace, child.Name, len(snapshot.OutputContract))
-	}
-	var contract workflowOutputContract
-	for _, contract = range snapshot.OutputContract {
-		break
-	}
-	if len(contract.Outputs) == 0 {
-		return nil, nil
-	}
-	outputs := make(map[string]string, len(contract.Outputs))
-	outputNames := make([]string, 0, len(contract.Outputs))
-	for name := range contract.Outputs {
+	outputs := make(map[string]string, len(contract))
+	outputNames := make([]string, 0, len(contract))
+	for name := range contract {
 		outputNames = append(outputNames, name)
 	}
 	sort.Strings(outputNames)
 	ctx := workflowRunJobOutputContext(child.Status.Jobs)
 	for _, name := range outputNames {
-		value, err := resolveExpr(contract.Outputs[name].Value, ctx)
+		value, err := resolveExpr(contract[name].Value, ctx)
 		if err != nil {
 			return nil, fmt.Errorf("output %q: %w", name, err)
 		}
@@ -771,53 +767,57 @@ func isTerminalWorkflowPhase(phase v1alpha1.WorkflowPhase) bool {
 	}
 }
 
-func childRunsToCancel(childRuns map[string]*v1alpha1.Run) []string {
-	runNames := make([]string, 0, len(childRuns))
+func childRunCancellationTargets(childRuns map[string]*v1alpha1.Run) []workflowRunTarget {
+	targets := make([]workflowRunTarget, 0, len(childRuns))
 	for _, run := range childRuns {
 		if !isTerminalRunPhase(run.Status.Phase) && !run.Spec.CancelRequested {
-			runNames = append(runNames, run.Name)
+			targets = append(targets, workflowRunTarget{kind: workflowRunTargetCancelRun, name: run.Name})
 		}
 	}
-	sort.Strings(runNames)
-	return runNames
+	sort.Slice(targets, func(i, j int) bool { return targets[i].name < targets[j].name })
+	return targets
 }
 
-func childWorkflowRunsToCancel(childWorkflows map[string]*v1alpha1.WorkflowRun) []string {
-	names := make([]string, 0, len(childWorkflows))
+func childWorkflowRunCancellationTargets(childWorkflows map[string]*v1alpha1.WorkflowRun) []workflowRunTarget {
+	targets := make([]workflowRunTarget, 0, len(childWorkflows))
 	for _, child := range childWorkflows {
 		if !isTerminalWorkflowPhase(child.Status.Phase) && !child.Spec.CancelRequested {
-			names = append(names, child.Name)
+			targets = append(targets, workflowRunTarget{kind: workflowRunTargetCancelWorkflowRun, name: child.Name})
 		}
 	}
-	sort.Strings(names)
-	return names
+	sort.Slice(targets, func(i, j int) bool { return targets[i].name < targets[j].name })
+	return targets
 }
 
-func (r *WorkflowRunReconciler) applyRequestChildCancellation(ctx context.Context, resources *workflowRunResources, runNames []string, workflowRunNames []string) error {
+func (r *WorkflowRunReconciler) applyRequestChildCancellation(ctx context.Context, resources *workflowRunResources, targets []workflowRunTarget) error {
 	childRuns := make(map[string]*v1alpha1.Run, len(resources.childRuns))
 	for _, run := range resources.childRuns {
 		childRuns[run.Name] = run
 	}
-	for _, runName := range runNames {
-		run := childRuns[runName]
-		if run == nil || run.Spec.CancelRequested || isTerminalRunPhase(run.Status.Phase) {
-			continue
-		}
-		base := run.DeepCopy()
-		run.Spec.CancelRequested = true
-		if err := r.Patch(ctx, run, client.MergeFrom(base)); err != nil {
-			return fmt.Errorf("request cancellation of child run %s/%s: %w", run.Namespace, run.Name, err)
-		}
-	}
-	for _, workflowRunName := range workflowRunNames {
-		child := resources.childWorkflows[workflowRunName]
-		if child == nil || child.Spec.CancelRequested || isTerminalWorkflowPhase(child.Status.Phase) {
-			continue
-		}
-		base := child.DeepCopy()
-		child.Spec.CancelRequested = true
-		if err := r.Patch(ctx, child, client.MergeFrom(base)); err != nil {
-			return fmt.Errorf("request cancellation of child workflowrun %s/%s: %w", child.Namespace, child.Name, err)
+	for _, target := range targets {
+		switch target.kind {
+		case workflowRunTargetCancelRun:
+			run := childRuns[target.name]
+			if run == nil || run.Spec.CancelRequested || isTerminalRunPhase(run.Status.Phase) {
+				continue
+			}
+			base := run.DeepCopy()
+			run.Spec.CancelRequested = true
+			if err := r.Patch(ctx, run, client.MergeFrom(base)); err != nil {
+				return fmt.Errorf("request cancellation of child run %s/%s: %w", run.Namespace, run.Name, err)
+			}
+		case workflowRunTargetCancelWorkflowRun:
+			child := resources.childWorkflows[target.name]
+			if child == nil || child.Spec.CancelRequested || isTerminalWorkflowPhase(child.Status.Phase) {
+				continue
+			}
+			base := child.DeepCopy()
+			child.Spec.CancelRequested = true
+			if err := r.Patch(ctx, child, client.MergeFrom(base)); err != nil {
+				return fmt.Errorf("request cancellation of child workflowrun %s/%s: %w", child.Namespace, child.Name, err)
+			}
+		default:
+			return fmt.Errorf("cancel workflowrun target has unsupported kind %q", target.kind)
 		}
 	}
 	return nil

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"strings"
@@ -39,30 +40,40 @@ const (
 type workflowRunAction string
 
 const (
-	workflowRunActionNone                        workflowRunAction = "None"
-	workflowRunActionInitialize                  workflowRunAction = "Initialize"
-	workflowRunActionStartRunnableTargets        workflowRunAction = "StartRunnableTargets"
-	workflowRunActionRequestChildRunCancellation workflowRunAction = "RequestChildRunCancellation"
+	workflowRunActionNone                     workflowRunAction = "None"
+	workflowRunActionInitialize               workflowRunAction = "Initialize"
+	workflowRunActionStartRunnableTargets     workflowRunAction = "StartRunnableTargets"
+	workflowRunActionRequestChildCancellation workflowRunAction = "RequestChildCancellation"
 )
 
 type workflowRunResources struct {
-	workflowRun *v1alpha1.WorkflowRun
-	childRuns   map[string]*v1alpha1.Run
-	snapshot    *workflowExecutionSnapshot
+	workflowRun    *v1alpha1.WorkflowRun
+	childRuns      map[string]*v1alpha1.Run
+	childWorkflows map[string]*v1alpha1.WorkflowRun
+	childSnapshots map[string]*workflowExecutionSnapshot
+	snapshot       *workflowExecutionSnapshot
 }
 
 type workflowRunPlan struct {
-	state    workflowRunState
-	action   workflowRunAction
-	targets  []workflowRunStepTarget
-	callJobs []string
-	runNames []string
+	state            workflowRunState
+	action           workflowRunAction
+	targets          []workflowRunStepTarget
+	callJobs         []string
+	runNames         []string
+	workflowRunNames []string
 }
 
 type workflowRunStepTarget struct {
 	jobName   string
 	stepIndex int
 }
+
+type workflowCallValidationError struct {
+	err error
+}
+
+func (e *workflowCallValidationError) Error() string { return e.err.Error() }
+func (e *workflowCallValidationError) Unwrap() error { return e.err }
 
 // WorkflowRunReconciler owns WorkflowRun execution-instance status.
 type WorkflowRunReconciler struct {
@@ -151,7 +162,50 @@ func (r *WorkflowRunReconciler) loadWorkflowRunResources(ctx context.Context, ke
 	}
 
 	resources.childRuns = childRuns
+	var workflowRuns v1alpha1.WorkflowRunList
+	childWorkflowLabels := client.MatchingLabels{v1alpha1.WorkflowRunUIDLabel: string(workflowRun.UID)}
+	if err := r.List(ctx, &workflowRuns, client.InNamespace(workflowRun.Namespace), childWorkflowLabels); err != nil {
+		return nil, fmt.Errorf("list child workflowruns for workflowrun %s/%s: %w", workflowRun.Namespace, workflowRun.Name, err)
+	}
+	resources.childWorkflows = make(map[string]*v1alpha1.WorkflowRun)
+	resources.childSnapshots = make(map[string]*workflowExecutionSnapshot)
+	for i := range workflowRuns.Items {
+		child := &workflowRuns.Items[i]
+		if metav1.IsControlledBy(child, workflowRun) {
+			childCopy := child.DeepCopy()
+			resources.childWorkflows[child.Name] = childCopy
+			childSnapshot, err := r.loadExistingWorkflowSnapshot(ctx, childCopy)
+			if err != nil {
+				return nil, err
+			}
+			if childSnapshot != nil {
+				resources.childSnapshots[child.Name] = childSnapshot
+			}
+		}
+	}
 	return resources, nil
+}
+
+func (r *WorkflowRunReconciler) loadExistingWorkflowSnapshot(ctx context.Context, workflowRun *v1alpha1.WorkflowRun) (*workflowExecutionSnapshot, error) {
+	snapshotName := workflowRun.Status.SnapshotName
+	if snapshotName == "" {
+		snapshotName = workflowSnapshotName(workflowRun)
+	}
+	revision := &appsv1.ControllerRevision{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: workflowRun.Namespace, Name: snapshotName}, revision); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("get workflow snapshot %s/%s: %w", workflowRun.Namespace, snapshotName, err)
+	}
+	if revision.Labels[v1alpha1.WorkflowRunUIDLabel] != string(workflowRun.UID) {
+		return nil, fmt.Errorf("workflow snapshot %s/%s belongs to another workflowrun", revision.Namespace, revision.Name)
+	}
+	snapshot, err := loadWorkflowSnapshot(revision)
+	if err != nil {
+		return nil, err
+	}
+	return snapshot, nil
 }
 
 func calculateWorkflowRunPlan(resources *workflowRunResources) workflowRunPlan {
@@ -160,14 +214,20 @@ func calculateWorkflowRunPlan(resources *workflowRunResources) workflowRunPlan {
 	state := workflowRunStateFor(workflowRun)
 	plan := workflowRunPlan{state: state, action: workflowRunActionNone}
 	if state == workflowRunStateEmpty {
+		if resources.snapshot == nil && isChildWorkflowRun(workflowRun) {
+			return plan
+		}
 		plan.action = workflowRunActionInitialize
 		return plan
 	}
 	if workflowRun.Spec.CancelRequested {
-		if runNames := childRunsToCancel(resources.childRuns); len(runNames) > 0 {
+		runNames := childRunsToCancel(resources.childRuns)
+		workflowRunNames := childWorkflowRunsToCancel(resources.childWorkflows)
+		if len(runNames) > 0 || len(workflowRunNames) > 0 {
 			plan.state = workflowRunStateCancelling
-			plan.action = workflowRunActionRequestChildRunCancellation
+			plan.action = workflowRunActionRequestChildCancellation
 			plan.runNames = runNames
+			plan.workflowRunNames = workflowRunNames
 			return plan
 		}
 	}
@@ -245,10 +305,19 @@ func (r *WorkflowRunReconciler) applyWorkflowRunAction(ctx context.Context, reso
 		return r.applyInitializeWorkflowRun(ctx, resources)
 	case workflowRunActionStartRunnableTargets:
 		return r.applyStartRunnableTargets(ctx, resources, plan.targets, plan.callJobs)
-	case workflowRunActionRequestChildRunCancellation:
-		return r.applyRequestChildRunCancellation(ctx, resources, plan.runNames)
+	case workflowRunActionRequestChildCancellation:
+		return r.applyRequestChildCancellation(ctx, resources, plan.runNames, plan.workflowRunNames)
 	}
 	return nil
+}
+
+func isChildWorkflowRun(workflowRun *v1alpha1.WorkflowRun) bool {
+	for _, owner := range workflowRun.OwnerReferences {
+		if owner.Controller != nil && *owner.Controller && owner.APIVersion == v1alpha1.GroupVersion.String() && owner.Kind == "WorkflowRun" {
+			return true
+		}
+	}
+	return false
 }
 
 // SetupWithManager registers the WorkflowRun reconciler.
@@ -385,6 +454,11 @@ func (r *WorkflowRunReconciler) applyStartRunnableTargets(ctx context.Context, r
 		job := resources.snapshot.Spec.Jobs[jobName]
 		child, err := r.createWorkflowCall(ctx, workflowRun, jobName, job)
 		if err != nil {
+			var validationErr *workflowCallValidationError
+			if errors.As(err, &validationErr) {
+				recordWorkflowCallFailure(workflowRun, jobName, validationErr.Error())
+				continue
+			}
 			return err
 		}
 		recordWorkflowCall(workflowRun, jobName, child.Name)
@@ -395,6 +469,9 @@ func (r *WorkflowRunReconciler) applyStartRunnableTargets(ctx context.Context, r
 func (r *WorkflowRunReconciler) createWorkflowCall(ctx context.Context, parent *v1alpha1.WorkflowRun, jobName string, job v1alpha1.JobSpec) (*v1alpha1.WorkflowRun, error) {
 	workflow := &v1alpha1.Workflow{}
 	if err := r.Get(ctx, client.ObjectKey{Namespace: parent.Namespace, Name: job.Uses}, workflow); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, &workflowCallValidationError{err: fmt.Errorf("reusable workflow %q for job %q does not exist", job.Uses, jobName)}
+		}
 		return nil, fmt.Errorf("get reusable workflow %q for job %q: %w", job.Uses, jobName, err)
 	}
 	if err := workflowtemplate.ValidateCallGraph(ctx, workflow.Name, func(ctx context.Context, name string) (*v1alpha1.Workflow, error) {
@@ -404,20 +481,26 @@ func (r *WorkflowRunReconciler) createWorkflowCall(ctx context.Context, parent *
 		}
 		return candidate, nil
 	}); err != nil {
-		return nil, fmt.Errorf("validate reusable workflow %q for job %q: %w", job.Uses, jobName, err)
+		return nil, &workflowCallValidationError{err: fmt.Errorf("validate reusable workflow %q for job %q: %w", job.Uses, jobName, err)}
 	}
 	inputs, err := resolveWorkflowCallInputs(job.With, workflowRunJobOutputContext(parent.Status.Jobs))
 	if err != nil {
-		return nil, fmt.Errorf("resolve inputs for job %q: %w", jobName, err)
+		return nil, &workflowCallValidationError{err: fmt.Errorf("resolve inputs for job %q: %w", jobName, err)}
 	}
 	jobs, err := workflowtemplate.Materialize(workflow.Spec, inputs)
 	if err != nil {
-		return nil, fmt.Errorf("materialize reusable workflow %q for job %q: %w", workflow.Name, jobName, err)
+		return nil, &workflowCallValidationError{err: fmt.Errorf("materialize reusable workflow %q for job %q: %w", workflow.Name, jobName, err)}
 	}
 
 	child := &v1alpha1.WorkflowRun{
-		ObjectMeta: metav1.ObjectMeta{Name: workflowCallRunName(parent.Name, jobName), Namespace: parent.Namespace},
-		Spec:       v1alpha1.WorkflowRunSpec{Jobs: jobs},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      workflowCallRunName(parent.Name, jobName),
+			Namespace: parent.Namespace,
+			Labels: map[string]string{
+				v1alpha1.WorkflowRunUIDLabel: string(parent.UID),
+			},
+		},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: jobs},
 	}
 	if err := controllerutil.SetControllerReference(parent, child, r.Scheme); err != nil {
 		return nil, fmt.Errorf("set parent workflowrun owner reference on child %s/%s: %w", child.Namespace, child.Name, err)
@@ -442,6 +525,14 @@ func recordWorkflowCall(workflowRun *v1alpha1.WorkflowRun, jobName string, child
 	status.WorkflowRunName = childName
 	workflowRun.Status.Jobs[jobName] = status
 	workflowRun.Status.Phase = v1alpha1.WorkflowRunning
+}
+
+func recordWorkflowCallFailure(workflowRun *v1alpha1.WorkflowRun, jobName string, message string) {
+	status := workflowRun.Status.Jobs[jobName]
+	status.Phase = v1alpha1.JobFailed
+	workflowRun.Status.Jobs[jobName] = status
+	workflowRun.Status.Phase = v1alpha1.WorkflowRunning
+	workflowRun.Status.Message = message
 }
 
 func (r *WorkflowRunReconciler) createOrReuseStepRun(ctx context.Context, resources *workflowRunResources, jobName string, job v1alpha1.JobSpec, stepIndex int) (*v1alpha1.Run, error) {
@@ -581,13 +672,76 @@ func terminalJobPhase(status v1alpha1.JobStatus) (v1alpha1.JobPhase, bool) {
 
 func deriveWorkflowRunStatus(resources *workflowRunResources) {
 	deriveStepStatusesFromChildRuns(resources)
-	deriveJobStatuses(resources.workflowRun)
+	deriveWorkflowCallStatuses(resources)
+	deriveJobStatuses(resources)
 	if resources.workflowRun.Spec.CancelRequested {
 		deriveCancelledWorkflowRunStatus(resources)
 		return
 	}
 	deriveSkippedJobStatuses(resources.workflowRun.Status.Jobs)
 	deriveTerminalWorkflowRunStatus(resources.workflowRun)
+}
+
+func deriveWorkflowCallStatuses(resources *workflowRunResources) {
+	for jobName, status := range resources.workflowRun.Status.Jobs {
+		if status.WorkflowRunName == "" || status.Phase != v1alpha1.JobRunning {
+			continue
+		}
+		child := resources.childWorkflows[status.WorkflowRunName]
+		if child == nil {
+			continue
+		}
+		switch child.Status.Phase {
+		case v1alpha1.WorkflowSucceeded:
+			outputs, err := resolveWorkflowCallOutputs(child, resources.childSnapshots[child.Name])
+			if err != nil {
+				status.Phase = v1alpha1.JobFailed
+				resources.workflowRun.Status.Message = fmt.Sprintf("resolve outputs for job %q: %v", jobName, err)
+			} else {
+				status.Phase = v1alpha1.JobSucceeded
+				status.Outputs = outputs
+			}
+		case v1alpha1.WorkflowFailed, v1alpha1.WorkflowCancelled:
+			status.Phase = v1alpha1.JobFailed
+		default:
+			continue
+		}
+		resources.workflowRun.Status.Jobs[jobName] = status
+	}
+}
+
+func resolveWorkflowCallOutputs(child *v1alpha1.WorkflowRun, snapshot *workflowExecutionSnapshot) (map[string]string, error) {
+	if snapshot == nil {
+		return nil, fmt.Errorf("child workflowrun %s/%s has no execution snapshot", child.Namespace, child.Name)
+	}
+	if len(snapshot.OutputContract) == 0 {
+		return nil, nil
+	}
+	if len(snapshot.OutputContract) != 1 {
+		return nil, fmt.Errorf("child workflowrun %s/%s has %d output contracts, want one", child.Namespace, child.Name, len(snapshot.OutputContract))
+	}
+	var contract workflowOutputContract
+	for _, contract = range snapshot.OutputContract {
+		break
+	}
+	if len(contract.Outputs) == 0 {
+		return nil, nil
+	}
+	outputs := make(map[string]string, len(contract.Outputs))
+	outputNames := make([]string, 0, len(contract.Outputs))
+	for name := range contract.Outputs {
+		outputNames = append(outputNames, name)
+	}
+	sort.Strings(outputNames)
+	ctx := workflowRunJobOutputContext(child.Status.Jobs)
+	for _, name := range outputNames {
+		value, err := resolveExpr(contract.Outputs[name].Value, ctx)
+		if err != nil {
+			return nil, fmt.Errorf("output %q: %w", name, err)
+		}
+		outputs[name] = value
+	}
+	return outputs, nil
 }
 
 func deriveCancelledWorkflowRunStatus(resources *workflowRunResources) {
@@ -597,6 +751,11 @@ func deriveCancelledWorkflowRunStatus(resources *workflowRunResources) {
 	}
 	for _, run := range resources.childRuns {
 		if !isTerminalRunPhase(run.Status.Phase) {
+			return
+		}
+	}
+	for _, child := range resources.childWorkflows {
+		if !isTerminalWorkflowPhase(child.Status.Phase) {
 			return
 		}
 	}
@@ -623,7 +782,18 @@ func childRunsToCancel(childRuns map[string]*v1alpha1.Run) []string {
 	return runNames
 }
 
-func (r *WorkflowRunReconciler) applyRequestChildRunCancellation(ctx context.Context, resources *workflowRunResources, runNames []string) error {
+func childWorkflowRunsToCancel(childWorkflows map[string]*v1alpha1.WorkflowRun) []string {
+	names := make([]string, 0, len(childWorkflows))
+	for _, child := range childWorkflows {
+		if !isTerminalWorkflowPhase(child.Status.Phase) && !child.Spec.CancelRequested {
+			names = append(names, child.Name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (r *WorkflowRunReconciler) applyRequestChildCancellation(ctx context.Context, resources *workflowRunResources, runNames []string, workflowRunNames []string) error {
 	childRuns := make(map[string]*v1alpha1.Run, len(resources.childRuns))
 	for _, run := range resources.childRuns {
 		childRuns[run.Name] = run
@@ -637,6 +807,17 @@ func (r *WorkflowRunReconciler) applyRequestChildRunCancellation(ctx context.Con
 		run.Spec.CancelRequested = true
 		if err := r.Patch(ctx, run, client.MergeFrom(base)); err != nil {
 			return fmt.Errorf("request cancellation of child run %s/%s: %w", run.Namespace, run.Name, err)
+		}
+	}
+	for _, workflowRunName := range workflowRunNames {
+		child := resources.childWorkflows[workflowRunName]
+		if child == nil || child.Spec.CancelRequested || isTerminalWorkflowPhase(child.Status.Phase) {
+			continue
+		}
+		base := child.DeepCopy()
+		child.Spec.CancelRequested = true
+		if err := r.Patch(ctx, child, client.MergeFrom(base)); err != nil {
+			return fmt.Errorf("request cancellation of child workflowrun %s/%s: %w", child.Namespace, child.Name, err)
 		}
 	}
 	return nil
@@ -660,7 +841,8 @@ func deriveTerminalWorkflowRunStatus(workflowRun *v1alpha1.WorkflowRun) {
 	workflowRun.Status.Phase = phase
 }
 
-func deriveJobStatuses(workflowRun *v1alpha1.WorkflowRun) {
+func deriveJobStatuses(resources *workflowRunResources) {
+	workflowRun := resources.workflowRun
 	for jobName, status := range workflowRun.Status.Jobs {
 		if status.Phase != v1alpha1.JobRunning {
 			continue
@@ -670,8 +852,43 @@ func deriveJobStatuses(workflowRun *v1alpha1.WorkflowRun) {
 			continue
 		}
 		status.Phase = phase
+		if phase == v1alpha1.JobSucceeded {
+			outputs, err := resolveJobOutputs(resources.snapshot.Spec.Jobs[jobName], status)
+			if err != nil {
+				status.Phase = v1alpha1.JobFailed
+				workflowRun.Status.Message = fmt.Sprintf("resolve outputs for job %q: %v", jobName, err)
+			} else {
+				status.Outputs = outputs
+			}
+		}
 		workflowRun.Status.Jobs[jobName] = status
 	}
+}
+
+func resolveJobOutputs(job v1alpha1.JobSpec, status v1alpha1.JobStatus) (map[string]string, error) {
+	if len(job.Outputs) == 0 {
+		return nil, nil
+	}
+	steps := make(map[string]map[string]string, len(status.Steps))
+	for _, step := range status.Steps {
+		if len(step.Outputs) > 0 {
+			steps[step.Name] = step.Outputs
+		}
+	}
+	outputNames := make([]string, 0, len(job.Outputs))
+	for name := range job.Outputs {
+		outputNames = append(outputNames, name)
+	}
+	sort.Strings(outputNames)
+	outputs := make(map[string]string, len(job.Outputs))
+	for _, name := range outputNames {
+		value, err := resolveExpr(job.Outputs[name], &resolveContext{steps: steps})
+		if err != nil {
+			return nil, fmt.Errorf("output %q: %w", name, err)
+		}
+		outputs[name] = value
+	}
+	return outputs, nil
 }
 
 func deriveSkippedJobStatuses(jobs map[string]v1alpha1.JobStatus) {
@@ -754,6 +971,7 @@ func deriveStepStatusesFromChildRuns(resources *workflowRunResources) {
 			}
 			step.RunName = run.Name
 			step.Phase = stepPhase
+			step.Outputs = maps.Clone(run.Status.Outputs)
 			workflowRun.Status.Jobs[jobName] = jobStatus
 			break
 		}

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	"github.com/kruntimes/kruntimes/internal/workflowtemplate"
 )
 
 type workflowRunState string
@@ -40,7 +41,7 @@ type workflowRunAction string
 const (
 	workflowRunActionNone                        workflowRunAction = "None"
 	workflowRunActionInitialize                  workflowRunAction = "Initialize"
-	workflowRunActionStartRunnableSteps          workflowRunAction = "StartRunnableSteps"
+	workflowRunActionStartRunnableTargets        workflowRunAction = "StartRunnableTargets"
 	workflowRunActionRequestChildRunCancellation workflowRunAction = "RequestChildRunCancellation"
 )
 
@@ -54,6 +55,7 @@ type workflowRunPlan struct {
 	state    workflowRunState
 	action   workflowRunAction
 	targets  []workflowRunStepTarget
+	callJobs []string
 	runNames []string
 }
 
@@ -182,9 +184,10 @@ func calculateWorkflowRunPlan(resources *workflowRunResources) workflowRunPlan {
 	if len(jobs) == 0 || len(workflowRun.Status.Jobs) == 0 {
 		return plan
 	}
-	if targets := runnableStepTargets(workflowRun.Status.Jobs, jobs); len(targets) > 0 {
-		plan.action = workflowRunActionStartRunnableSteps
-		plan.targets = targets
+	plan.targets = runnableStepTargets(workflowRun.Status.Jobs, jobs)
+	plan.callJobs = runnableWorkflowCallJobs(workflowRun.Status.Jobs, jobs)
+	if len(plan.targets) > 0 || len(plan.callJobs) > 0 {
+		plan.action = workflowRunActionStartRunnableTargets
 		return plan
 	}
 	return plan
@@ -240,8 +243,8 @@ func (r *WorkflowRunReconciler) applyWorkflowRunAction(ctx context.Context, reso
 	switch plan.action {
 	case workflowRunActionInitialize:
 		return r.applyInitializeWorkflowRun(ctx, resources)
-	case workflowRunActionStartRunnableSteps:
-		return r.applyStartRunnableSteps(ctx, resources, plan.targets)
+	case workflowRunActionStartRunnableTargets:
+		return r.applyStartRunnableTargets(ctx, resources, plan.targets, plan.callJobs)
 	case workflowRunActionRequestChildRunCancellation:
 		return r.applyRequestChildRunCancellation(ctx, resources, plan.runNames)
 	}
@@ -253,6 +256,7 @@ func (r *WorkflowRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.WorkflowRun{}).
 		Owns(&v1alpha1.Run{}).
+		Owns(&v1alpha1.WorkflowRun{}).
 		Owns(&appsv1.ControllerRevision{}).
 		Complete(r)
 }
@@ -266,7 +270,10 @@ func validateWorkflowRunJobs(jobs map[string]v1alpha1.JobSpec) error {
 	for _, jobName := range jobNames {
 		job := jobs[jobName]
 		if job.Uses != "" {
-			return fmt.Errorf("job %q uses reusable workflow %q, but job-level uses is not implemented yet", jobName, job.Uses)
+			if job.RunsOn != "" || len(job.Steps) != 0 {
+				return fmt.Errorf("job %q uses reusable workflow %q and may not set runs-on or steps", jobName, job.Uses)
+			}
+			continue
 		}
 		if job.RunsOn == "" {
 			return fmt.Errorf("job %q must set runs-on before creating child Runs", jobName)
@@ -364,7 +371,7 @@ func resolvedJobStatuses(jobs map[string]v1alpha1.JobSpec) map[string]v1alpha1.J
 	return statuses
 }
 
-func (r *WorkflowRunReconciler) applyStartRunnableSteps(ctx context.Context, resources *workflowRunResources, targets []workflowRunStepTarget) error {
+func (r *WorkflowRunReconciler) applyStartRunnableTargets(ctx context.Context, resources *workflowRunResources, targets []workflowRunStepTarget, callJobs []string) error {
 	workflowRun := resources.workflowRun
 	for _, target := range targets {
 		job := resources.snapshot.Spec.Jobs[target.jobName]
@@ -374,7 +381,67 @@ func (r *WorkflowRunReconciler) applyStartRunnableSteps(ctx context.Context, res
 		}
 		recordStepRun(workflowRun, target.jobName, target.stepIndex, run.Name)
 	}
+	for _, jobName := range callJobs {
+		job := resources.snapshot.Spec.Jobs[jobName]
+		child, err := r.createWorkflowCall(ctx, workflowRun, jobName, job)
+		if err != nil {
+			return err
+		}
+		recordWorkflowCall(workflowRun, jobName, child.Name)
+	}
 	return nil
+}
+
+func (r *WorkflowRunReconciler) createWorkflowCall(ctx context.Context, parent *v1alpha1.WorkflowRun, jobName string, job v1alpha1.JobSpec) (*v1alpha1.WorkflowRun, error) {
+	workflow := &v1alpha1.Workflow{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: parent.Namespace, Name: job.Uses}, workflow); err != nil {
+		return nil, fmt.Errorf("get reusable workflow %q for job %q: %w", job.Uses, jobName, err)
+	}
+	if err := workflowtemplate.ValidateCallGraph(ctx, workflow.Name, func(ctx context.Context, name string) (*v1alpha1.Workflow, error) {
+		candidate := &v1alpha1.Workflow{}
+		if err := r.Get(ctx, client.ObjectKey{Namespace: parent.Namespace, Name: name}, candidate); err != nil {
+			return nil, err
+		}
+		return candidate, nil
+	}); err != nil {
+		return nil, fmt.Errorf("validate reusable workflow %q for job %q: %w", job.Uses, jobName, err)
+	}
+	inputs, err := resolveWorkflowCallInputs(job.With, workflowRunJobOutputContext(parent.Status.Jobs))
+	if err != nil {
+		return nil, fmt.Errorf("resolve inputs for job %q: %w", jobName, err)
+	}
+	jobs, err := workflowtemplate.Materialize(workflow.Spec, inputs)
+	if err != nil {
+		return nil, fmt.Errorf("materialize reusable workflow %q for job %q: %w", workflow.Name, jobName, err)
+	}
+
+	child := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: workflowCallRunName(parent.Name, jobName), Namespace: parent.Namespace},
+		Spec:       v1alpha1.WorkflowRunSpec{Jobs: jobs},
+	}
+	if err := controllerutil.SetControllerReference(parent, child, r.Scheme); err != nil {
+		return nil, fmt.Errorf("set parent workflowrun owner reference on child %s/%s: %w", child.Namespace, child.Name, err)
+	}
+	if err := r.Create(ctx, child); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return nil, fmt.Errorf("create child workflowrun %s/%s: %w", child.Namespace, child.Name, err)
+		}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(child), child); err != nil {
+			return nil, fmt.Errorf("get existing child workflowrun %s/%s: %w", child.Namespace, child.Name, err)
+		}
+	}
+	if _, _, err := r.ensureWorkflowSnapshot(ctx, child, workflowSnapshotForMaterializedWorkflow(child, workflow)); err != nil {
+		return nil, fmt.Errorf("create child workflowrun snapshot %s/%s: %w", child.Namespace, child.Name, err)
+	}
+	return child, nil
+}
+
+func recordWorkflowCall(workflowRun *v1alpha1.WorkflowRun, jobName string, childName string) {
+	status := workflowRun.Status.Jobs[jobName]
+	status.Phase = v1alpha1.JobRunning
+	status.WorkflowRunName = childName
+	workflowRun.Status.Jobs[jobName] = status
+	workflowRun.Status.Phase = v1alpha1.WorkflowRunning
 }
 
 func (r *WorkflowRunReconciler) createOrReuseStepRun(ctx context.Context, resources *workflowRunResources, jobName string, job v1alpha1.JobSpec, stepIndex int) (*v1alpha1.Run, error) {
@@ -422,7 +489,7 @@ func runnableStepTargets(statuses map[string]v1alpha1.JobStatus, jobs map[string
 	for _, jobName := range jobNames {
 		job := jobs[jobName]
 		status, ok := statuses[jobName]
-		if !ok || len(status.Steps) != len(job.Steps) {
+		if !ok || job.Uses != "" || len(status.Steps) != len(job.Steps) || len(job.Steps) == 0 {
 			continue
 		}
 		if jobReadyToStart(status, statuses) && status.Steps[0].RunName == "" {
@@ -434,6 +501,49 @@ func runnableStepTargets(statuses map[string]v1alpha1.JobStatus, jobs map[string
 		}
 	}
 	return targets
+}
+
+func runnableWorkflowCallJobs(statuses map[string]v1alpha1.JobStatus, jobs map[string]v1alpha1.JobSpec) []string {
+	names := make([]string, 0, len(jobs))
+	for name := range jobs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	ready := make([]string, 0, len(names))
+	for _, name := range names {
+		job := jobs[name]
+		status, ok := statuses[name]
+		if !ok || job.Uses == "" || status.WorkflowRunName != "" || !jobReadyToStart(status, statuses) {
+			continue
+		}
+		ready = append(ready, name)
+	}
+	return ready
+}
+
+func workflowRunJobOutputContext(statuses map[string]v1alpha1.JobStatus) *resolveContext {
+	jobs := make(map[string]map[string]string, len(statuses))
+	for name, status := range statuses {
+		if len(status.Outputs) > 0 {
+			jobs[name] = status.Outputs
+		}
+	}
+	return &resolveContext{jobs: jobs}
+}
+
+func resolveWorkflowCallInputs(values map[string]string, ctx *resolveContext) (map[string]string, error) {
+	if values == nil {
+		return nil, nil
+	}
+	resolved := make(map[string]string, len(values))
+	for name, value := range values {
+		result, err := resolveExpr(value, ctx)
+		if err != nil {
+			return nil, fmt.Errorf("input %q: %w", name, err)
+		}
+		resolved[name] = result
+	}
+	return resolved, nil
 }
 
 func nextStepToStart(status v1alpha1.JobStatus) (int, bool) {
@@ -710,6 +820,21 @@ func workflowStepRunName(workflowRunName string, jobName string, stepName string
 	if len(prefix) > maxPrefixLength {
 		prefix = prefix[:maxPrefixLength]
 		prefix = strings.TrimRight(prefix, "-.")
+	}
+	if prefix == "" {
+		return suffix
+	}
+	return prefix + "-" + suffix
+}
+
+func workflowCallRunName(parentName string, jobName string) string {
+	sum := sha256.Sum256([]byte(jobName))
+	suffix := hex.EncodeToString(sum[:])[:10]
+	const maxNameLength = 253
+	maxPrefixLength := maxNameLength - len(suffix) - 1
+	prefix := parentName
+	if len(prefix) > maxPrefixLength {
+		prefix = strings.TrimRight(prefix[:maxPrefixLength], "-.")
 	}
 	if prefix == "" {
 		return suffix

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -68,8 +68,6 @@ type workflowRunPlan struct {
 type workflowRunTarget struct {
 	step         *jobStepRunTarget
 	workflowCall *jobWorkflowCallTarget
-	run          *childRunTarget
-	workflowRun  *childWorkflowRunTarget
 }
 
 type jobStepRunTarget struct {
@@ -79,14 +77,6 @@ type jobStepRunTarget struct {
 
 type jobWorkflowCallTarget struct {
 	jobName string
-}
-
-type childRunTarget struct {
-	name string
-}
-
-type childWorkflowRunTarget struct {
-	name string
 }
 
 type workflowCallValidationError struct {
@@ -208,8 +198,7 @@ func calculateWorkflowRunPlan(resources *workflowRunResources) workflowRunPlan {
 		return plan
 	}
 	if workflowRun.Spec.CancelRequested {
-		plan.targets = append(childRunCancellationTargets(resources.childRuns), childWorkflowRunCancellationTargets(resources.childWorkflows)...)
-		if len(plan.targets) > 0 {
+		if hasActiveChildRuns(resources.childRuns) || hasActiveChildWorkflowRuns(resources.childWorkflows) {
 			plan.state = workflowRunStateCancelling
 			plan.action = workflowRunActionRequestChildCancellation
 			return plan
@@ -289,7 +278,7 @@ func (r *WorkflowRunReconciler) applyWorkflowRunAction(ctx context.Context, reso
 	case workflowRunActionStartRunnableTargets:
 		return r.applyStartRunnableTargets(ctx, resources, plan.targets)
 	case workflowRunActionRequestChildCancellation:
-		return r.applyRequestChildCancellation(ctx, resources, plan.targets)
+		return r.applyRequestChildCancellation(ctx, resources)
 	}
 	return nil
 }
@@ -787,57 +776,43 @@ func isTerminalWorkflowPhase(phase v1alpha1.WorkflowPhase) bool {
 	}
 }
 
-func childRunCancellationTargets(childRuns map[string]*v1alpha1.Run) []workflowRunTarget {
-	targets := make([]workflowRunTarget, 0, len(childRuns))
+func hasActiveChildRuns(childRuns map[string]*v1alpha1.Run) bool {
 	for _, run := range childRuns {
 		if !isTerminalRunPhase(run.Status.Phase) && !run.Spec.CancelRequested {
-			targets = append(targets, workflowRunTarget{run: &childRunTarget{name: run.Name}})
+			return true
 		}
 	}
-	sort.Slice(targets, func(i, j int) bool { return targets[i].run.name < targets[j].run.name })
-	return targets
+	return false
 }
 
-func childWorkflowRunCancellationTargets(childWorkflows map[string]*v1alpha1.WorkflowRun) []workflowRunTarget {
-	targets := make([]workflowRunTarget, 0, len(childWorkflows))
+func hasActiveChildWorkflowRuns(childWorkflows map[string]*v1alpha1.WorkflowRun) bool {
 	for _, child := range childWorkflows {
 		if !isTerminalWorkflowPhase(child.Status.Phase) && !child.Spec.CancelRequested {
-			targets = append(targets, workflowRunTarget{workflowRun: &childWorkflowRunTarget{name: child.Name}})
+			return true
 		}
 	}
-	sort.Slice(targets, func(i, j int) bool { return targets[i].workflowRun.name < targets[j].workflowRun.name })
-	return targets
+	return false
 }
 
-func (r *WorkflowRunReconciler) applyRequestChildCancellation(ctx context.Context, resources *workflowRunResources, targets []workflowRunTarget) error {
-	childRuns := make(map[string]*v1alpha1.Run, len(resources.childRuns))
+func (r *WorkflowRunReconciler) applyRequestChildCancellation(ctx context.Context, resources *workflowRunResources) error {
 	for _, run := range resources.childRuns {
-		childRuns[run.Name] = run
+		if run.Spec.CancelRequested || isTerminalRunPhase(run.Status.Phase) {
+			continue
+		}
+		base := run.DeepCopy()
+		run.Spec.CancelRequested = true
+		if err := r.Patch(ctx, run, client.MergeFrom(base)); err != nil {
+			return fmt.Errorf("request cancellation of child run %s/%s: %w", run.Namespace, run.Name, err)
+		}
 	}
-	for _, target := range targets {
-		switch {
-		case target.run != nil:
-			run := childRuns[target.run.name]
-			if run == nil || run.Spec.CancelRequested || isTerminalRunPhase(run.Status.Phase) {
-				continue
-			}
-			base := run.DeepCopy()
-			run.Spec.CancelRequested = true
-			if err := r.Patch(ctx, run, client.MergeFrom(base)); err != nil {
-				return fmt.Errorf("request cancellation of child run %s/%s: %w", run.Namespace, run.Name, err)
-			}
-		case target.workflowRun != nil:
-			child := resources.childWorkflows[target.workflowRun.name]
-			if child == nil || child.Spec.CancelRequested || isTerminalWorkflowPhase(child.Status.Phase) {
-				continue
-			}
-			base := child.DeepCopy()
-			child.Spec.CancelRequested = true
-			if err := r.Patch(ctx, child, client.MergeFrom(base)); err != nil {
-				return fmt.Errorf("request cancellation of child workflowrun %s/%s: %w", child.Namespace, child.Name, err)
-			}
-		default:
-			return fmt.Errorf("cancel workflowrun target is not a child Run or WorkflowRun")
+	for _, child := range resources.childWorkflows {
+		if child.Spec.CancelRequested || isTerminalWorkflowPhase(child.Status.Phase) {
+			continue
+		}
+		base := child.DeepCopy()
+		child.Spec.CancelRequested = true
+		if err := r.Patch(ctx, child, client.MergeFrom(base)); err != nil {
+			return fmt.Errorf("request cancellation of child workflowrun %s/%s: %w", child.Namespace, child.Name, err)
 		}
 	}
 	return nil

--- a/internal/controller/workflowrun_controller.go
+++ b/internal/controller/workflowrun_controller.go
@@ -23,6 +23,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 	"github.com/kruntimes/kruntimes/internal/workflowtemplate"
@@ -62,21 +64,29 @@ type workflowRunPlan struct {
 	targets []workflowRunTarget
 }
 
-type workflowRunTargetKind string
-
-const (
-	workflowRunTargetStep              workflowRunTargetKind = "Step"
-	workflowRunTargetWorkflowCall      workflowRunTargetKind = "WorkflowCall"
-	workflowRunTargetCancelRun         workflowRunTargetKind = "CancelRun"
-	workflowRunTargetCancelWorkflowRun workflowRunTargetKind = "CancelWorkflowRun"
-)
-
 // workflowRunTarget identifies one child resource operation within a plan.
 type workflowRunTarget struct {
-	kind      workflowRunTargetKind
+	step         *jobStepRunTarget
+	workflowCall *jobWorkflowCallTarget
+	run          *childRunTarget
+	workflowRun  *childWorkflowRunTarget
+}
+
+type jobStepRunTarget struct {
 	jobName   string
 	stepIndex int
-	name      string
+}
+
+type jobWorkflowCallTarget struct {
+	jobName string
+}
+
+type childRunTarget struct {
+	name string
+}
+
+type childWorkflowRunTarget struct {
+	name string
 }
 
 type workflowCallValidationError struct {
@@ -289,9 +299,19 @@ func (r *WorkflowRunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.WorkflowRun{}).
 		Owns(&v1alpha1.Run{}).
-		Owns(&v1alpha1.WorkflowRun{}).
+		Watches(&v1alpha1.WorkflowRun{}, handler.EnqueueRequestsFromMapFunc(r.parentWorkflowRunRequest)).
 		Owns(&appsv1.ControllerRevision{}).
 		Complete(r)
+}
+
+// parentWorkflowRunRequest maps a child WorkflowRun event to its controller
+// owner. The primary For watch continues to reconcile WorkflowRuns themselves.
+func (r *WorkflowRunReconciler) parentWorkflowRunRequest(_ context.Context, object client.Object) []reconcile.Request {
+	owner := metav1.GetControllerOf(object)
+	if owner == nil || owner.APIVersion != v1alpha1.GroupVersion.String() || owner.Kind != "WorkflowRun" || owner.Name == "" {
+		return nil
+	}
+	return []reconcile.Request{{NamespacedName: client.ObjectKey{Namespace: object.GetNamespace(), Name: owner.Name}}}
 }
 
 func validateWorkflowRunJobs(jobs map[string]v1alpha1.JobSpec) error {
@@ -407,28 +427,28 @@ func resolvedJobStatuses(jobs map[string]v1alpha1.JobSpec) map[string]v1alpha1.J
 func (r *WorkflowRunReconciler) applyStartRunnableTargets(ctx context.Context, resources *workflowRunResources, targets []workflowRunTarget) error {
 	workflowRun := resources.workflowRun
 	for _, target := range targets {
-		switch target.kind {
-		case workflowRunTargetStep:
-			job := resources.snapshot.Spec.Jobs[target.jobName]
-			run, err := r.createOrReuseStepRun(ctx, resources, target.jobName, job, target.stepIndex)
+		switch {
+		case target.step != nil:
+			job := resources.snapshot.Spec.Jobs[target.step.jobName]
+			run, err := r.createOrReuseStepRun(ctx, resources, target.step.jobName, job, target.step.stepIndex)
 			if err != nil {
 				return err
 			}
-			recordStepRun(workflowRun, target.jobName, target.stepIndex, run.Name)
-		case workflowRunTargetWorkflowCall:
-			job := resources.snapshot.Spec.Jobs[target.jobName]
-			child, err := r.createWorkflowCall(ctx, workflowRun, target.jobName, job)
+			recordStepRun(workflowRun, target.step.jobName, target.step.stepIndex, run.Name)
+		case target.workflowCall != nil:
+			job := resources.snapshot.Spec.Jobs[target.workflowCall.jobName]
+			child, err := r.createWorkflowCall(ctx, workflowRun, target.workflowCall.jobName, job)
 			if err != nil {
 				var validationErr *workflowCallValidationError
 				if errors.As(err, &validationErr) {
-					recordWorkflowCallFailure(workflowRun, target.jobName, validationErr.Error())
+					recordWorkflowCallFailure(workflowRun, target.workflowCall.jobName, validationErr.Error())
 					continue
 				}
 				return err
 			}
-			recordWorkflowCall(workflowRun, target.jobName, child.Name)
+			recordWorkflowCall(workflowRun, target.workflowCall.jobName, child.Name)
 		default:
-			return fmt.Errorf("start workflowrun target has unsupported kind %q", target.kind)
+			return fmt.Errorf("start workflowrun target is not a step or workflow call")
 		}
 	}
 	return nil
@@ -554,11 +574,11 @@ func runnableStepTargets(statuses map[string]v1alpha1.JobStatus, jobs map[string
 			continue
 		}
 		if jobReadyToStart(status, statuses) && status.Steps[0].RunName == "" {
-			targets = append(targets, workflowRunTarget{kind: workflowRunTargetStep, jobName: jobName, stepIndex: 0})
+			targets = append(targets, workflowRunTarget{step: &jobStepRunTarget{jobName: jobName, stepIndex: 0}})
 			continue
 		}
 		if stepIndex, ok := nextStepToStart(status); ok {
-			targets = append(targets, workflowRunTarget{kind: workflowRunTargetStep, jobName: jobName, stepIndex: stepIndex})
+			targets = append(targets, workflowRunTarget{step: &jobStepRunTarget{jobName: jobName, stepIndex: stepIndex}})
 		}
 	}
 	return targets
@@ -577,7 +597,7 @@ func runnableWorkflowCallTargets(statuses map[string]v1alpha1.JobStatus, jobs ma
 		if !ok || job.Uses == "" || status.WorkflowRunName != "" || !jobReadyToStart(status, statuses) {
 			continue
 		}
-		targets = append(targets, workflowRunTarget{kind: workflowRunTargetWorkflowCall, jobName: name})
+		targets = append(targets, workflowRunTarget{workflowCall: &jobWorkflowCallTarget{jobName: name}})
 	}
 	return targets
 }
@@ -771,10 +791,10 @@ func childRunCancellationTargets(childRuns map[string]*v1alpha1.Run) []workflowR
 	targets := make([]workflowRunTarget, 0, len(childRuns))
 	for _, run := range childRuns {
 		if !isTerminalRunPhase(run.Status.Phase) && !run.Spec.CancelRequested {
-			targets = append(targets, workflowRunTarget{kind: workflowRunTargetCancelRun, name: run.Name})
+			targets = append(targets, workflowRunTarget{run: &childRunTarget{name: run.Name}})
 		}
 	}
-	sort.Slice(targets, func(i, j int) bool { return targets[i].name < targets[j].name })
+	sort.Slice(targets, func(i, j int) bool { return targets[i].run.name < targets[j].run.name })
 	return targets
 }
 
@@ -782,10 +802,10 @@ func childWorkflowRunCancellationTargets(childWorkflows map[string]*v1alpha1.Wor
 	targets := make([]workflowRunTarget, 0, len(childWorkflows))
 	for _, child := range childWorkflows {
 		if !isTerminalWorkflowPhase(child.Status.Phase) && !child.Spec.CancelRequested {
-			targets = append(targets, workflowRunTarget{kind: workflowRunTargetCancelWorkflowRun, name: child.Name})
+			targets = append(targets, workflowRunTarget{workflowRun: &childWorkflowRunTarget{name: child.Name}})
 		}
 	}
-	sort.Slice(targets, func(i, j int) bool { return targets[i].name < targets[j].name })
+	sort.Slice(targets, func(i, j int) bool { return targets[i].workflowRun.name < targets[j].workflowRun.name })
 	return targets
 }
 
@@ -795,9 +815,9 @@ func (r *WorkflowRunReconciler) applyRequestChildCancellation(ctx context.Contex
 		childRuns[run.Name] = run
 	}
 	for _, target := range targets {
-		switch target.kind {
-		case workflowRunTargetCancelRun:
-			run := childRuns[target.name]
+		switch {
+		case target.run != nil:
+			run := childRuns[target.run.name]
 			if run == nil || run.Spec.CancelRequested || isTerminalRunPhase(run.Status.Phase) {
 				continue
 			}
@@ -806,8 +826,8 @@ func (r *WorkflowRunReconciler) applyRequestChildCancellation(ctx context.Contex
 			if err := r.Patch(ctx, run, client.MergeFrom(base)); err != nil {
 				return fmt.Errorf("request cancellation of child run %s/%s: %w", run.Namespace, run.Name, err)
 			}
-		case workflowRunTargetCancelWorkflowRun:
-			child := resources.childWorkflows[target.name]
+		case target.workflowRun != nil:
+			child := resources.childWorkflows[target.workflowRun.name]
 			if child == nil || child.Spec.CancelRequested || isTerminalWorkflowPhase(child.Status.Phase) {
 				continue
 			}
@@ -817,7 +837,7 @@ func (r *WorkflowRunReconciler) applyRequestChildCancellation(ctx context.Contex
 				return fmt.Errorf("request cancellation of child workflowrun %s/%s: %w", child.Namespace, child.Name, err)
 			}
 		default:
-			return fmt.Errorf("cancel workflowrun target has unsupported kind %q", target.kind)
+			return fmt.Errorf("cancel workflowrun target is not a child Run or WorkflowRun")
 		}
 	}
 	return nil

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -476,6 +476,70 @@ func TestWorkflowRunReconcilerFailsOnlyInvalidReusableCall(t *testing.T) {
 	}
 }
 
+func TestWorkflowRunReconcilerRecoversMaterializedCallBeforeStatusPatch(t *testing.T) {
+	scheme := workflowRunTestScheme(t)
+	parent := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default", UID: "parent-uid"},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"deploy": {Uses: "deploy-workflow"},
+		}},
+		Status: v1alpha1.WorkflowRunStatus{
+			Phase: v1alpha1.WorkflowPending,
+			Jobs:  resolvedJobStatuses(map[string]v1alpha1.JobSpec{"deploy": {Uses: "deploy-workflow"}}),
+		},
+	}
+	workflow := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "deploy-workflow", Namespace: parent.Namespace},
+		Spec: v1alpha1.WorkflowSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"apply": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "deploy", Run: "deploy"}}},
+		}},
+	}
+	child := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      workflowCallRunName(parent.Name, "deploy"),
+			Namespace: parent.Namespace,
+			UID:       "child-uid",
+			Labels:    map[string]string{v1alpha1.WorkflowRunUIDLabel: string(parent.UID)},
+		},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: workflow.Spec.Jobs},
+	}
+	if err := controllerutil.SetControllerReference(parent, child, scheme); err != nil {
+		t.Fatalf("set child owner: %v", err)
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(parent, workflow, child).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	if _, _, err := reconciler.ensureWorkflowSnapshot(context.Background(), parent, workflowSnapshotForRun(parent)); err != nil {
+		t.Fatalf("persist parent snapshot: %v", err)
+	}
+	if _, _, err := reconciler.ensureWorkflowSnapshot(context.Background(), child, workflowSnapshotForMaterializedWorkflow(child, workflow)); err != nil {
+		t.Fatalf("persist child snapshot: %v", err)
+	}
+
+	// Simulate a controller crash after the child and its snapshot were created,
+	// but before the parent status recorded workflowRunName.
+	reconcileWorkflowRun(t, reconciler, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(parent)}, 1)
+
+	var updated v1alpha1.WorkflowRun
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(parent), &updated); err != nil {
+		t.Fatalf("get parent workflowrun: %v", err)
+	}
+	status := updated.Status.Jobs["deploy"]
+	if status.Phase != v1alpha1.JobRunning || status.WorkflowRunName != child.Name {
+		t.Fatalf("deploy status = %#v, want recovered existing child %q", status, child.Name)
+	}
+	var children v1alpha1.WorkflowRunList
+	if err := c.List(context.Background(), &children, client.InNamespace(parent.Namespace), client.MatchingLabels{v1alpha1.WorkflowRunUIDLabel: string(parent.UID)}); err != nil {
+		t.Fatalf("list child workflowruns: %v", err)
+	}
+	if len(children.Items) != 1 || children.Items[0].Name != child.Name {
+		t.Fatalf("child workflowruns = %#v, want exactly existing child", children.Items)
+	}
+}
+
 func TestWorkflowRunReconcilerRejectsOversizedSnapshot(t *testing.T) {
 	scheme := workflowRunTestScheme(t)
 	workflowRun := &v1alpha1.WorkflowRun{

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -178,7 +178,7 @@ func TestCalculateWorkflowRunPlanSeparatesCurrentStateFromAction(t *testing.T) {
 		},
 	}
 	plan = calculateWorkflowRunPlan(&workflowRunResources{workflowRun: pending, snapshot: snapshotForWorkflowRun(pending)})
-	if plan.state != workflowRunStatePending || plan.action != workflowRunActionStartRunnableSteps || len(plan.targets) != 1 || plan.targets[0] != (workflowRunStepTarget{jobName: "build", stepIndex: 0}) {
+	if plan.state != workflowRunStatePending || plan.action != workflowRunActionStartRunnableTargets || len(plan.targets) != 1 || plan.targets[0] != (workflowRunStepTarget{jobName: "build", stepIndex: 0}) {
 		t.Fatalf("pending plan = %#v, want Pending + StartRunnableSteps(build[0])", plan)
 	}
 
@@ -240,7 +240,7 @@ func TestCalculateWorkflowRunPlanProjectsStatusBeforeStartingReadyJobs(t *testin
 		snapshot:    snapshotForWorkflowRun(workflowRun),
 	})
 	want := []workflowRunStepTarget{{jobName: "lint", stepIndex: 0}}
-	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableSteps || !slices.Equal(plan.targets, want) {
+	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableTargets || !slices.Equal(plan.targets, want) {
 		t.Fatalf("plan = %#v, want Running + StartRunnableSteps(%#v)", plan, want)
 	}
 	if workflowRun.Status.Jobs["build"].Phase != v1alpha1.JobSucceeded {
@@ -265,7 +265,7 @@ func TestPlanWorkflowRunStartsAllRunnableSteps(t *testing.T) {
 
 	plan := calculateWorkflowRunPlan(&workflowRunResources{workflowRun: workflowRun, snapshot: snapshotForWorkflowRun(workflowRun)})
 	want := []workflowRunStepTarget{{jobName: "build", stepIndex: 1}, {jobName: "lint", stepIndex: 0}}
-	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableSteps || !slices.Equal(plan.targets, want) {
+	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableTargets || !slices.Equal(plan.targets, want) {
 		t.Fatalf("plan = %#v, want Running + StartRunnableSteps(%#v)", plan, want)
 	}
 }
@@ -287,7 +287,7 @@ func TestCalculateWorkflowRunPlanFinalizesJobsBeforeStartingReadyJobs(t *testing
 
 	plan := calculateWorkflowRunPlan(&workflowRunResources{workflowRun: workflowRun, snapshot: snapshotForWorkflowRun(workflowRun)})
 	want := []workflowRunStepTarget{{jobName: "lint", stepIndex: 0}}
-	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableSteps || !slices.Equal(plan.targets, want) {
+	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableTargets || !slices.Equal(plan.targets, want) {
 		t.Fatalf("plan = %#v, want Running + StartRunnableSteps(%#v)", plan, want)
 	}
 	if workflowRun.Status.Jobs["build"].Phase != v1alpha1.JobSucceeded {
@@ -362,7 +362,7 @@ func TestWorkflowRunReconcilerSkipsBlockedJobsAndStartsIndependentJobs(t *testin
 	}
 }
 
-func TestWorkflowRunReconcilerRejectsUnsupportedJobLevelUsesDuringInitialization(t *testing.T) {
+func TestWorkflowRunReconcilerCreatesMaterializedWorkflowCall(t *testing.T) {
 	scheme := workflowRunTestScheme(t)
 
 	workflowRun := &v1alpha1.WorkflowRun{
@@ -377,9 +377,10 @@ func TestWorkflowRunReconcilerRejectsUnsupportedJobLevelUsesDuringInitialization
 	}
 	workflow := &v1alpha1.Workflow{
 		ObjectMeta: metav1.ObjectMeta{Name: "build-and-test", Namespace: workflowRun.Namespace},
-		Spec: v1alpha1.WorkflowSpec{Jobs: map[string]v1alpha1.JobSpec{
-			"build": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}}},
-		}},
+		Spec: v1alpha1.WorkflowSpec{
+			Outputs: map[string]v1alpha1.WorkflowOutputSpec{"artifact": {Value: "${{ jobs.build.outputs.artifact }}"}},
+			Jobs:    map[string]v1alpha1.JobSpec{"build": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "compile", Run: "make build"}}}},
+		},
 	}
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
@@ -398,18 +399,35 @@ func TestWorkflowRunReconcilerRejectsUnsupportedJobLevelUsesDuringInitialization
 	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
 		t.Fatalf("get workflowrun: %v", err)
 	}
-	if updated.Status.Phase != v1alpha1.WorkflowFailed {
-		t.Fatalf("phase = %q, want %q", updated.Status.Phase, v1alpha1.WorkflowFailed)
+	if updated.Status.Phase != v1alpha1.WorkflowRunning {
+		t.Fatalf("phase = %q, want %q", updated.Status.Phase, v1alpha1.WorkflowRunning)
 	}
-	if !strings.Contains(updated.Status.Message, "job-level uses is not implemented yet") {
-		t.Fatalf("message = %q, want job-level uses not implemented", updated.Status.Message)
-	}
-	if updated.Status.Jobs != nil {
-		t.Fatalf("jobs = %#v, want nil for rejected workflowrun", updated.Status.Jobs)
+	job := updated.Status.Jobs["release"]
+	childName := workflowCallRunName(workflowRun.Name, "release")
+	if job.Phase != v1alpha1.JobRunning || job.WorkflowRunName != childName {
+		t.Fatalf("call status = %#v, want running child %q", job, childName)
 	}
 	cond := apimeta.FindStatusCondition(updated.Status.Conditions, v1alpha1.WorkflowRunAcceptedCondition)
-	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "WorkflowValidationFailed" {
-		t.Fatalf("condition = %#v, want validation rejection", cond)
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatalf("condition = %#v, want accepted workflowrun", cond)
+	}
+	child := &v1alpha1.WorkflowRun{}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: workflowRun.Namespace, Name: childName}, child); err != nil {
+		t.Fatalf("get child workflowrun: %v", err)
+	}
+	if child.Spec.Jobs["build"].Steps[0].Run != "make build" {
+		t.Fatalf("child spec = %#v, want materialized build job", child.Spec)
+	}
+	revision := &appsv1.ControllerRevision{}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: child.Namespace, Name: workflowSnapshotName(child)}, revision); err != nil {
+		t.Fatalf("get child snapshot: %v", err)
+	}
+	snapshot, err := loadWorkflowSnapshot(revision)
+	if err != nil {
+		t.Fatalf("load child snapshot: %v", err)
+	}
+	if snapshot.OutputContract[workflow.Name].Outputs["artifact"].Value != "${{ jobs.build.outputs.artifact }}" {
+		t.Fatalf("child snapshot output contract = %#v", snapshot.OutputContract)
 	}
 }
 

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -1207,6 +1207,45 @@ func TestWorkflowRunReconcilerSnapshotsInlineJobs(t *testing.T) {
 	}
 }
 
+func TestWorkflowRunReconcilerSnapshotsMaterializedWorkflowOutputContract(t *testing.T) {
+	scheme := workflowRunTestScheme(t)
+	child := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release-deploy", Namespace: "default", UID: "child-uid"},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"apply": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "deploy", Run: "deploy --environment=staging"}}},
+		}},
+	}
+	workflow := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "deploy-workflow", Namespace: child.Namespace},
+		Spec: v1alpha1.WorkflowSpec{Outputs: map[string]v1alpha1.WorkflowOutputSpec{
+			"endpoint": {Value: "${{ jobs.apply.outputs.endpoint }}"},
+		}},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(child).Build()
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+
+	if _, _, err := reconciler.ensureWorkflowSnapshot(context.Background(), child, workflowSnapshotForMaterializedWorkflow(child, workflow)); err != nil {
+		t.Fatalf("persist materialized workflow snapshot: %v", err)
+	}
+	workflow.Spec.Outputs["endpoint"] = v1alpha1.WorkflowOutputSpec{Value: "${{ jobs.apply.outputs.changed }}"}
+
+	revision := &appsv1.ControllerRevision{}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: child.Namespace, Name: workflowSnapshotName(child)}, revision); err != nil {
+		t.Fatalf("get snapshot: %v", err)
+	}
+	snapshot, err := loadWorkflowSnapshot(revision)
+	if err != nil {
+		t.Fatalf("load snapshot: %v", err)
+	}
+	if got := snapshot.Spec.Jobs["apply"].Steps[0].Run; got != "deploy --environment=staging" {
+		t.Fatalf("snapshot job = %q, want materialized job", got)
+	}
+	contract, ok := snapshot.OutputContract["deploy-workflow"]
+	if !ok || contract.Outputs["endpoint"].Value != "${{ jobs.apply.outputs.endpoint }}" {
+		t.Fatalf("output contract = %#v, want frozen source workflow output", snapshot.OutputContract)
+	}
+}
+
 func TestWorkflowRunReconcilerRecoversSnapshotBeforeStatusPatch(t *testing.T) {
 	scheme := workflowRunTestScheme(t)
 	workflowRun := &v1alpha1.WorkflowRun{

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -179,7 +180,7 @@ func TestCalculateWorkflowRunPlanSeparatesCurrentStateFromAction(t *testing.T) {
 		},
 	}
 	plan = calculateWorkflowRunPlan(&workflowRunResources{workflowRun: pending, snapshot: snapshotForWorkflowRun(pending)})
-	if plan.state != workflowRunStatePending || plan.action != workflowRunActionStartRunnableTargets || len(plan.targets) != 1 || plan.targets[0] != (workflowRunStepTarget{jobName: "build", stepIndex: 0}) {
+	if plan.state != workflowRunStatePending || plan.action != workflowRunActionStartRunnableTargets || len(plan.targets) != 1 || plan.targets[0] != (workflowRunTarget{kind: workflowRunTargetStep, jobName: "build", stepIndex: 0}) {
 		t.Fatalf("pending plan = %#v, want Pending + StartRunnableSteps(build[0])", plan)
 	}
 
@@ -198,7 +199,7 @@ func TestCalculateWorkflowRunPlanSeparatesCurrentStateFromAction(t *testing.T) {
 		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): activeRun},
 		snapshot:    snapshotForWorkflowRun(cancelling),
 	})
-	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildCancellation || !slices.Equal(plan.runNames, []string{"build-run"}) {
+	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildCancellation || !slices.Equal(plan.targets, []workflowRunTarget{{kind: workflowRunTargetCancelRun, name: "build-run"}}) {
 		t.Fatalf("cancelling plan = %#v, want Cancelling + RequestChildRunCancellation(build-run)", plan)
 	}
 
@@ -210,7 +211,7 @@ func TestCalculateWorkflowRunPlanSeparatesCurrentStateFromAction(t *testing.T) {
 		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): activeRun},
 		snapshot:    snapshotForWorkflowRun(cancelling),
 	})
-	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildCancellation || !slices.Equal(plan.runNames, []string{"build-run"}) {
+	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildCancellation || !slices.Equal(plan.targets, []workflowRunTarget{{kind: workflowRunTargetCancelRun, name: "build-run"}}) {
 		t.Fatalf("late child plan = %#v, want cancellation repair", plan)
 	}
 }
@@ -240,7 +241,7 @@ func TestCalculateWorkflowRunPlanProjectsStatusBeforeStartingReadyJobs(t *testin
 		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): buildRun},
 		snapshot:    snapshotForWorkflowRun(workflowRun),
 	})
-	want := []workflowRunStepTarget{{jobName: "lint", stepIndex: 0}}
+	want := []workflowRunTarget{{kind: workflowRunTargetStep, jobName: "lint", stepIndex: 0}}
 	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableTargets || !slices.Equal(plan.targets, want) {
 		t.Fatalf("plan = %#v, want Running + StartRunnableSteps(%#v)", plan, want)
 	}
@@ -265,7 +266,7 @@ func TestPlanWorkflowRunStartsAllRunnableSteps(t *testing.T) {
 	}
 
 	plan := calculateWorkflowRunPlan(&workflowRunResources{workflowRun: workflowRun, snapshot: snapshotForWorkflowRun(workflowRun)})
-	want := []workflowRunStepTarget{{jobName: "build", stepIndex: 1}, {jobName: "lint", stepIndex: 0}}
+	want := []workflowRunTarget{{kind: workflowRunTargetStep, jobName: "build", stepIndex: 1}, {kind: workflowRunTargetStep, jobName: "lint", stepIndex: 0}}
 	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableTargets || !slices.Equal(plan.targets, want) {
 		t.Fatalf("plan = %#v, want Running + StartRunnableSteps(%#v)", plan, want)
 	}
@@ -287,7 +288,7 @@ func TestCalculateWorkflowRunPlanFinalizesJobsBeforeStartingReadyJobs(t *testing
 	}
 
 	plan := calculateWorkflowRunPlan(&workflowRunResources{workflowRun: workflowRun, snapshot: snapshotForWorkflowRun(workflowRun)})
-	want := []workflowRunStepTarget{{jobName: "lint", stepIndex: 0}}
+	want := []workflowRunTarget{{kind: workflowRunTargetStep, jobName: "lint", stepIndex: 0}}
 	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableTargets || !slices.Equal(plan.targets, want) {
 		t.Fatalf("plan = %#v, want Running + StartRunnableSteps(%#v)", plan, want)
 	}
@@ -422,16 +423,16 @@ func TestWorkflowRunReconcilerCreatesMaterializedWorkflowCall(t *testing.T) {
 	if child.Labels[v1alpha1.WorkflowRunUIDLabel] != string(workflowRun.UID) {
 		t.Fatalf("child labels = %#v, want parent workflowrun UID", child.Labels)
 	}
+	if child.Annotations[v1alpha1.WorkflowOutputAnnotationPrefix+"artifact"] != "${{ jobs.build.outputs.artifact }}" {
+		t.Fatalf("child annotations = %#v, want frozen output contract", child.Annotations)
+	}
 	revision := &appsv1.ControllerRevision{}
+	if err := c.Get(context.Background(), client.ObjectKey{Namespace: child.Namespace, Name: workflowSnapshotName(child)}, revision); !apierrors.IsNotFound(err) {
+		t.Fatalf("child snapshot after parent reconcile error = %v, want not found", err)
+	}
+	reconcileWorkflowRun(t, reconciler, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(child)}, 1)
 	if err := c.Get(context.Background(), client.ObjectKey{Namespace: child.Namespace, Name: workflowSnapshotName(child)}, revision); err != nil {
-		t.Fatalf("get child snapshot: %v", err)
-	}
-	snapshot, err := loadWorkflowSnapshot(revision)
-	if err != nil {
-		t.Fatalf("load child snapshot: %v", err)
-	}
-	if snapshot.OutputContract[workflow.Name].Outputs["artifact"].Value != "${{ jobs.build.outputs.artifact }}" {
-		t.Fatalf("child snapshot output contract = %#v", snapshot.OutputContract)
+		t.Fatalf("get child-owned snapshot after child reconcile: %v", err)
 	}
 }
 
@@ -515,11 +516,7 @@ func TestWorkflowRunReconcilerRecoversMaterializedCallBeforeStatusPatch(t *testi
 	if _, _, err := reconciler.ensureWorkflowSnapshot(context.Background(), parent, workflowSnapshotForRun(parent)); err != nil {
 		t.Fatalf("persist parent snapshot: %v", err)
 	}
-	if _, _, err := reconciler.ensureWorkflowSnapshot(context.Background(), child, workflowSnapshotForMaterializedWorkflow(child, workflow)); err != nil {
-		t.Fatalf("persist child snapshot: %v", err)
-	}
-
-	// Simulate a controller crash after the child and its snapshot were created,
+	// Simulate a controller crash after the child was created,
 	// but before the parent status recorded workflowRunName.
 	reconcileWorkflowRun(t, reconciler, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(parent)}, 1)
 
@@ -1203,7 +1200,7 @@ func TestWorkflowRunReconcilerRequestsDirectChildWorkflowCancellation(t *testing
 	}
 }
 
-func TestWorkflowRunReconcilerDefersChildInitializationUntilParentSnapshotExists(t *testing.T) {
+func TestWorkflowRunReconcilerInitializesChildWithoutParentSnapshot(t *testing.T) {
 	scheme := workflowRunTestScheme(t)
 	parent := &v1alpha1.WorkflowRun{ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default", UID: "parent-uid"}}
 	child := &v1alpha1.WorkflowRun{
@@ -1231,13 +1228,13 @@ func TestWorkflowRunReconcilerDefersChildInitializationUntilParentSnapshotExists
 	if err := c.Get(context.Background(), client.ObjectKeyFromObject(child), &updated); err != nil {
 		t.Fatalf("get child workflowrun: %v", err)
 	}
-	if updated.Status.Jobs != nil || updated.Status.SnapshotName != "" {
-		t.Fatalf("child status = %#v, want deferred initialization", updated.Status)
+	if updated.Status.Jobs == nil || updated.Status.SnapshotName == "" {
+		t.Fatalf("child status = %#v, want initialized child", updated.Status)
 	}
 	revision := &appsv1.ControllerRevision{}
 	err := c.Get(context.Background(), client.ObjectKey{Namespace: child.Namespace, Name: workflowSnapshotName(child)}, revision)
-	if !apierrors.IsNotFound(err) {
-		t.Fatalf("get child snapshot error = %v, want not found", err)
+	if err != nil {
+		t.Fatalf("get child-owned snapshot: %v", err)
 	}
 }
 
@@ -1423,27 +1420,25 @@ func TestWorkflowRunReconcilerSnapshotsInlineJobs(t *testing.T) {
 	}
 }
 
-func TestWorkflowRunReconcilerSnapshotsMaterializedWorkflowOutputContract(t *testing.T) {
+func TestWorkflowRunReconcilerInitializesMaterializedWorkflowSnapshot(t *testing.T) {
 	scheme := workflowRunTestScheme(t)
 	child := &v1alpha1.WorkflowRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "release-deploy", Namespace: "default", UID: "child-uid"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "release-deploy",
+			Namespace: "default",
+			UID:       "child-uid",
+			Annotations: map[string]string{
+				v1alpha1.WorkflowOutputAnnotationPrefix + "endpoint": "${{ jobs.apply.outputs.endpoint }}",
+			},
+		},
 		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
 			"apply": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "deploy", Run: "deploy --environment=staging"}}},
 		}},
 	}
-	workflow := &v1alpha1.Workflow{
-		ObjectMeta: metav1.ObjectMeta{Name: "deploy-workflow", Namespace: child.Namespace},
-		Spec: v1alpha1.WorkflowSpec{Outputs: map[string]v1alpha1.WorkflowOutputSpec{
-			"endpoint": {Value: "${{ jobs.apply.outputs.endpoint }}"},
-		}},
-	}
-	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(child).Build()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(child).WithStatusSubresource(&v1alpha1.WorkflowRun{}).Build()
 	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
 
-	if _, _, err := reconciler.ensureWorkflowSnapshot(context.Background(), child, workflowSnapshotForMaterializedWorkflow(child, workflow)); err != nil {
-		t.Fatalf("persist materialized workflow snapshot: %v", err)
-	}
-	workflow.Spec.Outputs["endpoint"] = v1alpha1.WorkflowOutputSpec{Value: "${{ jobs.apply.outputs.changed }}"}
+	reconcileWorkflowRun(t, reconciler, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(child)}, 1)
 
 	revision := &appsv1.ControllerRevision{}
 	if err := c.Get(context.Background(), client.ObjectKey{Namespace: child.Namespace, Name: workflowSnapshotName(child)}, revision); err != nil {
@@ -1456,9 +1451,8 @@ func TestWorkflowRunReconcilerSnapshotsMaterializedWorkflowOutputContract(t *tes
 	if got := snapshot.Spec.Jobs["apply"].Steps[0].Run; got != "deploy --environment=staging" {
 		t.Fatalf("snapshot job = %q, want materialized job", got)
 	}
-	contract, ok := snapshot.OutputContract["deploy-workflow"]
-	if !ok || contract.Outputs["endpoint"].Value != "${{ jobs.apply.outputs.endpoint }}" {
-		t.Fatalf("output contract = %#v, want frozen source workflow output", snapshot.OutputContract)
+	if child.Annotations[v1alpha1.WorkflowOutputAnnotationPrefix+"endpoint"] != "${{ jobs.apply.outputs.endpoint }}" {
+		t.Fatalf("child annotations = %#v, want frozen source workflow output", child.Annotations)
 	}
 }
 
@@ -1469,7 +1463,13 @@ func TestDeriveWorkflowCallStatusesProjectsFrozenChildOutputs(t *testing.T) {
 		}},
 	}
 	child := &v1alpha1.WorkflowRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "deploy-child", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "deploy-child",
+			Namespace: "default",
+			Annotations: map[string]string{
+				v1alpha1.WorkflowOutputAnnotationPrefix + "endpoint": "${{ jobs.apply.outputs.endpoint }}",
+			},
+		},
 		Status: v1alpha1.WorkflowRunStatus{
 			Phase: v1alpha1.WorkflowSucceeded,
 			Jobs: map[string]v1alpha1.JobStatus{
@@ -1481,15 +1481,6 @@ func TestDeriveWorkflowCallStatusesProjectsFrozenChildOutputs(t *testing.T) {
 		workflowRun: parent,
 		childWorkflows: map[string]*v1alpha1.WorkflowRun{
 			child.Name: child,
-		},
-		childSnapshots: map[string]*workflowExecutionSnapshot{
-			child.Name: {
-				OutputContract: map[string]workflowOutputContract{
-					"deploy-workflow": {Outputs: map[string]v1alpha1.WorkflowOutputSpec{
-						"endpoint": {Value: "${{ jobs.apply.outputs.endpoint }}"},
-					}},
-				},
-			},
 		},
 	}
 
@@ -1507,22 +1498,19 @@ func TestDeriveWorkflowCallStatusesFailsInvalidOutputContract(t *testing.T) {
 		}},
 	}
 	child := &v1alpha1.WorkflowRun{
-		ObjectMeta: metav1.ObjectMeta{Name: "deploy-child", Namespace: "default"},
-		Status:     v1alpha1.WorkflowRunStatus{Phase: v1alpha1.WorkflowSucceeded},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "deploy-child",
+			Namespace: "default",
+			Annotations: map[string]string{
+				v1alpha1.WorkflowOutputAnnotationPrefix + "endpoint": "${{ jobs.apply.outputs.endpoint }}",
+			},
+		},
+		Status: v1alpha1.WorkflowRunStatus{Phase: v1alpha1.WorkflowSucceeded},
 	}
 	resources := &workflowRunResources{
 		workflowRun: parent,
 		childWorkflows: map[string]*v1alpha1.WorkflowRun{
 			child.Name: child,
-		},
-		childSnapshots: map[string]*workflowExecutionSnapshot{
-			child.Name: {
-				OutputContract: map[string]workflowOutputContract{
-					"deploy-workflow": {Outputs: map[string]v1alpha1.WorkflowOutputSpec{
-						"endpoint": {Value: "${{ jobs.apply.outputs.endpoint }}"},
-					}},
-				},
-			},
 		},
 	}
 
@@ -1530,6 +1518,34 @@ func TestDeriveWorkflowCallStatusesFailsInvalidOutputContract(t *testing.T) {
 	status := parent.Status.Jobs["deploy"]
 	if status.Phase != v1alpha1.JobFailed || !strings.Contains(parent.Status.Message, "resolve outputs for job \"deploy\"") {
 		t.Fatalf("parent status = %#v, want failed call with output error", parent.Status)
+	}
+}
+
+func TestWorkflowOutputContractAnnotations(t *testing.T) {
+	annotations, err := workflowOutputContractAnnotations(map[string]v1alpha1.WorkflowOutputSpec{
+		"endpoint": {Value: "${{ jobs.apply.outputs.endpoint }}"},
+	})
+	if err != nil {
+		t.Fatalf("create output annotations: %v", err)
+	}
+	contract, err := workflowOutputContractFromAnnotations(annotations)
+	if err != nil {
+		t.Fatalf("read output annotations: %v", err)
+	}
+	if got := contract["endpoint"].Value; got != "${{ jobs.apply.outputs.endpoint }}" {
+		t.Fatalf("output contract = %#v", contract)
+	}
+	if _, err := workflowOutputContractAnnotations(map[string]v1alpha1.WorkflowOutputSpec{
+		"invalid/key": {Value: "${{ jobs.apply.outputs.endpoint }}"},
+	}); err == nil {
+		t.Fatal("invalid output name error = nil, want annotation validation error")
+	}
+	outputs := make(map[string]v1alpha1.WorkflowOutputSpec)
+	for i := range 64 {
+		outputs[fmt.Sprintf("output-%d", i)] = v1alpha1.WorkflowOutputSpec{Value: strings.Repeat("x", 8192)}
+	}
+	if _, err := workflowOutputContractAnnotations(outputs); err == nil {
+		t.Fatal("oversized output contract error = nil, want annotation size error")
 	}
 }
 

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -435,6 +435,47 @@ func TestWorkflowRunReconcilerCreatesMaterializedWorkflowCall(t *testing.T) {
 	}
 }
 
+func TestWorkflowRunReconcilerFailsOnlyInvalidReusableCall(t *testing.T) {
+	scheme := workflowRunTestScheme(t)
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default", UID: "workflowrun-uid"},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"deploy": {Uses: "missing-workflow"},
+			"lint":   {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "check", Run: "make lint"}}},
+		}},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(workflowRun).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(workflowRun)}
+
+	reconcileWorkflowRun(t, reconciler, req, 2)
+
+	var updated v1alpha1.WorkflowRun
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), &updated); err != nil {
+		t.Fatalf("get workflowrun: %v", err)
+	}
+	if updated.Status.Jobs["deploy"].Phase != v1alpha1.JobFailed {
+		t.Fatalf("deploy status = %#v, want failed missing reusable workflow", updated.Status.Jobs["deploy"])
+	}
+	if updated.Status.Jobs["lint"].Phase != v1alpha1.JobRunning {
+		t.Fatalf("lint status = %#v, want independent job running", updated.Status.Jobs["lint"])
+	}
+	if !strings.Contains(updated.Status.Message, `reusable workflow "missing-workflow"`) {
+		t.Fatalf("message = %q, want missing reusable workflow", updated.Status.Message)
+	}
+	var children v1alpha1.WorkflowRunList
+	if err := c.List(context.Background(), &children, client.InNamespace(workflowRun.Namespace)); err != nil {
+		t.Fatalf("list child workflowruns: %v", err)
+	}
+	if len(children.Items) != 1 {
+		t.Fatalf("workflowruns = %#v, want only parent", children.Items)
+	}
+}
+
 func TestWorkflowRunReconcilerRejectsOversizedSnapshot(t *testing.T) {
 	scheme := workflowRunTestScheme(t)
 	workflowRun := &v1alpha1.WorkflowRun{

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 )
@@ -197,7 +198,7 @@ func TestCalculateWorkflowRunPlanSeparatesCurrentStateFromAction(t *testing.T) {
 		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): activeRun},
 		snapshot:    snapshotForWorkflowRun(cancelling),
 	})
-	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildRunCancellation || !slices.Equal(plan.runNames, []string{"build-run"}) {
+	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildCancellation || !slices.Equal(plan.runNames, []string{"build-run"}) {
 		t.Fatalf("cancelling plan = %#v, want Cancelling + RequestChildRunCancellation(build-run)", plan)
 	}
 
@@ -209,7 +210,7 @@ func TestCalculateWorkflowRunPlanSeparatesCurrentStateFromAction(t *testing.T) {
 		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): activeRun},
 		snapshot:    snapshotForWorkflowRun(cancelling),
 	})
-	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildRunCancellation || !slices.Equal(plan.runNames, []string{"build-run"}) {
+	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildCancellation || !slices.Equal(plan.runNames, []string{"build-run"}) {
 		t.Fatalf("late child plan = %#v, want cancellation repair", plan)
 	}
 }
@@ -417,6 +418,9 @@ func TestWorkflowRunReconcilerCreatesMaterializedWorkflowCall(t *testing.T) {
 	}
 	if child.Spec.Jobs["build"].Steps[0].Run != "make build" {
 		t.Fatalf("child spec = %#v, want materialized build job", child.Spec)
+	}
+	if child.Labels[v1alpha1.WorkflowRunUIDLabel] != string(workflowRun.UID) {
+		t.Fatalf("child labels = %#v, want parent workflowrun UID", child.Labels)
 	}
 	revision := &appsv1.ControllerRevision{}
 	if err := c.Get(context.Background(), client.ObjectKey{Namespace: child.Namespace, Name: workflowSnapshotName(child)}, revision); err != nil {
@@ -1043,6 +1047,95 @@ func TestWorkflowRunReconcilerRequestsCancellationWithoutStartingNewJobs(t *test
 	}
 }
 
+func TestWorkflowRunReconcilerRequestsDirectChildWorkflowCancellation(t *testing.T) {
+	scheme := workflowRunTestScheme(t)
+	parent := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default", UID: "parent-uid"},
+		Spec: v1alpha1.WorkflowRunSpec{
+			CancelRequested: true,
+			Jobs: map[string]v1alpha1.JobSpec{
+				"deploy": {Uses: "deploy-workflow"},
+			},
+		},
+		Status: v1alpha1.WorkflowRunStatus{
+			Phase: v1alpha1.WorkflowRunning,
+			Jobs: map[string]v1alpha1.JobStatus{
+				"deploy": {Phase: v1alpha1.JobRunning, WorkflowRunName: "release-deploy"},
+			},
+		},
+	}
+	child := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "release-deploy",
+			Namespace: parent.Namespace,
+			UID:       "child-uid",
+			Labels:    map[string]string{v1alpha1.WorkflowRunUIDLabel: string(parent.UID)},
+		},
+		Spec:   v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{"apply": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "deploy", Run: "deploy"}}}}},
+		Status: v1alpha1.WorkflowRunStatus{Phase: v1alpha1.WorkflowRunning},
+	}
+	if err := controllerutil.SetControllerReference(parent, child, scheme); err != nil {
+		t.Fatalf("set child owner: %v", err)
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(parent, child).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+	if _, _, err := reconciler.ensureWorkflowSnapshot(context.Background(), parent, workflowSnapshotForRun(parent)); err != nil {
+		t.Fatalf("persist parent snapshot: %v", err)
+	}
+
+	reconcileWorkflowRun(t, reconciler, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(parent)}, 1)
+
+	var updatedChild v1alpha1.WorkflowRun
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(child), &updatedChild); err != nil {
+		t.Fatalf("get child workflowrun: %v", err)
+	}
+	if !updatedChild.Spec.CancelRequested {
+		t.Fatal("child workflowrun cancelRequested = false, want true")
+	}
+}
+
+func TestWorkflowRunReconcilerDefersChildInitializationUntilParentSnapshotExists(t *testing.T) {
+	scheme := workflowRunTestScheme(t)
+	parent := &v1alpha1.WorkflowRun{ObjectMeta: metav1.ObjectMeta{Name: "release", Namespace: "default", UID: "parent-uid"}}
+	child := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "release-deploy",
+			Namespace: parent.Namespace,
+			UID:       "child-uid",
+			Labels:    map[string]string{v1alpha1.WorkflowRunUIDLabel: string(parent.UID)},
+		},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{"apply": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "deploy", Run: "deploy"}}}}},
+	}
+	if err := controllerutil.SetControllerReference(parent, child, scheme); err != nil {
+		t.Fatalf("set child owner: %v", err)
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(parent, child).
+		WithStatusSubresource(&v1alpha1.WorkflowRun{}).
+		Build()
+	reconciler := &WorkflowRunReconciler{Client: c, Scheme: scheme}
+
+	reconcileWorkflowRun(t, reconciler, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(child)}, 1)
+
+	var updated v1alpha1.WorkflowRun
+	if err := c.Get(context.Background(), client.ObjectKeyFromObject(child), &updated); err != nil {
+		t.Fatalf("get child workflowrun: %v", err)
+	}
+	if updated.Status.Jobs != nil || updated.Status.SnapshotName != "" {
+		t.Fatalf("child status = %#v, want deferred initialization", updated.Status)
+	}
+	revision := &appsv1.ControllerRevision{}
+	err := c.Get(context.Background(), client.ObjectKey{Namespace: child.Namespace, Name: workflowSnapshotName(child)}, revision)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("get child snapshot error = %v, want not found", err)
+	}
+}
+
 func TestWorkflowRunReconcilerFinalizesCancellationAfterChildRunsSettle(t *testing.T) {
 	scheme := workflowRunTestScheme(t)
 	workflowRun := &v1alpha1.WorkflowRun{
@@ -1261,6 +1354,97 @@ func TestWorkflowRunReconcilerSnapshotsMaterializedWorkflowOutputContract(t *tes
 	contract, ok := snapshot.OutputContract["deploy-workflow"]
 	if !ok || contract.Outputs["endpoint"].Value != "${{ jobs.apply.outputs.endpoint }}" {
 		t.Fatalf("output contract = %#v, want frozen source workflow output", snapshot.OutputContract)
+	}
+}
+
+func TestDeriveWorkflowCallStatusesProjectsFrozenChildOutputs(t *testing.T) {
+	parent := &v1alpha1.WorkflowRun{
+		Status: v1alpha1.WorkflowRunStatus{Jobs: map[string]v1alpha1.JobStatus{
+			"deploy": {Phase: v1alpha1.JobRunning, WorkflowRunName: "deploy-child"},
+		}},
+	}
+	child := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "deploy-child", Namespace: "default"},
+		Status: v1alpha1.WorkflowRunStatus{
+			Phase: v1alpha1.WorkflowSucceeded,
+			Jobs: map[string]v1alpha1.JobStatus{
+				"apply": {Phase: v1alpha1.JobSucceeded, Outputs: map[string]string{"endpoint": "https://staging.example.com"}},
+			},
+		},
+	}
+	resources := &workflowRunResources{
+		workflowRun: parent,
+		childWorkflows: map[string]*v1alpha1.WorkflowRun{
+			child.Name: child,
+		},
+		childSnapshots: map[string]*workflowExecutionSnapshot{
+			child.Name: {
+				OutputContract: map[string]workflowOutputContract{
+					"deploy-workflow": {Outputs: map[string]v1alpha1.WorkflowOutputSpec{
+						"endpoint": {Value: "${{ jobs.apply.outputs.endpoint }}"},
+					}},
+				},
+			},
+		},
+	}
+
+	deriveWorkflowCallStatuses(resources)
+	status := parent.Status.Jobs["deploy"]
+	if status.Phase != v1alpha1.JobSucceeded || status.Outputs["endpoint"] != "https://staging.example.com" {
+		t.Fatalf("call status = %#v, want succeeded projected output", status)
+	}
+}
+
+func TestDeriveWorkflowCallStatusesFailsInvalidOutputContract(t *testing.T) {
+	parent := &v1alpha1.WorkflowRun{
+		Status: v1alpha1.WorkflowRunStatus{Jobs: map[string]v1alpha1.JobStatus{
+			"deploy": {Phase: v1alpha1.JobRunning, WorkflowRunName: "deploy-child"},
+		}},
+	}
+	child := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "deploy-child", Namespace: "default"},
+		Status:     v1alpha1.WorkflowRunStatus{Phase: v1alpha1.WorkflowSucceeded},
+	}
+	resources := &workflowRunResources{
+		workflowRun: parent,
+		childWorkflows: map[string]*v1alpha1.WorkflowRun{
+			child.Name: child,
+		},
+		childSnapshots: map[string]*workflowExecutionSnapshot{
+			child.Name: {
+				OutputContract: map[string]workflowOutputContract{
+					"deploy-workflow": {Outputs: map[string]v1alpha1.WorkflowOutputSpec{
+						"endpoint": {Value: "${{ jobs.apply.outputs.endpoint }}"},
+					}},
+				},
+			},
+		},
+	}
+
+	deriveWorkflowCallStatuses(resources)
+	status := parent.Status.Jobs["deploy"]
+	if status.Phase != v1alpha1.JobFailed || !strings.Contains(parent.Status.Message, "resolve outputs for job \"deploy\"") {
+		t.Fatalf("parent status = %#v, want failed call with output error", parent.Status)
+	}
+}
+
+func TestDeriveJobStatusesProjectsStepOutputs(t *testing.T) {
+	workflowRun := &v1alpha1.WorkflowRun{
+		Status: v1alpha1.WorkflowRunStatus{Jobs: map[string]v1alpha1.JobStatus{
+			"build": {Phase: v1alpha1.JobRunning, Steps: []v1alpha1.StepStatus{{Name: "package", Phase: v1alpha1.StepSucceeded, Outputs: map[string]string{"artifact": "dist.tgz"}}}},
+		}},
+	}
+	resources := &workflowRunResources{
+		workflowRun: workflowRun,
+		snapshot: &workflowExecutionSnapshot{Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"build": {Outputs: map[string]string{"artifact": "${{ steps.package.outputs.artifact }}"}},
+		}}},
+	}
+
+	deriveJobStatuses(resources)
+	status := workflowRun.Status.Jobs["build"]
+	if status.Phase != v1alpha1.JobSucceeded || status.Outputs["artifact"] != "dist.tgz" {
+		t.Fatalf("job status = %#v, want succeeded projected output", status)
 	}
 }
 

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -33,6 +33,41 @@ func workflowRunTestScheme(t *testing.T) *runtime.Scheme {
 		t.Fatalf("add apps scheme: %v", err)
 	}
 	return scheme
+}
+
+func stepRunTarget(jobName string, stepIndex int) workflowRunTarget {
+	return workflowRunTarget{step: &jobStepRunTarget{jobName: jobName, stepIndex: stepIndex}}
+}
+
+func cancelRunTarget(name string) workflowRunTarget {
+	return workflowRunTarget{run: &childRunTarget{name: name}}
+}
+
+func equalWorkflowRunTargets(got, want []workflowRunTarget) bool {
+	return reflect.DeepEqual(got, want)
+}
+
+func TestParentWorkflowRunRequest(t *testing.T) {
+	reconciler := &WorkflowRunReconciler{}
+	child := &v1alpha1.WorkflowRun{ObjectMeta: metav1.ObjectMeta{
+		Name:      "child",
+		Namespace: "default",
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: v1alpha1.GroupVersion.String(),
+			Kind:       "WorkflowRun",
+			Name:       "parent",
+			Controller: ptr(true),
+		}},
+	}}
+	requests := reconciler.parentWorkflowRunRequest(context.Background(), child)
+	if len(requests) != 1 || requests[0].Namespace != "default" || requests[0].Name != "parent" {
+		t.Fatalf("requests = %#v, want parent workflowrun request", requests)
+	}
+
+	primary := &v1alpha1.WorkflowRun{ObjectMeta: metav1.ObjectMeta{Name: "parent", Namespace: "default"}}
+	if requests := reconciler.parentWorkflowRunRequest(context.Background(), primary); len(requests) != 0 {
+		t.Fatalf("primary workflowrun mapped to %#v, want no owner request", requests)
+	}
 }
 
 func TestWorkflowRunReconcilerAcceptsWorkflowRun(t *testing.T) {
@@ -180,7 +215,7 @@ func TestCalculateWorkflowRunPlanSeparatesCurrentStateFromAction(t *testing.T) {
 		},
 	}
 	plan = calculateWorkflowRunPlan(&workflowRunResources{workflowRun: pending, snapshot: snapshotForWorkflowRun(pending)})
-	if plan.state != workflowRunStatePending || plan.action != workflowRunActionStartRunnableTargets || len(plan.targets) != 1 || plan.targets[0] != (workflowRunTarget{kind: workflowRunTargetStep, jobName: "build", stepIndex: 0}) {
+	if plan.state != workflowRunStatePending || plan.action != workflowRunActionStartRunnableTargets || !equalWorkflowRunTargets(plan.targets, []workflowRunTarget{stepRunTarget("build", 0)}) {
 		t.Fatalf("pending plan = %#v, want Pending + StartRunnableSteps(build[0])", plan)
 	}
 
@@ -199,7 +234,7 @@ func TestCalculateWorkflowRunPlanSeparatesCurrentStateFromAction(t *testing.T) {
 		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): activeRun},
 		snapshot:    snapshotForWorkflowRun(cancelling),
 	})
-	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildCancellation || !slices.Equal(plan.targets, []workflowRunTarget{{kind: workflowRunTargetCancelRun, name: "build-run"}}) {
+	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildCancellation || !equalWorkflowRunTargets(plan.targets, []workflowRunTarget{cancelRunTarget("build-run")}) {
 		t.Fatalf("cancelling plan = %#v, want Cancelling + RequestChildRunCancellation(build-run)", plan)
 	}
 
@@ -211,7 +246,7 @@ func TestCalculateWorkflowRunPlanSeparatesCurrentStateFromAction(t *testing.T) {
 		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): activeRun},
 		snapshot:    snapshotForWorkflowRun(cancelling),
 	})
-	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildCancellation || !slices.Equal(plan.targets, []workflowRunTarget{{kind: workflowRunTargetCancelRun, name: "build-run"}}) {
+	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildCancellation || !equalWorkflowRunTargets(plan.targets, []workflowRunTarget{cancelRunTarget("build-run")}) {
 		t.Fatalf("late child plan = %#v, want cancellation repair", plan)
 	}
 }
@@ -241,8 +276,8 @@ func TestCalculateWorkflowRunPlanProjectsStatusBeforeStartingReadyJobs(t *testin
 		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): buildRun},
 		snapshot:    snapshotForWorkflowRun(workflowRun),
 	})
-	want := []workflowRunTarget{{kind: workflowRunTargetStep, jobName: "lint", stepIndex: 0}}
-	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableTargets || !slices.Equal(plan.targets, want) {
+	want := []workflowRunTarget{stepRunTarget("lint", 0)}
+	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableTargets || !equalWorkflowRunTargets(plan.targets, want) {
 		t.Fatalf("plan = %#v, want Running + StartRunnableSteps(%#v)", plan, want)
 	}
 	if workflowRun.Status.Jobs["build"].Phase != v1alpha1.JobSucceeded {
@@ -266,8 +301,8 @@ func TestPlanWorkflowRunStartsAllRunnableSteps(t *testing.T) {
 	}
 
 	plan := calculateWorkflowRunPlan(&workflowRunResources{workflowRun: workflowRun, snapshot: snapshotForWorkflowRun(workflowRun)})
-	want := []workflowRunTarget{{kind: workflowRunTargetStep, jobName: "build", stepIndex: 1}, {kind: workflowRunTargetStep, jobName: "lint", stepIndex: 0}}
-	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableTargets || !slices.Equal(plan.targets, want) {
+	want := []workflowRunTarget{stepRunTarget("build", 1), stepRunTarget("lint", 0)}
+	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableTargets || !equalWorkflowRunTargets(plan.targets, want) {
 		t.Fatalf("plan = %#v, want Running + StartRunnableSteps(%#v)", plan, want)
 	}
 }
@@ -288,8 +323,8 @@ func TestCalculateWorkflowRunPlanFinalizesJobsBeforeStartingReadyJobs(t *testing
 	}
 
 	plan := calculateWorkflowRunPlan(&workflowRunResources{workflowRun: workflowRun, snapshot: snapshotForWorkflowRun(workflowRun)})
-	want := []workflowRunTarget{{kind: workflowRunTargetStep, jobName: "lint", stepIndex: 0}}
-	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableTargets || !slices.Equal(plan.targets, want) {
+	want := []workflowRunTarget{stepRunTarget("lint", 0)}
+	if plan.state != workflowRunStateRunning || plan.action != workflowRunActionStartRunnableTargets || !equalWorkflowRunTargets(plan.targets, want) {
 		t.Fatalf("plan = %#v, want Running + StartRunnableSteps(%#v)", plan, want)
 	}
 	if workflowRun.Status.Jobs["build"].Phase != v1alpha1.JobSucceeded {

--- a/internal/controller/workflowrun_controller_test.go
+++ b/internal/controller/workflowrun_controller_test.go
@@ -39,10 +39,6 @@ func stepRunTarget(jobName string, stepIndex int) workflowRunTarget {
 	return workflowRunTarget{step: &jobStepRunTarget{jobName: jobName, stepIndex: stepIndex}}
 }
 
-func cancelRunTarget(name string) workflowRunTarget {
-	return workflowRunTarget{run: &childRunTarget{name: name}}
-}
-
 func equalWorkflowRunTargets(got, want []workflowRunTarget) bool {
 	return reflect.DeepEqual(got, want)
 }
@@ -234,7 +230,7 @@ func TestCalculateWorkflowRunPlanSeparatesCurrentStateFromAction(t *testing.T) {
 		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): activeRun},
 		snapshot:    snapshotForWorkflowRun(cancelling),
 	})
-	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildCancellation || !equalWorkflowRunTargets(plan.targets, []workflowRunTarget{cancelRunTarget("build-run")}) {
+	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildCancellation || len(plan.targets) != 0 {
 		t.Fatalf("cancelling plan = %#v, want Cancelling + RequestChildRunCancellation(build-run)", plan)
 	}
 
@@ -246,7 +242,7 @@ func TestCalculateWorkflowRunPlanSeparatesCurrentStateFromAction(t *testing.T) {
 		childRuns:   map[string]*v1alpha1.Run{workflowStepKey("build", "compile"): activeRun},
 		snapshot:    snapshotForWorkflowRun(cancelling),
 	})
-	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildCancellation || !equalWorkflowRunTargets(plan.targets, []workflowRunTarget{cancelRunTarget("build-run")}) {
+	if plan.state != workflowRunStateCancelling || plan.action != workflowRunActionRequestChildCancellation || len(plan.targets) != 0 {
 		t.Fatalf("late child plan = %#v, want cancellation repair", plan)
 	}
 }

--- a/internal/workflowtemplate/call_graph.go
+++ b/internal/workflowtemplate/call_graph.go
@@ -1,0 +1,90 @@
+package workflowtemplate
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+// MaxCallDepth bounds a reusable Workflow root and its nested Workflow calls.
+const MaxCallDepth = 8
+
+// WorkflowLookup loads a namespace-local reusable Workflow by name.
+type WorkflowLookup func(context.Context, string) (*v1alpha1.Workflow, error)
+
+// ValidateCallGraph verifies that the reusable Workflows reachable from root
+// exist, do not form a call cycle, and do not exceed MaxCallDepth. It visits
+// referenced Workflow names in sorted order so callers receive stable errors.
+func ValidateCallGraph(ctx context.Context, root string, lookup WorkflowLookup) error {
+	if root == "" {
+		return fmt.Errorf("workflow name is required")
+	}
+	if lookup == nil {
+		return fmt.Errorf("workflow lookup is required")
+	}
+
+	const (
+		stateVisiting = iota + 1
+		stateVisited
+	)
+	states := map[string]int{}
+	stack := make([]string, 0, MaxCallDepth)
+
+	var visit func(string) error
+	visit = func(name string) error {
+		if states[name] == stateVisiting {
+			cycleStart := slices.Index(stack, name)
+			cycle := append(slices.Clone(stack[cycleStart:]), name)
+			return fmt.Errorf("workflow call cycle: %s", strings.Join(cycle, " -> "))
+		}
+		if states[name] == stateVisited {
+			return nil
+		}
+		if len(stack) >= MaxCallDepth {
+			path := append(slices.Clone(stack), name)
+			return fmt.Errorf("workflow call depth exceeds maximum %d: %s", MaxCallDepth, strings.Join(path, " -> "))
+		}
+
+		workflow, err := lookup(ctx, name)
+		if err != nil {
+			return fmt.Errorf("get workflow %q: %w", name, err)
+		}
+		if workflow == nil {
+			return fmt.Errorf("get workflow %q: empty result", name)
+		}
+
+		states[name] = stateVisiting
+		stack = append(stack, name)
+		for _, callee := range calledWorkflowNames(workflow.Spec.Jobs) {
+			if err := visit(callee); err != nil {
+				return err
+			}
+		}
+		stack = stack[:len(stack)-1]
+		states[name] = stateVisited
+		return nil
+	}
+
+	return visit(root)
+}
+
+func calledWorkflowNames(jobs map[string]v1alpha1.JobSpec) []string {
+	names := make([]string, 0, len(jobs))
+	seen := make(map[string]struct{}, len(jobs))
+	for _, job := range jobs {
+		if job.Uses == "" {
+			continue
+		}
+		if _, ok := seen[job.Uses]; ok {
+			continue
+		}
+		seen[job.Uses] = struct{}{}
+		names = append(names, job.Uses)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/workflowtemplate/call_graph_test.go
+++ b/internal/workflowtemplate/call_graph_test.go
@@ -1,0 +1,112 @@
+package workflowtemplate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+func TestValidateCallGraph(t *testing.T) {
+	tests := []struct {
+		name      string
+		workflows map[string]v1alpha1.Workflow
+		root      string
+		wantError string
+	}{
+		{
+			name: "acyclic nested calls",
+			root: "release",
+			workflows: map[string]v1alpha1.Workflow{
+				"release": workflowWithCalls("release", "build", "deploy"),
+				"build":   workflowWithCalls("build", "verify"),
+				"deploy":  workflowWithCalls("deploy"),
+				"verify":  workflowWithCalls("verify"),
+			},
+		},
+		{
+			name: "self cycle",
+			root: "release",
+			workflows: map[string]v1alpha1.Workflow{
+				"release": workflowWithCalls("release", "release"),
+			},
+			wantError: "workflow call cycle: release -> release",
+		},
+		{
+			name: "multi workflow cycle",
+			root: "release",
+			workflows: map[string]v1alpha1.Workflow{
+				"release": workflowWithCalls("release", "build"),
+				"build":   workflowWithCalls("build", "deploy"),
+				"deploy":  workflowWithCalls("deploy", "release"),
+			},
+			wantError: "workflow call cycle: release -> build -> deploy -> release",
+		},
+		{
+			name: "missing workflow",
+			root: "release",
+			workflows: map[string]v1alpha1.Workflow{
+				"release": workflowWithCalls("release", "missing"),
+			},
+			wantError: `get workflow "missing": not found`,
+		},
+		{
+			name:      "maximum nesting depth",
+			root:      "workflow-0",
+			workflows: nestedWorkflows(MaxCallDepth + 1),
+			wantError: "workflow call depth exceeds maximum 8: workflow-0 -> workflow-1 -> workflow-2 -> workflow-3 -> workflow-4 -> workflow-5 -> workflow-6 -> workflow-7 -> workflow-8",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCallGraph(context.Background(), tt.root, func(_ context.Context, name string) (*v1alpha1.Workflow, error) {
+				workflow, ok := tt.workflows[name]
+				if !ok {
+					return nil, errors.New("not found")
+				}
+				return workflow.DeepCopy(), nil
+			})
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("ValidateCallGraph() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("ValidateCallGraph() error = %v, want %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func workflowWithCalls(name string, calls ...string) v1alpha1.Workflow {
+	jobs := map[string]v1alpha1.JobSpec{
+		"inline": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "run", Run: "echo ready"}}},
+	}
+	for i, call := range calls {
+		jobs[fmt.Sprintf("call-%d", i)] = v1alpha1.JobSpec{Uses: call}
+	}
+	return v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Spec:       v1alpha1.WorkflowSpec{Jobs: jobs},
+	}
+}
+
+func nestedWorkflows(count int) map[string]v1alpha1.Workflow {
+	workflows := make(map[string]v1alpha1.Workflow, count)
+	for i := range count {
+		name := fmt.Sprintf("workflow-%d", i)
+		if i == count-1 {
+			workflows[name] = workflowWithCalls(name)
+			continue
+		}
+		workflows[name] = workflowWithCalls(name, fmt.Sprintf("workflow-%d", i+1))
+	}
+	return workflows
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -627,6 +627,53 @@ func TestWorkflowTriggerMaterializesAndExecutesTemplate(t *testing.T) {
 	}
 }
 
+func TestWorkflowRunExecutesReusableWorkflowAndProjectsOutputs(t *testing.T) {
+	ensureRuntime(t, "bash", bashRuntimeImage(), 9091)
+
+	nameSuffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	workflow := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "e2e-deploy-" + nameSuffix, Namespace: testNamespace},
+		Spec: v1alpha1.WorkflowSpec{
+			Outputs: map[string]v1alpha1.WorkflowOutputSpec{
+				"endpoint": {Value: "${{ jobs.apply.outputs.endpoint }}"},
+			},
+			Jobs: map[string]v1alpha1.JobSpec{
+				"apply": {
+					RunsOn: "bash",
+					Outputs: map[string]string{
+						"endpoint": "${{ steps.deploy.outputs.endpoint }}",
+					},
+					Steps: []v1alpha1.StepSpec{{
+						Name: "deploy",
+						Run:  `printf 'endpoint=https://e2e.example.com\n' > "$KRUNTIME_OUTPUTS"`,
+					}},
+				},
+			},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), workflow); err != nil {
+		t.Fatalf("create reusable workflow: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(context.Background(), workflow) })
+
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "e2e-reuse-" + nameSuffix, Namespace: testNamespace},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"deploy": {Uses: workflow.Name},
+		}},
+	}
+	if err := k8sClient.Create(context.Background(), workflowRun); err != nil {
+		t.Fatalf("create workflowrun: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(context.Background(), workflowRun) })
+
+	waitForWorkflowRunPhase(t, workflowRun, 45*time.Second, v1alpha1.WorkflowSucceeded)
+	deploy := workflowRun.Status.Jobs["deploy"]
+	if deploy.WorkflowRunName == "" || deploy.Phase != v1alpha1.JobSucceeded || deploy.Outputs["endpoint"] != "https://e2e.example.com" {
+		t.Fatalf("deploy job status = %#v, want succeeded reusable call with projected endpoint", deploy)
+	}
+}
+
 func TestFilesystemArtifacts(t *testing.T) {
 	runtimeName := "bash-filesystem-artifacts"
 	claimName := "e2e-filesystem-artifacts"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -674,6 +674,119 @@ func TestWorkflowRunExecutesReusableWorkflowAndProjectsOutputs(t *testing.T) {
 	}
 }
 
+func TestWorkflowRunExecutesNestedReusableWorkflows(t *testing.T) {
+	ensureRuntime(t, "bash", bashRuntimeImage(), 9091)
+
+	nameSuffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	leaf := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "e2e-leaf-" + nameSuffix, Namespace: testNamespace},
+		Spec: v1alpha1.WorkflowSpec{
+			Outputs: map[string]v1alpha1.WorkflowOutputSpec{
+				"result": {Value: "${{ jobs.test.outputs.result }}"},
+			},
+			Jobs: map[string]v1alpha1.JobSpec{
+				"test": {
+					RunsOn: "bash",
+					Outputs: map[string]string{
+						"result": "${{ steps.emit.outputs.result }}",
+					},
+					Steps: []v1alpha1.StepSpec{{
+						Name: "emit",
+						Run:  `printf 'result=nested-ok\n' > "$KRUNTIME_OUTPUTS"`,
+					}},
+				},
+			},
+		},
+	}
+	middle := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "e2e-middle-" + nameSuffix, Namespace: testNamespace},
+		Spec: v1alpha1.WorkflowSpec{
+			Outputs: map[string]v1alpha1.WorkflowOutputSpec{
+				"result": {Value: "${{ jobs.call-leaf.outputs.result }}"},
+			},
+			Jobs: map[string]v1alpha1.JobSpec{
+				"call-leaf": {Uses: leaf.Name},
+			},
+		},
+	}
+	for _, workflow := range []*v1alpha1.Workflow{leaf, middle} {
+		if err := k8sClient.Create(context.Background(), workflow); err != nil {
+			t.Fatalf("create reusable workflow %s: %v", workflow.Name, err)
+		}
+		t.Cleanup(func() { _ = k8sClient.Delete(context.Background(), workflow) })
+	}
+
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "e2e-nested-" + nameSuffix, Namespace: testNamespace},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"call-middle": {Uses: middle.Name},
+		}},
+	}
+	if err := k8sClient.Create(context.Background(), workflowRun); err != nil {
+		t.Fatalf("create workflowrun: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(context.Background(), workflowRun) })
+
+	waitForWorkflowRunPhase(t, workflowRun, 45*time.Second, v1alpha1.WorkflowSucceeded)
+	call := workflowRun.Status.Jobs["call-middle"]
+	if call.WorkflowRunName == "" || call.Phase != v1alpha1.JobSucceeded || call.Outputs["result"] != "nested-ok" {
+		t.Fatalf("call-middle job status = %#v, want succeeded nested reusable call with projected result", call)
+	}
+}
+
+func TestWorkflowRunCancellationPropagatesToReusableWorkflow(t *testing.T) {
+	ensureRuntime(t, "bash", bashRuntimeImage(), 9091)
+
+	nameSuffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	workflow := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "e2e-cancel-reuse-" + nameSuffix, Namespace: testNamespace},
+		Spec: v1alpha1.WorkflowSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"apply": {
+				RunsOn: "bash",
+				Steps:  []v1alpha1.StepSpec{{Name: "wait", Run: "sleep 300"}},
+			},
+		}},
+	}
+	if err := k8sClient.Create(context.Background(), workflow); err != nil {
+		t.Fatalf("create reusable workflow: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(context.Background(), workflow) })
+
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "e2e-cancel-reuse-run-" + nameSuffix, Namespace: testNamespace},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"deploy": {Uses: workflow.Name},
+		}},
+	}
+	if err := k8sClient.Create(context.Background(), workflowRun); err != nil {
+		t.Fatalf("create workflowrun: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(context.Background(), workflowRun) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	for {
+		time.Sleep(200 * time.Millisecond)
+		if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), workflowRun); err != nil {
+			t.Fatalf("get workflowrun: %v", err)
+		}
+		if workflowRun.Status.Jobs["deploy"].WorkflowRunName != "" {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for reusable call to start: %#v", workflowRun.Status)
+		default:
+		}
+	}
+	workflowRun.Spec.CancelRequested = true
+	if err := k8sClient.Update(context.Background(), workflowRun); err != nil {
+		t.Fatalf("request workflowrun cancellation: %v", err)
+	}
+
+	waitForWorkflowRunPhase(t, workflowRun, 30*time.Second, v1alpha1.WorkflowCancelled)
+}
+
 func TestFilesystemArtifacts(t *testing.T) {
 	runtimeName := "bash-filesystem-artifacts"
 	claimName := "e2e-filesystem-artifacts"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -787,6 +787,174 @@ func TestWorkflowRunCancellationPropagatesToReusableWorkflow(t *testing.T) {
 	waitForWorkflowRunPhase(t, workflowRun, 30*time.Second, v1alpha1.WorkflowCancelled)
 }
 
+func TestWorkflowRunRejectsReusableWorkflowCycle(t *testing.T) {
+	nameSuffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	workflowA := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "e2e-cycle-a-" + nameSuffix, Namespace: testNamespace},
+		Spec: v1alpha1.WorkflowSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"call-b": {Uses: "e2e-cycle-b-" + nameSuffix},
+		}},
+	}
+	workflowB := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "e2e-cycle-b-" + nameSuffix, Namespace: testNamespace},
+		Spec: v1alpha1.WorkflowSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"call-a": {Uses: workflowA.Name},
+		}},
+	}
+	for _, workflow := range []*v1alpha1.Workflow{workflowA, workflowB} {
+		if err := k8sClient.Create(context.Background(), workflow); err != nil {
+			t.Fatalf("create reusable workflow %s: %v", workflow.Name, err)
+		}
+		t.Cleanup(func() { _ = k8sClient.Delete(context.Background(), workflow) })
+	}
+
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "e2e-cycle-run-" + nameSuffix, Namespace: testNamespace},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"call-a": {Uses: workflowA.Name},
+		}},
+	}
+	if err := k8sClient.Create(context.Background(), workflowRun); err != nil {
+		t.Fatalf("create workflowrun: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(context.Background(), workflowRun) })
+
+	waitForWorkflowRunPhase(t, workflowRun, 20*time.Second, v1alpha1.WorkflowFailed)
+	status := workflowRun.Status.Jobs["call-a"]
+	if status.Phase != v1alpha1.JobFailed || status.WorkflowRunName != "" {
+		t.Fatalf("call-a status = %#v, want failed call without child workflowrun", status)
+	}
+	if !strings.Contains(workflowRun.Status.Message, "workflow call cycle:") {
+		t.Fatalf("message = %q, want reusable workflow cycle", workflowRun.Status.Message)
+	}
+}
+
+func TestWorkflowRunFreezesReusableTemplateAfterChildCreation(t *testing.T) {
+	ensureRuntime(t, "bash", bashRuntimeImage(), 9091)
+
+	nameSuffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	workflow := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "e2e-freeze-" + nameSuffix, Namespace: testNamespace},
+		Spec: v1alpha1.WorkflowSpec{
+			Outputs: map[string]v1alpha1.WorkflowOutputSpec{
+				"result": {Value: "${{ jobs.apply.outputs.result }}"},
+			},
+			Jobs: map[string]v1alpha1.JobSpec{
+				"apply": {
+					RunsOn: "bash",
+					Outputs: map[string]string{
+						"result": "${{ steps.emit.outputs.result }}",
+					},
+					Steps: []v1alpha1.StepSpec{{
+						Name: "emit",
+						Run:  `sleep 2; printf 'result=original\n' > "$KRUNTIME_OUTPUTS"`,
+					}},
+				},
+			},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), workflow); err != nil {
+		t.Fatalf("create reusable workflow: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(context.Background(), workflow) })
+
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "e2e-freeze-run-" + nameSuffix, Namespace: testNamespace},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"call": {Uses: workflow.Name},
+		}},
+	}
+	if err := k8sClient.Create(context.Background(), workflowRun); err != nil {
+		t.Fatalf("create workflowrun: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(context.Background(), workflowRun) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	for {
+		time.Sleep(200 * time.Millisecond)
+		if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(workflowRun), workflowRun); err != nil {
+			t.Fatalf("get workflowrun: %v", err)
+		}
+		if workflowRun.Status.Jobs["call"].WorkflowRunName != "" {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for reusable child creation: %#v", workflowRun.Status)
+		default:
+		}
+	}
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(workflow), workflow); err != nil {
+		t.Fatalf("get reusable workflow: %v", err)
+	}
+	workflow.Spec.Outputs["result"] = v1alpha1.WorkflowOutputSpec{Value: "changed"}
+	if err := k8sClient.Update(context.Background(), workflow); err != nil {
+		t.Fatalf("update reusable workflow after child creation: %v", err)
+	}
+
+	waitForWorkflowRunPhase(t, workflowRun, 30*time.Second, v1alpha1.WorkflowSucceeded)
+	if got := workflowRun.Status.Jobs["call"].Outputs["result"]; got != "original" {
+		t.Fatalf("call output = %q, want original frozen output contract", got)
+	}
+}
+
+func TestWorkflowRunBindsReusableTemplateWhenCallBecomesReady(t *testing.T) {
+	ensureRuntime(t, "bash", bashRuntimeImage(), 9091)
+
+	nameSuffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	workflow := &v1alpha1.Workflow{
+		ObjectMeta: metav1.ObjectMeta{Name: "e2e-late-bind-" + nameSuffix, Namespace: testNamespace},
+		Spec: v1alpha1.WorkflowSpec{
+			Outputs: map[string]v1alpha1.WorkflowOutputSpec{
+				"result": {Value: "${{ jobs.apply.outputs.result }}"},
+			},
+			Jobs: map[string]v1alpha1.JobSpec{
+				"apply": reusableOutputJob(`printf 'result=original\n' > "$KRUNTIME_OUTPUTS"`),
+			},
+		},
+	}
+	if err := k8sClient.Create(context.Background(), workflow); err != nil {
+		t.Fatalf("create reusable workflow: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(context.Background(), workflow) })
+
+	workflowRun := &v1alpha1.WorkflowRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "e2e-late-bind-run-" + nameSuffix, Namespace: testNamespace},
+		Spec: v1alpha1.WorkflowRunSpec{Jobs: map[string]v1alpha1.JobSpec{
+			"gate": {RunsOn: "bash", Steps: []v1alpha1.StepSpec{{Name: "wait", Run: "sleep 2"}}},
+			"call": {Needs: []string{"gate"}, Uses: workflow.Name},
+		}},
+	}
+	if err := k8sClient.Create(context.Background(), workflowRun); err != nil {
+		t.Fatalf("create workflowrun: %v", err)
+	}
+	t.Cleanup(func() { _ = k8sClient.Delete(context.Background(), workflowRun) })
+
+	if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(workflow), workflow); err != nil {
+		t.Fatalf("get reusable workflow: %v", err)
+	}
+	workflow.Spec.Jobs["apply"] = reusableOutputJob(`printf 'result=updated\n' > "$KRUNTIME_OUTPUTS"`)
+	if err := k8sClient.Update(context.Background(), workflow); err != nil {
+		t.Fatalf("update reusable workflow before call becomes ready: %v", err)
+	}
+
+	waitForWorkflowRunPhase(t, workflowRun, 30*time.Second, v1alpha1.WorkflowSucceeded)
+	if got := workflowRun.Status.Jobs["call"].Outputs["result"]; got != "updated" {
+		t.Fatalf("call output = %q, want updated late-bound template output", got)
+	}
+}
+
+func reusableOutputJob(run string) v1alpha1.JobSpec {
+	return v1alpha1.JobSpec{
+		RunsOn: "bash",
+		Outputs: map[string]string{
+			"result": "${{ steps.emit.outputs.result }}",
+		},
+		Steps: []v1alpha1.StepSpec{{Name: "emit", Run: run}},
+	}
+}
+
 func TestFilesystemArtifacts(t *testing.T) {
 	runtimeName := "bash-filesystem-artifacts"
 	claimName := "e2e-filesystem-artifacts"


### PR DESCRIPTION
## Summary
- persist a reusable Workflow's declared output contract with the materialized child WorkflowRun snapshot
- clone the contract before persistence so later template edits cannot alter the execution definition
- cover snapshot round-trip and template mutation behavior

This is the first implementation slice of the reviewed job-level workflow reuse design. It does not enable `job.uses` yet; child materialization and parent output projection follow in separate PRs.