### PR TITLE
docs(scheduler): propose Run resource accounting

### DIFF
--- a/docs/design/_index.md
+++ b/docs/design/_index.md
@@ -13,6 +13,7 @@ implemented.
 - [Workflow Data Sharing](workflow-data-sharing/)
 - [Run Workspace References and Affinity](run-workspace-affinity/)
 - [Scheduler Framework and Batch Planning](scheduler-framework/)
+- [Run Resource Accounting](run-resource-accounting/)
 - [Workflow Reuse](workflow-reuse/)
 - [Job-Level Reusable Workflow Execution](workflow-job-reuse/)
 - [Dashboard](dashboard/)

--- a/docs/design/_index.zh.md
+++ b/docs/design/_index.zh.md
@@ -11,6 +11,7 @@
 - [Workflow Data Sharing](workflow-data-sharing/)
 - [Run Workspace 引用与 Affinity](run-workspace-affinity/)
 - [Scheduler Framework 与批量规划](scheduler-framework/)
+- [Run 资源记账](run-resource-accounting/)
 - [Workflow Reuse](workflow-reuse/)
 - [Job-Level Reusable Workflow Execution](workflow-job-reuse/)
 - [Dashboard](dashboard/)

--- a/docs/design/run-resource-accounting.md
+++ b/docs/design/run-resource-accounting.md
@@ -1,0 +1,94 @@
+---
+title: "Run Resource Accounting"
+---
+
+# Run Resource Accounting
+
+Status: **Proposal; API review required before implementation**
+
+Runtime capacity is not limited to concurrent Run count. `Runtime.spec.capacity.resources`
+already declares named per-Runtime-Pod capacities and the Runtime controller
+projects them to Pod annotations. The scheduler currently accounts only for
+the built-in `runs` resource. This document defines the missing Run-side
+request model needed to enforce every declared capacity consistently.
+
+## API
+
+Add an immutable `Run.spec.resources` field of type `corev1.ResourceList`.
+It declares logical Runtime resources consumed for the Run's full active
+lifetime, from `Scheduled` through terminal completion or function release.
+
+```yaml
+apiVersion: kruntimes.io/v1alpha1
+kind: Run
+spec:
+  runtime: python
+  resources:
+    runs: "1"
+    example.com/gpu: "1"
+  mode:
+    task:
+      args: ["python", "train.py"]
+```
+
+`runs` is the built-in logical resource. When omitted, it defaults to a
+request of `1` so existing Runs retain their current capacity behavior. Other
+resources are optional and must be explicitly requested. These are scheduler
+resources, not container CPU or memory requests; users continue to configure
+the Runtime Pod template's Kubernetes container resources independently.
+
+Resource quantities must be non-negative integers. A request of zero is
+ignored. The initial API does not define limits, overcommit, sharing ratios,
+or runtime-specific resource classes.
+
+## Capacity Contract
+
+`Runtime.spec.capacity.resources` remains the declaration of per-Pod logical
+capacity. The Runtime controller copies each declared value to the matching
+Runtime Pod annotation:
+
+```yaml
+kruntimes.io/capacity.runs: "4"
+kruntimes.io/capacity.example.com/gpu: "1"
+```
+
+For each candidate Pod, the scheduler reads the complete annotation set and
+filters the Pod when any requested resource would exceed capacity:
+
+```text
+usage[pod][resource] + request[run][resource] <= capacity[pod][resource]
+```
+
+Active assigned Runs and scheduler-local assumed assignments both contribute
+their full resource request to `usage`. Reserve/Assume and Bind therefore use
+the same accounting model. The least-loaded strategy may continue to score on
+`runs` initially; adding multi-resource scoring is a separate policy design.
+
+If a Run requests a resource that a candidate Pod does not advertise, that Pod
+is infeasible. If no ready Pod satisfies all requests, the Run remains
+`Pending` with a bounded insufficient-capacity reason. It is reactivated when
+Runtime Pod capacity changes or active/assumed usage is released. A malformed
+request is an invalid Run configuration and fails validation before scheduling.
+
+## Compatibility And Boundaries
+
+- Existing Runs omit `resources`; the scheduler treats them as `{runs: 1}`.
+- Existing Runtime Pods without a `runs` annotation retain the current default
+  `runs` capacity. No implicit capacity exists for any other resource.
+- Scheduler accounting is namespace-local because Run assignments are
+  namespace-local. Runtime Pods are also selected in the Run namespace.
+- runtimed enforces execution and does not make placement decisions. It need
+  not understand logical resource names in this phase.
+- This does not change Kubernetes scheduling of Runtime Pods, the Runtime Pod
+  template's container requests/limits, or function invocation concurrency.
+
+## Implementation Sequence
+
+1. Review this API and its Pending/validation semantics.
+2. Add `Run.spec.resources`, immutability validation, generated CRDs, and
+   user-facing API documentation.
+3. Add Runtime Pod helpers that parse complete capacity annotations.
+4. Accumulate complete active and assumed Run resource usage in the scheduler,
+   then filter candidates using the capacity contract above.
+5. Add unit, integration, and E2E coverage for defaults, multi-resource
+   placement, release/reactivation, and missing capacity.

