### PR TITLE
feat(bash-runtime): add FunctionRuntime adapter

### DIFF
--- a/docs/design/function-runtime-contract.md
+++ b/docs/design/function-runtime-contract.md
@@ -38,7 +38,7 @@ failure enters retry or reassignment. Retrying an uncertain Pod-local
 does not change Run status.
 
 `registration_attempt` is not an invocation counter. `invocation_id` is
-separate caller-generated correlation data for one function call.
+optional correlation data for one function call.
 
 `RegisterFunction` uses Run UID plus `registration_attempt` to establish a
 new local registration generation. It returns an opaque `registration_id`.
@@ -235,7 +235,9 @@ retry policy for an incompatible Runtime.
 reference. v0.x
 allows one in-flight invocation per function Run and does not queue requests.
 
-- `invocation_id` is caller-generated correlation data, limited to 128 bytes.
+- `invocation_id` is optional correlation data, limited to 128 bytes. The
+  caller may supply one for cross-system tracing. When it is empty, the Runtime
+  Server generates an opaque ID; the response always returns the ID in use.
 - It is not a deduplication key. Retrying after an unknown result can execute
   work again; no component automatically retries after dispatch.
 - `timeout_millis` is bounded by runtimed to the remaining Run lifetime and

--- a/docs/design/function-runtime-contract.zh.md
+++ b/docs/design/function-runtime-contract.zh.md
@@ -34,8 +34,8 @@ registration lifecycle attempts：初始 registration 为 `1`，只有在 regist
 或 reassignment 时，shared retry engine 才递增它。对同一 registration attempt 的不确定 Pod-local
 `RegisterFunction` RPC 进行重试是幂等的，且不改变 Run status。
 
-`registration_attempt` 不是 invocation counter。每一次 function 调用使用独立、由 caller 生成的
-`invocation_id`。
+`registration_attempt` 不是 invocation counter。每一次 function 调用可选地携带独立的
+`invocation_id` 用于关联。
 
 `RegisterFunction` 使用 Run UID 加 `registration_attempt` 建立新的本地 registration generation，
 并返回 opaque `registration_id`。后续所有 Pod-local 操作使用这个 ID，而不再重复传递 attempt。
@@ -215,7 +215,8 @@ runtimed 以有界频率轮询它用于健康检查和 idle timeout，绝不把�
 `InvokeFunction` 要求提供的 registration reference 处于 `READY`。v0.x 每个 function Run 只允许一个
 in-flight invocation，并且不排队。
 
-- `invocation_id` 由调用方生成，用于关联，最大 128 bytes。
+- `invocation_id` 是可选的关联数据，最大 128 bytes。调用方可提供它用于跨系统 trace；为空时
+  Runtime Server 生成 opaque ID，response 始终返回实际使用的 ID。
 - 它不是去重 key。未知结果后的重试可能再次执行；dispatch 后没有组件自动重试。
 - `timeout_millis` 由 runtimed 限制为剩余 Run 生命周期和 gateway deadline 以内。零表示
   有界 gateway 默认值，绝不代表无限运行。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -144,11 +144,14 @@ wiring from accumulating avoidable conflicts.
   artifact references, and log access without writing high-frequency invocation
   history into Run status.
   Initial implementation TODO:
-  - [ ] review and approve the
+  - [x] review and approve the
     [Function Runtime Server Contract](design/function-runtime-contract.md);
-  - [ ] add idempotent register/status/invoke/unregister protobuf operations
+  - [x] add idempotent register/status/invoke/unregister protobuf operations
     keyed by Run UID;
-  - [ ] implement built-in Bash and Python function adapters;
+  - [ ] implement built-in function adapters:
+    - [x] Bash FunctionRuntime adapter with handler validation, registration
+      fencing, one in-flight invocation, bounded output, and unregister drain;
+    - [ ] Python FunctionRuntime adapter;
   - [ ] add bounded invocation outputs/artifact references and structured logs
     keyed by Run UID and invocation ID;
 - [ ] Function-mode reliability and isolation: cover function registration,

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -128,10 +128,13 @@ controller wiring 累积不必要的冲突。
   unregister APIs；定义有界 invoke request inputs、response outputs、artifact
   references 和 log access，同时避免把高频 invocation history 写入 Run status。
   初始实现 TODO：
-  - [ ] review 并确认
+  - [x] review 并确认
     [Function Runtime Server 协议](design/function-runtime-contract.md)；
-  - [ ] 增加以 Run UID 为 key 的幂等 register/status/invoke/unregister protobuf operations；
-  - [ ] 实现内置 Bash 和 Python function adapters；
+  - [x] 增加以 Run UID 为 key 的幂等 register/status/invoke/unregister protobuf operations；
+  - [ ] 实现内置 function adapters：
+    - [x] Bash FunctionRuntime adapter：handler validation、registration fencing、单个
+      in-flight invocation、有界输出和 unregister drain；
+    - [ ] Python FunctionRuntime adapter；
   - [ ] 增加有界 invocation outputs/artifact references，以及以 Run UID 和 invocation ID
     为 key 的 structured logs；
 - [ ] Function-mode reliability and isolation：覆盖 function registration、ready

--- a/runtimes/bash/cmd/main.go
+++ b/runtimes/bash/cmd/main.go
@@ -32,7 +32,9 @@ func main() {
 	}
 
 	srv := grpc.NewServer()
-	pb.RegisterRuntimeServer(srv, bash.NewServer(workDir))
+	runtimeServer := bash.NewServer(workDir)
+	pb.RegisterRuntimeServer(srv, runtimeServer)
+	pb.RegisterFunctionRuntimeServer(srv, runtimeServer)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()