--- a/docs/design/run-resource-accounting.md
+++ b/docs/design/run-resource-accounting.md
@@ -14,9 +14,10 @@ request model needed to enforce every declared capacity consistently.
 
 ## API
 
-Add an immutable `Run.spec.resources` field of type `corev1.ResourceList`.
-It declares logical Runtime resources consumed for the Run's full active
-lifetime, from `Scheduled` through terminal completion or function release.
+Add an immutable `Run.spec.resources.requests` field of type
+`corev1.ResourceList`. It declares logical Runtime resources consumed for the
+Run's full active lifetime, from `Scheduled` through terminal completion or
+function release.
 
 ```yaml
 apiVersion: kruntimes.io/v1alpha1
@@ -24,22 +25,28 @@ kind: Run
 spec:
   runtime: python
   resources:
-    runs: "1"
-    example.com/gpu: "1"
+    requests:
+      runs: "1"
+      example.com/gpu: "1"
   mode:
     task:
       args: ["python", "train.py"]
 ```
 
-`runs` is the built-in logical resource. When omitted, it defaults to a
-request of `1` so existing Runs retain their current capacity behavior. Other
-resources are optional and must be explicitly requested. These are scheduler
-resources, not container CPU or memory requests; users continue to configure
-the Runtime Pod template's Kubernetes container resources independently.
+`runs` is the built-in logical resource. When `resources` or
+`resources.requests.runs` is omitted, it defaults to a request of `1` so
+existing Runs retain their current capacity behavior. Other resources are
+optional and must be explicitly requested. These are logical Runtime resources,
+not container CPU or memory requests; users continue to configure the Runtime
+Pod template's Kubernetes container resources independently.
 
 Resource quantities must be non-negative integers. A request of zero is
-ignored. The initial API does not define limits, overcommit, sharing ratios,
-or runtime-specific resource classes.
+ignored. The initial API intentionally does not define `limits`: logical
+capacity is reserved at the requested amount by both scheduler and runtimed.
+Adding limits would require a separately reviewed model for overcommit,
+runtime-side enforcement, sharing ratios, and runtime-specific resource
+classes. A future `limits` field can be added to the same resource object only
+with those semantics defined.
 
 ## Capacity Contract
 
@@ -60,15 +67,32 @@ usage[pod][resource] + request[run][resource] <= capacity[pod][resource]
 ```
 
 Active assigned Runs and scheduler-local assumed assignments both contribute
-their full resource request to `usage`. Reserve/Assume and Bind therefore use
-the same accounting model. The least-loaded strategy may continue to score on
-`runs` initially; adding multi-resource scoring is a separate policy design.
+their full resource request to scheduler `usage`. Reserve/Assume and Bind
+therefore use the same accounting model. The least-loaded strategy may continue
+to score on `runs` initially; adding multi-resource scoring is a separate
+policy design.
 
 If a Run requests a resource that a candidate Pod does not advertise, that Pod
 is infeasible. If no ready Pod satisfies all requests, the Run remains
 `Pending` with a bounded insufficient-capacity reason. It is reactivated when
 Runtime Pod capacity changes or active/assumed usage is released. A malformed
 request is an invalid Run configuration and fails validation before scheduling.
+
+## Runtime Admission
+
+Scheduler accounting is not an execution authorization. runtimed must maintain
+a local, watch-backed resource usage cache for the Runtime Pod it owns. Before
+claiming a `Scheduled` Run, it atomically checks the Run's complete request
+against that cache and reserves the request only when every resource fits the
+Pod's annotated capacity.
+
+When a request does not fit, runtimed leaves the Run `Scheduled`; it does not
+start the Runtime Server call, mark the Run failed, or release the assignment.
+It rechecks the queued Run when a locally active Run reaches a terminal state
+or capacity changes. This makes runtimed the execution-time guard against a
+stale scheduler cache, concurrent transitions, or an assignment created by an
+older scheduler version. A Run whose request is larger than every eligible Pod
+should normally remain `Pending` because the scheduler never assigns it.
 
 ## Compatibility And Boundaries
 
@@ -77,8 +101,8 @@ request is an invalid Run configuration and fails validation before scheduling.
   `runs` capacity. No implicit capacity exists for any other resource.
 - Scheduler accounting is namespace-local because Run assignments are
   namespace-local. Runtime Pods are also selected in the Run namespace.
-- runtimed enforces execution and does not make placement decisions. It need
-  not understand logical resource names in this phase.
+- runtimed enforces local execution admission from a Pod-local resource cache;
+  it does not choose among Pods or make placement decisions.
 - This does not change Kubernetes scheduling of Runtime Pods, the Runtime Pod
   template's container requests/limits, or function invocation concurrency.
 
@@ -90,5 +114,9 @@ request is an invalid Run configuration and fails validation before scheduling.
 3. Add Runtime Pod helpers that parse complete capacity annotations.
 4. Accumulate complete active and assumed Run resource usage in the scheduler,
    then filter candidates using the capacity contract above.
-5. Add unit, integration, and E2E coverage for defaults, multi-resource
-   placement, release/reactivation, and missing capacity.
+5. Add runtimed's atomic local admission/reservation cache. A capacity-blocked
+   assigned Run remains `Scheduled` until locally reserved resources are
+   released.
+6. Add unit, integration, and E2E coverage for defaults, multi-resource
+   placement, release/reactivation, missing capacity, and runtimed admission
+   after stale or competing assignments.

--- a/docs/design/run-resource-accounting.zh.md
+++ b/docs/design/run-resource-accounting.zh.md
@@ -1,0 +1,78 @@
+---
+title: "Run 资源记账"
+---
+
+# Run 资源记账
+
+状态：**Proposal；实现前需要 API review**
+
+Runtime capacity 不应只限制并发 Run 数量。`Runtime.spec.capacity.resources`
+已经声明每个 Runtime Pod 的命名 capacity，Runtime controller 会将其投影为 Pod annotation；但 scheduler
+目前只对内建 `runs` resource 记账。本文定义完整执行所有 capacity 所需的 Run-side request model。
+
+## API
+
+增加 immutable 的 `Run.spec.resources`，类型为 `corev1.ResourceList`。它表示 Run 在整个 active lifetime
+内消耗的 logical Runtime resources：从 `Scheduled` 到 terminal completion 或 function release。
+
+```yaml
+apiVersion: kruntimes.io/v1alpha1
+kind: Run
+spec:
+  runtime: python
+  resources:
+    runs: "1"
+    example.com/gpu: "1"
+  mode:
+    task:
+      args: ["python", "train.py"]
+```
+
+`runs` 是内建 logical resource。省略时默认 request 为 `1`，因此现有 Run 保持现在的 capacity 行为。其他
+resource 可选且必须显式 request。这些是 scheduler resources，并非 container CPU/memory requests；用户仍然
+通过 Runtime Pod template 独立配置 Kubernetes container resources。
+
+resource quantity 必须是非负整数。零 request 被忽略。初始 API 不定义 limits、overcommit、sharing ratio 或
+runtime-specific resource classes。
+
+## Capacity Contract
+
+`Runtime.spec.capacity.resources` 仍然声明每个 Pod 的 logical capacity。Runtime controller 把每个值复制到
+对应 Runtime Pod annotation：
+
+```yaml
+kruntimes.io/capacity.runs: "4"
+kruntimes.io/capacity.example.com/gpu: "1"
+```
+
+对每个 candidate Pod，scheduler 读取完整 annotation 集；只要任一 request 超过 capacity，就过滤该 Pod：
+
+```text
+usage[pod][resource] + request[run][resource] <= capacity[pod][resource]
+```
+
+active assigned Runs 与 scheduler-local assumed assignments 都以完整 resource request 计入 `usage`。因此
+Reserve/Assume 与 Bind 共享同一记账模型。least-loaded strategy 初期可以继续只按 `runs` score；multi-resource
+scoring 属于单独的 policy design。
+
+如果 Run request 的 resource 没有被 candidate Pod 声明，该 Pod 不可行。没有 ready Pod 满足全部 request 时，Run
+保持 `Pending`，并记录有界 insufficient-capacity reason；Runtime Pod capacity 变化或 active/assumed usage
+释放时会重新激活。malformed request 属于 invalid Run configuration，应在调度前 validation 失败。
+
+## 兼容性与边界
+
+- 现有 Run 省略 `resources`；scheduler 将其视为 `{runs: 1}`。
+- 现有 Runtime Pod 没有 `runs` annotation 时保留当前默认 `runs` capacity；其他任何 resource 都没有隐式 capacity。
+- scheduler 记账是 namespace-local 的：Run assignment 与 Runtime Pod selection 均在 Run namespace 内。
+- runtimed 负责 execution，不做 placement decision；此阶段无需理解 logical resource name。
+- 本文不改变 Kubernetes 对 Runtime Pods 的调度、Runtime Pod template 的 container requests/limits，或 function
+  invocation concurrency。
+
+## 实现顺序
+
+1. Review 本 API 及其 Pending/validation semantics。
+2. 增加 `Run.spec.resources`、immutability validation、generated CRDs 与 user-facing API docs。
+3. 增加解析完整 capacity annotations 的 Runtime Pod helpers。
+4. scheduler 累积完整 active/assumed Run resource usage，并按照上述 contract filter candidates。
+5. 增加 defaults、multi-resource placement、release/reactivation 和 missing capacity 的 unit、integration 与 E2E
+   coverage。

--- a/docs/design/run-resource-accounting.zh.md
+++ b/docs/design/run-resource-accounting.zh.md
@@ -12,8 +12,9 @@ Runtime capacity 不应只限制并发 Run 数量。`Runtime.spec.capacity.resou
 
 ## API
 