--- a/runtimes/bash/function.go
+++ b/runtimes/bash/function.go
@@ -34,7 +34,7 @@ const (
 var bashFunctionName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 type functionEntry struct {
-	mu                   sync.Mutex
+	mu                   sync.RWMutex
 	registration         *pb.FunctionRegistration
 	attempt              int32
 	digest               string

--- a/runtimes/bash/function.go
+++ b/runtimes/bash/function.go
@@ -122,19 +122,21 @@ func (s *Server) InvokeFunction(ctx context.Context, req *pb.InvokeFunctionReque
 		return nil, status.Error(codes.InvalidArgument, "input must be valid JSON no larger than 1 MiB")
 	}
 
-	// Registration changes and invocation admission share this lock. Once an
-	// invocation is admitted, a newer registration or unregistration fences it
-	// by cancelling and waiting for this invocation to finish.
-	s.operationMu.Lock()
+	// Registration changes and invocation admission share this lifecycle
+	// barrier. Multiple functions may admit invocations concurrently. A
+	// registration replacement or unregistration takes the exclusive side before
+	// it inspects and fences the target function, so no new invocation is
+	// admitted during that transition.
+	s.operationMu.RLock()
 	entry, err := s.matchFunction(req.GetRegistration())
 	if err != nil {
-		s.operationMu.Unlock()
+		s.operationMu.RUnlock()
 		return nil, err
 	}
 	invokeCtx, cancel := functionInvokeContext(ctx, req.TimeoutMillis)
 
 	invocation, err := entry.startInvocation(cancel)
-	s.operationMu.Unlock()
+	s.operationMu.RUnlock()
 	if err != nil {
 		cancel()
 		return nil, err

--- a/runtimes/bash/function.go
+++ b/runtimes/bash/function.go
@@ -126,8 +126,16 @@ func (s *Server) FunctionStatus(_ context.Context, req *pb.FunctionStatusRequest
 }
 
 func (s *Server) InvokeFunction(ctx context.Context, req *pb.InvokeFunctionRequest) (*pb.InvokeFunctionResponse, error) {
-	if req.InvocationId == "" || len(req.InvocationId) > 128 {
-		return nil, status.Error(codes.InvalidArgument, "invocation id must be between 1 and 128 bytes")
+	invocationID := req.InvocationId
+	if len(invocationID) > 128 {
+		return nil, status.Error(codes.InvalidArgument, "invocation id must be no larger than 128 bytes")
+	}
+	if invocationID == "" {
+		var err error
+		invocationID, err = newInvocationID()
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "generate invocation id: %v", err)
+		}
 	}
 	if req.ContentType != "application/json" {
 		return nil, status.Error(codes.InvalidArgument, "Bash functions support only application/json input")
@@ -191,7 +199,7 @@ func (s *Server) InvokeFunction(ctx context.Context, req *pb.InvokeFunctionReque
 	}
 	return &pb.InvokeFunctionResponse{
 		Registration: registration,
-		InvocationId: req.InvocationId,
+		InvocationId: invocationID,
 		Output:       output,
 		ContentType:  "application/json",
 	}, nil
@@ -441,11 +449,19 @@ func waitForFunction(ctx context.Context, done <-chan struct{}) error {
 }
 
 func newRegistrationID() (string, error) {
+	return newFunctionID("reg_")
+}
+
+func newInvocationID() (string, error) {
+	return newFunctionID("inv_")
+}
+
+func newFunctionID(prefix string) (string, error) {
 	bytes := make([]byte, 16)
 	if _, err := rand.Read(bytes); err != nil {
 		return "", err
 	}
-	return "reg_" + hex.EncodeToString(bytes), nil
+	return prefix + hex.EncodeToString(bytes), nil
 }
 
 func cloneFunctionRegistration(registration *pb.FunctionRegistration) *pb.FunctionRegistration {

--- a/runtimes/bash/function.go
+++ b/runtimes/bash/function.go
@@ -1,0 +1,484 @@
+package bash
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/kruntimes/kruntimes/internal/execpath"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/kruntimes/kruntimes/api/runtime/v1"
+)
+
+const (
+	defaultFunctionInvokeTimeout = 30 * time.Second
+	maxFunctionInvokeTimeout     = 5 * time.Minute
+	defaultFunctionDrainTimeout  = 30 * time.Second
+)
+
+var bashFunctionName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+type functionEntry struct {
+	mu                   sync.Mutex
+	registration         *pb.FunctionRegistration
+	attempt              int32
+	digest               string
+	workingDir           string
+	handlerFile          string
+	handlerName          string
+	env                  map[string]string
+	state                pb.FunctionRegistrationState
+	inFlight             bool
+	lastActivityUnixNano int64
+	cancel               context.CancelFunc
+	done                 chan struct{}
+}
+
+func (s *Server) RegisterFunction(ctx context.Context, req *pb.RegisterFunctionRequest) (*pb.RegisterFunctionResponse, error) {
+	workingDir, handlerFile, handlerName, err := s.validateFunctionRegistration(req)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	s.operationMu.Lock()
+	defer s.operationMu.Unlock()
+
+	if existing := s.function(req.RunUid); existing != nil {
+		existing.mu.Lock()
+		switch {
+		case req.RegistrationAttempt < existing.attempt:
+			existing.mu.Unlock()
+			return nil, status.Error(codes.FailedPrecondition, "registration attempt is stale")
+		case req.RegistrationAttempt == existing.attempt:
+			if req.RegistrationDigest != existing.digest {
+				existing.mu.Unlock()
+				return nil, status.Error(codes.AlreadyExists, "registration attempt already exists with a different digest")
+			}
+			resp := &pb.RegisterFunctionResponse{Registration: cloneFunctionRegistration(existing.registration), State: existing.state}
+			existing.mu.Unlock()
+			return resp, nil
+		default:
+			inFlight, cancel, done := existing.inFlight, existing.cancel, existing.done
+			existing.mu.Unlock()
+			if inFlight {
+				cancel()
+				if err := waitForFunction(ctx, done); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+
+	registrationID, err := newRegistrationID()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "generate registration id: %v", err)
+	}
+	entry := &functionEntry{
+		registration: &pb.FunctionRegistration{RunUid: req.RunUid, RegistrationId: registrationID},
+		attempt:      req.RegistrationAttempt,
+		digest:       req.RegistrationDigest,
+		workingDir:   workingDir,
+		handlerFile:  handlerFile,
+		handlerName:  handlerName,
+		env:          cloneStringMap(req.Env),
+		state:        pb.FunctionRegistrationState_FUNCTION_REGISTRATION_STATE_READY,
+	}
+	s.mu.Lock()
+	s.functions[req.RunUid] = entry
+	s.mu.Unlock()
+
+	return &pb.RegisterFunctionResponse{Registration: cloneFunctionRegistration(entry.registration), State: entry.state}, nil
+}
+
+func (s *Server) FunctionStatus(_ context.Context, req *pb.FunctionStatusRequest) (*pb.FunctionStatusResponse, error) {
+	entry, err := s.matchFunction(req.GetRegistration())
+	if err != nil {
+		return nil, err
+	}
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+
+	inFlight := int32(0)
+	if entry.inFlight {
+		inFlight = 1
+	}
+	return &pb.FunctionStatusResponse{
+		Registration:         cloneFunctionRegistration(entry.registration),
+		State:                entry.state,
+		InFlight:             inFlight,
+		LastActivityUnixNano: entry.lastActivityUnixNano,
+	}, nil
+}
+
+func (s *Server) InvokeFunction(ctx context.Context, req *pb.InvokeFunctionRequest) (*pb.InvokeFunctionResponse, error) {
+	if req.InvocationId == "" || len(req.InvocationId) > 128 {
+		return nil, status.Error(codes.InvalidArgument, "invocation id must be between 1 and 128 bytes")
+	}
+	if req.ContentType != "application/json" {
+		return nil, status.Error(codes.InvalidArgument, "Bash functions support only application/json input")
+	}
+	if len(req.Input) == 0 || len(req.Input) > defaultOutputLimitBytes || !json.Valid(req.Input) || bytes.IndexByte(req.Input, 0) >= 0 {
+		return nil, status.Error(codes.InvalidArgument, "input must be valid JSON no larger than 1 MiB")
+	}
+
+	// Registration changes and invocation admission share this lock. Once an
+	// invocation is admitted, a newer registration or unregistration fences it
+	// by cancelling and waiting for this invocation to finish.
+	s.operationMu.Lock()
+	entry, err := s.matchFunction(req.GetRegistration())
+	if err != nil {
+		s.operationMu.Unlock()
+		return nil, err
+	}
+	invokeCtx, cancel := functionInvokeContext(ctx, req.TimeoutMillis)
+
+	entry.mu.Lock()
+	if entry.state != pb.FunctionRegistrationState_FUNCTION_REGISTRATION_STATE_READY {
+		entry.mu.Unlock()
+		s.operationMu.Unlock()
+		cancel()
+		return nil, status.Error(codes.FailedPrecondition, "function registration is not ready")
+	}
+	if entry.inFlight {
+		entry.mu.Unlock()
+		s.operationMu.Unlock()
+		cancel()
+		return nil, status.Error(codes.ResourceExhausted, "function registration already has an in-flight invocation")
+	}
+	entry.inFlight = true
+	entry.lastActivityUnixNano = time.Now().UnixNano()
+	entry.cancel = cancel
+	entry.done = make(chan struct{})
+	workingDir, handlerFile, handlerName, env, registration := entry.workingDir, entry.handlerFile, entry.handlerName, cloneStringMap(entry.env), cloneFunctionRegistration(entry.registration)
+	done := entry.done
+	entry.mu.Unlock()
+	s.operationMu.Unlock()
+	defer cancel()
+
+	defer func() {
+		entry.mu.Lock()
+		entry.inFlight = false
+		entry.cancel = nil
+		entry.lastActivityUnixNano = time.Now().UnixNano()
+		close(done)
+		entry.mu.Unlock()
+	}()
+
+	output, err := invokeBashFunction(invokeCtx, workingDir, handlerFile, handlerName, string(req.Input), env, s.outputLimit)
+	if err != nil {
+		if errorsIsContextError(err) {
+			return nil, status.FromContextError(err).Err()
+		}
+		if errorsIsOutputLimit(err) {
+			return nil, status.Error(codes.ResourceExhausted, err.Error())
+		}
+		return nil, status.Errorf(codes.Internal, "invoke handler: %v", err)
+	}
+	return &pb.InvokeFunctionResponse{
+		Registration: registration,
+		InvocationId: req.InvocationId,
+		Output:       output,
+		ContentType:  "application/json",
+	}, nil
+}
+
+func (s *Server) UnregisterFunction(ctx context.Context, req *pb.UnregisterFunctionRequest) (*pb.UnregisterFunctionResponse, error) {
+	registration := req.GetRegistration()
+	if registration == nil || registration.RunUid == "" || registration.RegistrationId == "" {
+		return nil, status.Error(codes.InvalidArgument, "registration run uid and id are required")
+	}
+
+	s.operationMu.Lock()
+	defer s.operationMu.Unlock()
+	entry := s.function(registration.RunUid)
+	if entry == nil {
+		return &pb.UnregisterFunctionResponse{Registration: cloneFunctionRegistration(registration)}, nil
+	}
+
+	entry.mu.Lock()
+	if entry.registration.RegistrationId != registration.RegistrationId {
+		entry.mu.Unlock()
+		return nil, status.Error(codes.FailedPrecondition, "function registration is stale")
+	}
+	entry.state = pb.FunctionRegistrationState_FUNCTION_REGISTRATION_STATE_DRAINING
+	inFlight, cancel, done := entry.inFlight, entry.cancel, entry.done
+	entry.mu.Unlock()
+
+	if inFlight {
+		if req.CancelInFlight {
+			cancel()
+		}
+		drainCtx, cancel := functionDrainContext(ctx, req.DrainTimeoutMillis)
+		err := waitForFunction(drainCtx, done)
+		cancel()
+		if err != nil {
+			return nil, err
+		}
+	}
+	s.mu.Lock()
+	if s.functions[registration.RunUid] == entry {
+		delete(s.functions, registration.RunUid)
+	}
+	s.mu.Unlock()
+	return &pb.UnregisterFunctionResponse{Registration: cloneFunctionRegistration(registration)}, nil
+}
+
+func (s *Server) function(runUID string) *functionEntry {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.functions[runUID]
+}
+
+func (s *Server) matchFunction(registration *pb.FunctionRegistration) (*functionEntry, error) {
+	if registration == nil || registration.RunUid == "" || registration.RegistrationId == "" {
+		return nil, status.Error(codes.InvalidArgument, "registration run uid and id are required")
+	}
+	entry := s.function(registration.RunUid)
+	if entry == nil {
+		return nil, status.Error(codes.NotFound, "function registration not found")
+	}
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if entry.registration.RegistrationId != registration.RegistrationId {
+		return nil, status.Error(codes.FailedPrecondition, "function registration is stale")
+	}
+	return entry, nil
+}
+
+func (s *Server) validateFunctionRegistration(req *pb.RegisterFunctionRequest) (string, string, string, error) {
+	if req.RunUid == "" || req.RegistrationAttempt < 1 || req.RegistrationDigest == "" {
+		return "", "", "", fmt.Errorf("run uid, positive registration attempt, and registration digest are required")
+	}
+	if len(req.RegistrationDigest) > 128 {
+		return "", "", "", fmt.Errorf("registration digest must be no larger than 128 bytes")
+	}
+	workingDir, err := s.functionWorkingDir(req.WorkingDir)
+	if err != nil {
+		return "", "", "", err
+	}
+	handlerFile, handlerName, err := parseBashHandler(req.Handler)
+	if err != nil {
+		return "", "", "", err
+	}
+	handlerPath, err := functionFilePath(workingDir, handlerFile)
+	if err != nil {
+		return "", "", "", err
+	}
+	if err := validateBashFunction(workingDir, handlerPath, handlerName, req.Env); err != nil {
+		return "", "", "", err
+	}
+	return workingDir, handlerFile, handlerName, nil
+}
+
+func (s *Server) functionWorkingDir(workingDir string) (string, error) {
+	if workingDir == "" {
+		return "", fmt.Errorf("working directory is required")
+	}
+	base, err := filepath.EvalSymlinks(s.workDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve runtime workspace: %w", err)
+	}
+	path, err := filepath.EvalSymlinks(workingDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve working directory: %w", err)
+	}
+	relative, err := filepath.Rel(base, path)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("working directory must be within the runtime workspace")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("working directory: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("working directory must be a directory")
+	}
+	return path, nil
+}
+
+func functionFilePath(workingDir, handlerFile string) (string, error) {
+	path, err := filepath.EvalSymlinks(filepath.Join(workingDir, handlerFile))
+	if err != nil {
+		return "", fmt.Errorf("handler file: %w", err)
+	}
+	relative, err := filepath.Rel(workingDir, path)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("handler file must be within the working directory")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("handler file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", fmt.Errorf("handler file must be a regular file")
+	}
+	return path, nil
+}
+
+func parseBashHandler(handler string) (string, string, error) {
+	separator := strings.LastIndex(handler, ".")
+	if separator <= 0 || separator == len(handler)-1 {
+		return "", "", fmt.Errorf("handler must use file.function form")
+	}
+	file, err := execpath.ResolveEntrypoint(handler[:separator]+".sh", "")
+	if err != nil {
+		return "", "", err
+	}
+	function := handler[separator+1:]
+	if !bashFunctionName.MatchString(function) {
+		return "", "", fmt.Errorf("handler function name is invalid")
+	}
+	return file, function, nil
+}
+
+func validateBashFunction(workingDir, handlerPath, handlerName string, env map[string]string) error {
+	cmd := exec.Command("bash", "-c", `source "$1"; declare -F "$2" >/dev/null`, "kruntimes-function-validation", handlerPath, handlerName)
+	cmd.Dir = workingDir
+	cmd.Env = functionEnvironment(env)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("handler %q is not defined by %s: %w: %s", handlerName, filepath.Base(handlerPath), err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func invokeBashFunction(ctx context.Context, workingDir, handlerFile, handlerName, input string, env map[string]string, outputLimit int) ([]byte, error) {
+	// The fixed bash program receives the file, function, and JSON as positional
+	// arguments. Neither the handler nor request data is interpolated as shell source.
+	handlerPath, err := functionFilePath(workingDir, handlerFile)
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command("bash", "-c", `source "$1"; "$2" "$3"`, "kruntimes-function", handlerPath, handlerName, input)
+	cmd.Dir = workingDir
+	cmd.Env = functionEnvironment(env)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	var stdout boundedBuffer
+	stdout = newBoundedBuffer(outputLimit)
+	var stderr boundedBuffer
+	stderr = newBoundedBuffer(outputLimit)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	waitCh := make(chan error, 1)
+	go func() { waitCh <- cmd.Wait() }()
+	select {
+	case err := <-waitCh:
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", err, stderr.String())
+		}
+	case <-ctx.Done():
+		_ = terminateProcessGroupAndWait(cmd.Process.Pid, waitCh, processTerminationGrace)
+		return nil, ctx.Err()
+	}
+	if stdout.truncated {
+		return nil, errFunctionOutputLimit{}
+	}
+	return []byte(stdout.String()), nil
+}
+
+type errFunctionOutputLimit struct{}
+
+func (errFunctionOutputLimit) Error() string {
+	return "function response exceeds the configured output limit"
+}
+
+func errorsIsOutputLimit(err error) bool {
+	_, ok := err.(errFunctionOutputLimit)
+	return ok
+}
+
+func errorsIsContextError(err error) bool {
+	return err == context.Canceled || err == context.DeadlineExceeded
+}
+
+func functionInvokeContext(parent context.Context, timeoutMillis int64) (context.Context, context.CancelFunc) {
+	timeout := defaultFunctionInvokeTimeout
+	if timeoutMillis > 0 {
+		timeout = time.Duration(timeoutMillis) * time.Millisecond
+	}
+	if timeout > maxFunctionInvokeTimeout {
+		timeout = maxFunctionInvokeTimeout
+	}
+	return context.WithTimeout(parent, timeout)
+}
+
+func functionDrainContext(parent context.Context, timeoutMillis int64) (context.Context, context.CancelFunc) {
+	timeout := defaultFunctionDrainTimeout
+	if timeoutMillis > 0 {
+		timeout = time.Duration(timeoutMillis) * time.Millisecond
+	}
+	if timeout > maxFunctionInvokeTimeout {
+		timeout = maxFunctionInvokeTimeout
+	}
+	return context.WithTimeout(parent, timeout)
+}
+
+func waitForFunction(ctx context.Context, done <-chan struct{}) error {
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return status.FromContextError(ctx.Err()).Err()
+	}
+}
+
+func newRegistrationID() (string, error) {
+	bytes := make([]byte, 16)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return "reg_" + hex.EncodeToString(bytes), nil
+}
+
+func cloneFunctionRegistration(registration *pb.FunctionRegistration) *pb.FunctionRegistration {
+	if registration == nil {
+		return nil
+	}
+	return &pb.FunctionRegistration{RunUid: registration.RunUid, RegistrationId: registration.RegistrationId}
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	return maps.Clone(values)
+}
+
+func functionEnvironment(values map[string]string) []string {
+	overrides := cloneStringMap(values)
+	environment := make([]string, 0, len(os.Environ())+len(overrides))
+	for _, value := range os.Environ() {
+		key, _, found := strings.Cut(value, "=")
+		if !found {
+			continue
+		}
+		if _, overridden := overrides[key]; overridden {
+			continue
+		}
+		environment = append(environment, value)
+	}
+	keys := make([]string, 0, len(overrides))
+	for key := range overrides {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		environment = append(environment, key+"="+overrides[key])
+	}
+	return environment
+}

--- a/runtimes/bash/function.go
+++ b/runtimes/bash/function.go
@@ -59,27 +59,17 @@ func (s *Server) RegisterFunction(ctx context.Context, req *pb.RegisterFunctionR
 	defer s.operationMu.Unlock()
 
 	if existing := s.function(req.RunUid); existing != nil {
-		existing.mu.Lock()
-		switch {
-		case req.RegistrationAttempt < existing.attempt:
-			existing.mu.Unlock()
-			return nil, status.Error(codes.FailedPrecondition, "registration attempt is stale")
-		case req.RegistrationAttempt == existing.attempt:
-			if req.RegistrationDigest != existing.digest {
-				existing.mu.Unlock()
-				return nil, status.Error(codes.AlreadyExists, "registration attempt already exists with a different digest")
-			}
-			resp := &pb.RegisterFunctionResponse{Registration: cloneFunctionRegistration(existing.registration), State: existing.state}
-			existing.mu.Unlock()
+		resp, drain, err := existing.registrationAction(req.RegistrationAttempt, req.RegistrationDigest)
+		if err != nil {
+			return nil, err
+		}
+		if resp != nil {
 			return resp, nil
-		default:
-			inFlight, cancel, done := existing.inFlight, existing.cancel, existing.done
-			existing.mu.Unlock()
-			if inFlight {
-				cancel()
-				if err := waitForFunction(ctx, done); err != nil {
-					return nil, err
-				}
+		}
+		if drain.inFlight {
+			drain.cancel()
+			if err := waitForFunction(ctx, drain.done); err != nil {
+				return nil, err
 			}
 		}
 	}
@@ -102,7 +92,7 @@ func (s *Server) RegisterFunction(ctx context.Context, req *pb.RegisterFunctionR
 	s.functions[req.RunUid] = entry
 	s.mu.Unlock()
 
-	return &pb.RegisterFunctionResponse{Registration: cloneFunctionRegistration(entry.registration), State: entry.state}, nil
+	return entry.registrationResponse(), nil
 }
 
 func (s *Server) FunctionStatus(_ context.Context, req *pb.FunctionStatusRequest) (*pb.FunctionStatusResponse, error) {
@@ -110,19 +100,7 @@ func (s *Server) FunctionStatus(_ context.Context, req *pb.FunctionStatusRequest
 	if err != nil {
 		return nil, err
 	}
-	entry.mu.Lock()
-	defer entry.mu.Unlock()
-
-	inFlight := int32(0)
-	if entry.inFlight {
-		inFlight = 1
-	}
-	return &pb.FunctionStatusResponse{
-		Registration:         cloneFunctionRegistration(entry.registration),
-		State:                entry.state,
-		InFlight:             inFlight,
-		LastActivityUnixNano: entry.lastActivityUnixNano,
-	}, nil
+	return entry.statusResponse(), nil
 }
 
 func (s *Server) InvokeFunction(ctx context.Context, req *pb.InvokeFunctionRequest) (*pb.InvokeFunctionResponse, error) {
@@ -155,39 +133,19 @@ func (s *Server) InvokeFunction(ctx context.Context, req *pb.InvokeFunctionReque
 	}
 	invokeCtx, cancel := functionInvokeContext(ctx, req.TimeoutMillis)
 
-	entry.mu.Lock()
-	if entry.state != pb.FunctionRegistrationState_FUNCTION_REGISTRATION_STATE_READY {
-		entry.mu.Unlock()
-		s.operationMu.Unlock()
-		cancel()
-		return nil, status.Error(codes.FailedPrecondition, "function registration is not ready")
-	}
-	if entry.inFlight {
-		entry.mu.Unlock()
-		s.operationMu.Unlock()
-		cancel()
-		return nil, status.Error(codes.ResourceExhausted, "function registration already has an in-flight invocation")
-	}
-	entry.inFlight = true
-	entry.lastActivityUnixNano = time.Now().UnixNano()
-	entry.cancel = cancel
-	entry.done = make(chan struct{})
-	workingDir, handlerFile, handlerName, env, registration := entry.workingDir, entry.handlerFile, entry.handlerName, cloneStringMap(entry.env), cloneFunctionRegistration(entry.registration)
-	done := entry.done
-	entry.mu.Unlock()
+	invocation, err := entry.startInvocation(cancel)
 	s.operationMu.Unlock()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
 	defer cancel()
 
 	defer func() {
-		entry.mu.Lock()
-		entry.inFlight = false
-		entry.cancel = nil
-		entry.lastActivityUnixNano = time.Now().UnixNano()
-		close(done)
-		entry.mu.Unlock()
+		entry.finishInvocation(invocation.done)
 	}()
 
-	output, err := invokeBashFunction(invokeCtx, workingDir, handlerFile, handlerName, string(req.Input), env, s.outputLimit)
+	output, err := invokeBashFunction(invokeCtx, invocation.workingDir, invocation.handlerFile, invocation.handlerName, string(req.Input), invocation.env, s.outputLimit)
 	if err != nil {
 		if errorsIsContextError(err) {
 			return nil, status.FromContextError(err).Err()
@@ -198,7 +156,7 @@ func (s *Server) InvokeFunction(ctx context.Context, req *pb.InvokeFunctionReque
 		return nil, status.Errorf(codes.Internal, "invoke handler: %v", err)
 	}
 	return &pb.InvokeFunctionResponse{
-		Registration: registration,
+		Registration: invocation.registration,
 		InvocationId: invocationID,
 		Output:       output,
 		ContentType:  "application/json",
@@ -218,21 +176,16 @@ func (s *Server) UnregisterFunction(ctx context.Context, req *pb.UnregisterFunct
 		return &pb.UnregisterFunctionResponse{Registration: cloneFunctionRegistration(registration)}, nil
 	}
 
-	entry.mu.Lock()
-	if entry.registration.RegistrationId != registration.RegistrationId {
-		entry.mu.Unlock()
-		return nil, status.Error(codes.FailedPrecondition, "function registration is stale")
+	drain, err := entry.beginDrain(registration.RegistrationId)
+	if err != nil {
+		return nil, err
 	}
-	entry.state = pb.FunctionRegistrationState_FUNCTION_REGISTRATION_STATE_DRAINING
-	inFlight, cancel, done := entry.inFlight, entry.cancel, entry.done
-	entry.mu.Unlock()
-
-	if inFlight {
+	if drain.inFlight {
 		if req.CancelInFlight {
-			cancel()
+			drain.cancel()
 		}
 		drainCtx, cancel := functionDrainContext(ctx, req.DrainTimeoutMillis)
-		err := waitForFunction(drainCtx, done)
+		err := waitForFunction(drainCtx, drain.done)
 		cancel()
 		if err != nil {
 			return nil, err
@@ -260,9 +213,7 @@ func (s *Server) matchFunction(registration *pb.FunctionRegistration) (*function
 	if entry == nil {
 		return nil, status.Error(codes.NotFound, "function registration not found")
 	}
-	entry.mu.Lock()
-	defer entry.mu.Unlock()
-	if entry.registration.RegistrationId != registration.RegistrationId {
+	if !entry.matchesRegistration(registration.RegistrationId) {
 		return nil, status.Error(codes.FailedPrecondition, "function registration is stale")
 	}
 	return entry, nil

--- a/runtimes/bash/function_entry.go
+++ b/runtimes/bash/function_entry.go
@@ -48,8 +48,8 @@ func (e *functionEntry) registrationAction(attempt int32, digest string) (*pb.Re
 }
 
 func (e *functionEntry) registrationResponse() *pb.RegisterFunctionResponse {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	return &pb.RegisterFunctionResponse{
 		Registration: cloneFunctionRegistration(e.registration),
 		State:        e.state,
@@ -57,8 +57,8 @@ func (e *functionEntry) registrationResponse() *pb.RegisterFunctionResponse {
 }
 
 func (e *functionEntry) statusResponse() *pb.FunctionStatusResponse {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 
 	inFlight := int32(0)
 	if e.inFlight {
@@ -119,7 +119,7 @@ func (e *functionEntry) beginDrain(registrationID string) (functionDrain, error)
 }
 
 func (e *functionEntry) matchesRegistration(registrationID string) bool {
-	e.mu.Lock()
-	defer e.mu.Unlock()
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	return e.registration.RegistrationId == registrationID
 }

--- a/runtimes/bash/function_entry.go
+++ b/runtimes/bash/function_entry.go
@@ -1,0 +1,125 @@
+package bash
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/kruntimes/kruntimes/api/runtime/v1"
+)
+
+type functionInvocation struct {
+	workingDir   string
+	handlerFile  string
+	handlerName  string
+	env          map[string]string
+	registration *pb.FunctionRegistration
+	done         chan struct{}
+}
+
+type functionDrain struct {
+	inFlight bool
+	cancel   context.CancelFunc
+	done     <-chan struct{}
+}
+
+// registrationAction returns an idempotent response for the current
+// generation or the in-flight invocation that must finish before replacement.
+func (e *functionEntry) registrationAction(attempt int32, digest string) (*pb.RegisterFunctionResponse, functionDrain, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	switch {
+	case attempt < e.attempt:
+		return nil, functionDrain{}, status.Error(codes.FailedPrecondition, "registration attempt is stale")
+	case attempt == e.attempt:
+		if digest != e.digest {
+			return nil, functionDrain{}, status.Error(codes.AlreadyExists, "registration attempt already exists with a different digest")
+		}
+		return &pb.RegisterFunctionResponse{
+			Registration: cloneFunctionRegistration(e.registration),
+			State:        e.state,
+		}, functionDrain{}, nil
+	default:
+		return nil, functionDrain{inFlight: e.inFlight, cancel: e.cancel, done: e.done}, nil
+	}
+}
+
+func (e *functionEntry) registrationResponse() *pb.RegisterFunctionResponse {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return &pb.RegisterFunctionResponse{
+		Registration: cloneFunctionRegistration(e.registration),
+		State:        e.state,
+	}
+}
+
+func (e *functionEntry) statusResponse() *pb.FunctionStatusResponse {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	inFlight := int32(0)
+	if e.inFlight {
+		inFlight = 1
+	}
+	return &pb.FunctionStatusResponse{
+		Registration:         cloneFunctionRegistration(e.registration),
+		State:                e.state,
+		InFlight:             inFlight,
+		LastActivityUnixNano: e.lastActivityUnixNano,
+	}
+}
+
+func (e *functionEntry) startInvocation(cancel context.CancelFunc) (functionInvocation, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.state != pb.FunctionRegistrationState_FUNCTION_REGISTRATION_STATE_READY {
+		return functionInvocation{}, status.Error(codes.FailedPrecondition, "function registration is not ready")
+	}
+	if e.inFlight {
+		return functionInvocation{}, status.Error(codes.ResourceExhausted, "function registration already has an in-flight invocation")
+	}
+	e.inFlight = true
+	e.lastActivityUnixNano = time.Now().UnixNano()
+	e.cancel = cancel
+	e.done = make(chan struct{})
+	return functionInvocation{
+		workingDir:   e.workingDir,
+		handlerFile:  e.handlerFile,
+		handlerName:  e.handlerName,
+		env:          cloneStringMap(e.env),
+		registration: cloneFunctionRegistration(e.registration),
+		done:         e.done,
+	}, nil
+}
+
+func (e *functionEntry) finishInvocation(done chan struct{}) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.done != done {
+		return
+	}
+	e.inFlight = false
+	e.cancel = nil
+	e.lastActivityUnixNano = time.Now().UnixNano()
+	close(done)
+}
+
+func (e *functionEntry) beginDrain(registrationID string) (functionDrain, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.registration.RegistrationId != registrationID {
+		return functionDrain{}, status.Error(codes.FailedPrecondition, "function registration is stale")
+	}
+	e.state = pb.FunctionRegistrationState_FUNCTION_REGISTRATION_STATE_DRAINING
+	return functionDrain{inFlight: e.inFlight, cancel: e.cancel, done: e.done}, nil
+}
+
+func (e *functionEntry) matchesRegistration(registrationID string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.registration.RegistrationId == registrationID
+}

--- a/runtimes/bash/server.go
+++ b/runtimes/bash/server.go
@@ -123,7 +123,7 @@ type Server struct {
 	pb.UnimplementedRuntimeServer
 	pb.UnimplementedFunctionRuntimeServer
 
-	operationMu sync.Mutex
+	operationMu sync.RWMutex
 	mu          sync.RWMutex
 	executions  map[string]*executionEntry
 	functions   map[string]*functionEntry

--- a/runtimes/bash/server.go
+++ b/runtimes/bash/server.go
@@ -121,10 +121,12 @@ func (e *executionEntry) snapshot(id string) *pb.StatusResponse {
 // Server implements the Runtime gRPC service by executing bash commands.
 type Server struct {
 	pb.UnimplementedRuntimeServer
+	pb.UnimplementedFunctionRuntimeServer
 
 	operationMu sync.Mutex
 	mu          sync.RWMutex
 	executions  map[string]*executionEntry
+	functions   map[string]*functionEntry
 	workDir     string
 	outputLimit int
 }
@@ -139,6 +141,7 @@ func NewServerWithOutputLimit(workDir string, outputLimit int) *Server {
 	}
 	return &Server{
 		executions:  make(map[string]*executionEntry),
+		functions:   make(map[string]*functionEntry),
 		workDir:     workDir,
 		outputLimit: outputLimit,
 	}

--- a/runtimes/bash/server_test.go
+++ b/runtimes/bash/server_test.go
@@ -52,6 +52,222 @@ func startTestServerWithOutputLimit(t *testing.T, outputLimit int) (pb.RuntimeCl
 	}
 }
 
+func startFunctionTestServer(t *testing.T, outputLimit int) (pb.FunctionRuntimeClient, string, func()) {
+	t.Helper()
+
+	workDir := t.TempDir()
+	srv := grpc.NewServer()
+	runtimeServer := NewServerWithOutputLimit(workDir, outputLimit)
+	pb.RegisterRuntimeServer(srv, runtimeServer)
+	pb.RegisterFunctionRuntimeServer(srv, runtimeServer)
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = srv.Serve(lis) }()
+
+	conn, err := grpc.NewClient(lis.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	return pb.NewFunctionRuntimeClient(conn), workDir, func() {
+		conn.Close()
+		srv.Stop()
+	}
+}
+
+func writeFunctionHandler(t *testing.T, workDir, name, script string) string {
+	t.Helper()
+	functionDir := filepath.Join(workDir, name)
+	if err := os.MkdirAll(functionDir, 0o755); err != nil {
+		t.Fatalf("mkdir function directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(functionDir, "handler.sh"), []byte(script), 0o644); err != nil {
+		t.Fatalf("write handler: %v", err)
+	}
+	return functionDir
+}
+
+func registerFunction(t *testing.T, client pb.FunctionRuntimeClient, workDir, runUID string, attempt int32, digest string) *pb.FunctionRegistration {
+	t.Helper()
+	resp, err := client.RegisterFunction(context.Background(), &pb.RegisterFunctionRequest{
+		RunUid:              runUID,
+		RegistrationAttempt: attempt,
+		WorkingDir:          workDir,
+		Handler:             "handler.handle",
+		RegistrationDigest:  digest,
+	})
+	if err != nil {
+		t.Fatalf("RegisterFunction: %v", err)
+	}
+	if resp.State != pb.FunctionRegistrationState_FUNCTION_REGISTRATION_STATE_READY {
+		t.Fatalf("registration state = %v, want ready", resp.State)
+	}
+	return resp.Registration
+}
+
+func TestFunctionRuntimeRegisterInvokeAndUnregister(t *testing.T) {
+	client, workDir, cleanup := startFunctionTestServer(t, defaultOutputLimitBytes)
+	defer cleanup()
+	functionDir := writeFunctionHandler(t, workDir, "one", "handle() { printf '%s' \"$1\"; }\n")
+	registration := registerFunction(t, client, functionDir, "run-uid-1", 1, "sha256:first")
+
+	resp, err := client.InvokeFunction(context.Background(), &pb.InvokeFunctionRequest{
+		Registration: registration,
+		InvocationId: "invoke-1",
+		Input:        []byte(`{"message":"hello"}`),
+		ContentType:  "application/json",
+	})
+	if err != nil {
+		t.Fatalf("InvokeFunction: %v", err)
+	}
+	if got, want := string(resp.Output), `{"message":"hello"}`; got != want {
+		t.Fatalf("output = %q, want %q", got, want)
+	}
+
+	statusResp, err := client.FunctionStatus(context.Background(), &pb.FunctionStatusRequest{Registration: registration})
+	if err != nil {
+		t.Fatalf("FunctionStatus: %v", err)
+	}
+	if statusResp.State != pb.FunctionRegistrationState_FUNCTION_REGISTRATION_STATE_READY || statusResp.InFlight != 0 || statusResp.LastActivityUnixNano == 0 {
+		t.Fatalf("status = %#v", statusResp)
+	}
+
+	if _, err := client.UnregisterFunction(context.Background(), &pb.UnregisterFunctionRequest{Registration: registration}); err != nil {
+		t.Fatalf("UnregisterFunction: %v", err)
+	}
+	if _, err := client.FunctionStatus(context.Background(), &pb.FunctionStatusRequest{Registration: registration}); status.Code(err) != codes.NotFound {
+		t.Fatalf("FunctionStatus after unregister = %v, want NotFound", err)
+	}
+}
+
+func TestFunctionRuntimeRegistrationFencing(t *testing.T) {
+	client, workDir, cleanup := startFunctionTestServer(t, defaultOutputLimitBytes)
+	defer cleanup()
+	functionDir := writeFunctionHandler(t, workDir, "fence", "handle() { printf '{}'; }\n")
+	first := registerFunction(t, client, functionDir, "run-uid-2", 1, "sha256:first")
+
+	idempotent := registerFunction(t, client, functionDir, "run-uid-2", 1, "sha256:first")
+	if idempotent.RegistrationId != first.RegistrationId {
+		t.Fatalf("idempotent registration ID = %q, want %q", idempotent.RegistrationId, first.RegistrationId)
+	}
+	if _, err := client.RegisterFunction(context.Background(), &pb.RegisterFunctionRequest{
+		RunUid: "run-uid-2", RegistrationAttempt: 1, WorkingDir: functionDir, Handler: "handler.handle", RegistrationDigest: "sha256:changed",
+	}); status.Code(err) != codes.AlreadyExists {
+		t.Fatalf("same attempt with changed digest = %v, want AlreadyExists", err)
+	}
+
+	second := registerFunction(t, client, functionDir, "run-uid-2", 2, "sha256:second")
+	if second.RegistrationId == first.RegistrationId {
+		t.Fatal("new registration attempt reused its registration ID")
+	}
+	if _, err := client.InvokeFunction(context.Background(), &pb.InvokeFunctionRequest{
+		Registration: first, InvocationId: "stale", Input: []byte(`{}`), ContentType: "application/json",
+	}); status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("InvokeFunction with stale registration = %v, want FailedPrecondition", err)
+	}
+}
+
+func TestFunctionRuntimeDoesNotInterpretInputAsShell(t *testing.T) {
+	client, workDir, cleanup := startFunctionTestServer(t, defaultOutputLimitBytes)
+	defer cleanup()
+	functionDir := writeFunctionHandler(t, workDir, "safe", "handle() { printf '%s' \"$1\"; }\n")
+	registration := registerFunction(t, client, functionDir, "run-uid-3", 1, "sha256:safe")
+	marker := filepath.Join(workDir, "must-not-exist")
+	input := fmt.Sprintf(`{"value":"$(touch %s)"}`, marker)
+
+	resp, err := client.InvokeFunction(context.Background(), &pb.InvokeFunctionRequest{
+		Registration: registration, InvocationId: "safe-input", Input: []byte(input), ContentType: "application/json",
+	})
+	if err != nil {
+		t.Fatalf("InvokeFunction: %v", err)
+	}
+	if got := string(resp.Output); got != input {
+		t.Fatalf("output = %q, want original input", got)
+	}
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("input was interpreted as shell source; marker stat error = %v", err)
+	}
+}
+
+func TestFunctionRuntimeRejectsInvalidInputAndBoundsOutput(t *testing.T) {
+	client, workDir, cleanup := startFunctionTestServer(t, 16)
+	defer cleanup()
+	functionDir := writeFunctionHandler(t, workDir, "limits", "handle() { printf '%s' '0123456789abcdefx'; }\n")
+	registration := registerFunction(t, client, functionDir, "run-uid-4", 1, "sha256:limits")
+
+	if _, err := client.InvokeFunction(context.Background(), &pb.InvokeFunctionRequest{
+		Registration: registration, InvocationId: "bad-type", Input: []byte(`{}`), ContentType: "text/plain",
+	}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("InvokeFunction unsupported content type = %v, want InvalidArgument", err)
+	}
+	if _, err := client.InvokeFunction(context.Background(), &pb.InvokeFunctionRequest{
+		Registration: registration, InvocationId: "too-large", Input: []byte(`{}`), ContentType: "application/json",
+	}); status.Code(err) != codes.ResourceExhausted {
+		t.Fatalf("InvokeFunction oversized response = %v, want ResourceExhausted", err)
+	}
+}
+
+func TestFunctionRuntimeRejectsMissingHandlerAndEscapingWorkspace(t *testing.T) {
+	client, workDir, cleanup := startFunctionTestServer(t, defaultOutputLimitBytes)
+	defer cleanup()
+	functionDir := writeFunctionHandler(t, workDir, "validation", "other() { printf '{}'; }\n")
+	if _, err := client.RegisterFunction(context.Background(), &pb.RegisterFunctionRequest{
+		RunUid: "run-uid-missing-handler", RegistrationAttempt: 1, WorkingDir: functionDir, Handler: "handler.handle", RegistrationDigest: "sha256:missing",
+	}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("RegisterFunction missing handler = %v, want InvalidArgument", err)
+	}
+
+	externalDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(externalDir, "handler.sh"), []byte("handle() { printf '{}'; }\n"), 0o644); err != nil {
+		t.Fatalf("write external handler: %v", err)
+	}
+	escapingLink := filepath.Join(workDir, "escaping")
+	if err := os.Symlink(externalDir, escapingLink); err != nil {
+		t.Fatalf("create workspace symlink: %v", err)
+	}
+	if _, err := client.RegisterFunction(context.Background(), &pb.RegisterFunctionRequest{
+		RunUid: "run-uid-escaping-workspace", RegistrationAttempt: 1, WorkingDir: escapingLink, Handler: "handler.handle", RegistrationDigest: "sha256:escaping",
+	}); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("RegisterFunction escaping workspace = %v, want InvalidArgument", err)
+	}
+}
+
+func TestFunctionRuntimeUnregisterCancelsInFlightInvocation(t *testing.T) {
+	client, workDir, cleanup := startFunctionTestServer(t, defaultOutputLimitBytes)
+	defer cleanup()
+	functionDir := writeFunctionHandler(t, workDir, "cancel", "handle() { sleep 30; printf '{}'; }\n")
+	registration := registerFunction(t, client, functionDir, "run-uid-cancel", 1, "sha256:cancel")
+
+	invokeResult := make(chan error, 1)
+	go func() {
+		_, err := client.InvokeFunction(context.Background(), &pb.InvokeFunctionRequest{
+			Registration: registration, InvocationId: "invoke-cancel", Input: []byte(`{}`), ContentType: "application/json",
+		})
+		invokeResult <- err
+	}()
+	for deadline := time.Now().Add(5 * time.Second); time.Now().Before(deadline); {
+		functionStatus, err := client.FunctionStatus(context.Background(), &pb.FunctionStatusRequest{Registration: registration})
+		if err != nil {
+			t.Fatalf("FunctionStatus: %v", err)
+		}
+		if functionStatus.InFlight == 1 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if _, err := client.UnregisterFunction(context.Background(), &pb.UnregisterFunctionRequest{
+		Registration: registration, CancelInFlight: true, DrainTimeoutMillis: 5_000,
+	}); err != nil {
+		t.Fatalf("UnregisterFunction: %v", err)
+	}
+	if err := <-invokeResult; status.Code(err) != codes.Canceled {
+		t.Fatalf("InvokeFunction after cancellation = %v, want Canceled", err)
+	}
+}
+
 func TestCreateAndGetTask_Success(t *testing.T) {
 	client, cleanup := startTestServer(t)
 	defer cleanup()

--- a/runtimes/bash/server_test.go
+++ b/runtimes/bash/server_test.go
@@ -125,6 +125,21 @@ func TestFunctionRuntimeRegisterInvokeAndUnregister(t *testing.T) {
 	if got, want := string(resp.Output), `{"message":"hello"}`; got != want {
 		t.Fatalf("output = %q, want %q", got, want)
 	}
+	if resp.InvocationId != "invoke-1" {
+		t.Fatalf("invocation ID = %q, want caller-provided ID", resp.InvocationId)
+	}
+
+	generated, err := client.InvokeFunction(context.Background(), &pb.InvokeFunctionRequest{
+		Registration: registration,
+		Input:        []byte(`{"message":"generated"}`),
+		ContentType:  "application/json",
+	})
+	if err != nil {
+		t.Fatalf("InvokeFunction without ID: %v", err)
+	}
+	if !strings.HasPrefix(generated.InvocationId, "inv_") {
+		t.Fatalf("generated invocation ID = %q, want inv_ prefix", generated.InvocationId)
+	}
 
 	statusResp, err := client.FunctionStatus(context.Background(), &pb.FunctionStatusRequest{Registration: registration})
 	if err != nil {


### PR DESCRIPTION
## Summary
- implement the Bash FunctionRuntime register, status, invoke, and unregister operations
- validate handlers and workspace containment; fence registrations and serialize invocations
- document Bash adapter completion in the v0.x roadmap

## Validation
- `make test`
- `make test-integration`