-增加 immutable 的 `Run.spec.resources`，类型为 `corev1.ResourceList`。它表示 Run 在整个 active lifetime
-内消耗的 logical Runtime resources：从 `Scheduled` 到 terminal completion 或 function release。
+增加 immutable 的 `Run.spec.resources.requests`，类型为 `corev1.ResourceList`。它表示 Run 在整个
+active lifetime 内消耗的 logical Runtime resources：从 `Scheduled` 到 terminal completion 或 function
+release。
 
 ```yaml
 apiVersion: kruntimes.io/v1alpha1
@@ -21,19 +22,23 @@ kind: Run
 spec:
   runtime: python
   resources:
-    runs: "1"
-    example.com/gpu: "1"
+    requests:
+      runs: "1"
+      example.com/gpu: "1"
   mode:
     task:
       args: ["python", "train.py"]
 ```
 
-`runs` 是内建 logical resource。省略时默认 request 为 `1`，因此现有 Run 保持现在的 capacity 行为。其他
-resource 可选且必须显式 request。这些是 scheduler resources，并非 container CPU/memory requests；用户仍然
-通过 Runtime Pod template 独立配置 Kubernetes container resources。
+`runs` 是内建 logical resource。省略 `resources` 或 `resources.requests.runs` 时默认 request 为 `1`，因此
+现有 Run 保持现在的 capacity 行为。其他 resource 可选且必须显式 request。这些是 logical Runtime resources，
+并非 container CPU/memory requests；用户仍然通过 Runtime Pod template 独立配置 Kubernetes container
+resources。
 
-resource quantity 必须是非负整数。零 request 被忽略。初始 API 不定义 limits、overcommit、sharing ratio 或
-runtime-specific resource classes。
+resource quantity 必须是非负整数。零 request 被忽略。初始 API 有意不定义 `limits`：scheduler 和 runtimed
+都会按 request amount 保留 logical capacity。加入 limits 需要先单独 review overcommit、runtime-side
+enforcement、sharing ratio 和 runtime-specific resource classes 的模型。只有这些语义确定后，才可以在同一个
+resource object 中加入未来的 `limits` field。
 
 ## Capacity Contract
 
@@ -51,20 +56,32 @@ kruntimes.io/capacity.example.com/gpu: "1"
 usage[pod][resource] + request[run][resource] <= capacity[pod][resource]
 ```
 
-active assigned Runs 与 scheduler-local assumed assignments 都以完整 resource request 计入 `usage`。因此
-Reserve/Assume 与 Bind 共享同一记账模型。least-loaded strategy 初期可以继续只按 `runs` score；multi-resource
-scoring 属于单独的 policy design。
+active assigned Runs 与 scheduler-local assumed assignments 都以完整 resource request 计入 scheduler `usage`。
+因此 Reserve/Assume 与 Bind 共享同一记账模型。least-loaded strategy 初期可以继续只按 `runs` score；
+multi-resource scoring 属于单独的 policy design。
 
 如果 Run request 的 resource 没有被 candidate Pod 声明，该 Pod 不可行。没有 ready Pod 满足全部 request 时，Run
 保持 `Pending`，并记录有界 insufficient-capacity reason；Runtime Pod capacity 变化或 active/assumed usage
 释放时会重新激活。malformed request 属于 invalid Run configuration，应在调度前 validation 失败。
+
+## Runtime Admission
+
+scheduler 记账不是 execution authorization。runtimed 必须为它所在的 Runtime Pod 维护 watch-backed local
+resource usage cache。它在 claim `Scheduled` Run 前，原子地检查 Run 的完整 request 是否适合该 Pod 的 annotation
+capacity；只有所有 resource 都适合时才保留 request 并执行 claim。
+
+request 不适合时，runtimed 保持 Run 为 `Scheduled`；它不开始 Runtime Server call、不把 Run 标记为 failed、也不
+释放 assignment。local active Run 变为 terminal 或 capacity 变化时，它会重新检查 queued Run。这使 runtimed 能够
+在 scheduler cache stale、并发 transition 或旧 scheduler version 创建 assignment 时作为 execution-time guard。
+如果某个 Run request 大于所有 eligible Pod，它通常应保持 `Pending`，因为 scheduler 不会分配它。
 
 ## 兼容性与边界
 
 - 现有 Run 省略 `resources`；scheduler 将其视为 `{runs: 1}`。
 - 现有 Runtime Pod 没有 `runs` annotation 时保留当前默认 `runs` capacity；其他任何 resource 都没有隐式 capacity。
 - scheduler 记账是 namespace-local 的：Run assignment 与 Runtime Pod selection 均在 Run namespace 内。
-- runtimed 负责 execution，不做 placement decision；此阶段无需理解 logical resource name。
+- runtimed 从 Pod-local resource cache 强制执行 local execution admission；它不在 Pods 之间选择，也不做
+  placement decision。
 - 本文不改变 Kubernetes 对 Runtime Pods 的调度、Runtime Pod template 的 container requests/limits，或 function
   invocation concurrency。
 
@@ -74,5 +91,7 @@ scoring 属于单独的 policy design。
 2. 增加 `Run.spec.resources`、immutability validation、generated CRDs 与 user-facing API docs。
 3. 增加解析完整 capacity annotations 的 Runtime Pod helpers。
 4. scheduler 累积完整 active/assumed Run resource usage，并按照上述 contract filter candidates。
-5. 增加 defaults、multi-resource placement、release/reactivation 和 missing capacity 的 unit、integration 与 E2E
-   coverage。
+5. 增加 runtimed 的 atomic local admission/reservation cache。capacity-blocked 的 assigned Run 保持
+   `Scheduled`，直到 local reserved resources 被释放。
+6. 增加 defaults、multi-resource placement、release/reactivation、missing capacity，以及 stale 或 competing
+   assignments 后 runtimed admission 的 unit、integration 与 E2E coverage。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -84,8 +84,11 @@ wiring from accumulating avoidable conflicts.
   [Scheduler Framework](design/scheduler-framework.md) architecture before
   changing scheduler behavior.
   Initial implementation TODO:
-  - [ ] review Run queue ownership, snapshot, PreFilter, Filter, Score,
+    - [ ] review Run queue ownership, snapshot, PreFilter, Filter, Score,
     Reserve/Assume, Bind, status, and retry semantics;
+  - [ ] review the [Run resource accounting](design/run-resource-accounting.md)
+    API before extending scheduler capacity checks beyond the built-in `runs`
+    resource;
   - [ ] refactor scheduler internals behind queue/planner interfaces while
     preserving current observable behavior and metrics;
   - [ ] add deterministic selection, assumed-capacity, bind-conflict,

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -78,6 +78,8 @@ controller wiring 累积不必要的冲突。
   初始实现 TODO：
   - [ ] review Run queue ownership、snapshot、PreFilter、Filter、Score、Reserve/Assume、Bind、status 和
     retry semantics；
+  - [ ] 在将 scheduler capacity check 扩展到内建 `runs` resource 以外前，review
+    [Run resource accounting](design/run-resource-accounting.md) API；
   - [ ] 在 queue/planner interfaces 后重构 scheduler internals，同时保留当前 observable behavior 和
     metrics；
   - [ ] 增加 deterministic selection、assumed-capacity、bind-conflict 和 restart-recovery coverage；


### PR DESCRIPTION
## Summary
- define the proposed immutable `Run.spec.resources` request API
- define full Runtime Pod capacity filtering, including active and assumed usage
- define compatibility, validation, and Pending semantics for missing capacity
- add the review-gated implementation sequence to the roadmap

This is an API and scheduling-architecture proposal only. `#312` continues to preserve current `runs`-only behavior until this design is approved.