### PR TITLE
refactor(scheduler): add scheduling framework core

### DIFF
--- a/docs/design/scheduler-framework.md
+++ b/docs/design/scheduler-framework.md
@@ -1,7 +1,6 @@
 # Scheduler Framework
 
-Status: **Proposal; review required before implementation or affinity API
-semantics change**
+Status: **Accepted; Scheduler Framework core implementation in progress**
 
 This document defines the target scheduling architecture for kruntimes. It
 replaces the current model of independently reconciling each Pending Run with
@@ -179,8 +178,10 @@ names, selectors, and Pod names must not be metric labels.
 
 1. Review this architecture and update the Run affinity design to make this
    document authoritative for scheduling execution semantics.
-2. Refactor scheduler internals behind a queue/planner interface while
-   preserving current one-Run observable behavior and existing metrics.
+2. Refactor scheduler internals behind the controller-runtime queue and a
+   snapshot/planning interface while preserving current one-Run observable
+   behavior and existing metrics. This core step is in progress; it does not
+   introduce assumed reservations or affinity semantics.
 3. Implement snapshot, PreFilter, Filter, Score, Reserve/Assume, and Bind with
    unit tests for deterministic selection, assumed capacity accounting, and bind
    conflicts.

--- a/docs/design/scheduler-framework.zh.md
+++ b/docs/design/scheduler-framework.zh.md
@@ -4,7 +4,7 @@ title: "Scheduler Framework"
 
 # Scheduler Framework
 
-状态：**Proposal；实现或改变 affinity API 语义前必须 review**
+状态：**Accepted；Scheduler Framework core 实现中**
 
 本文定义 kruntimes 的目标调度架构。它将当前“每个 Pending Run 独立 reconcile”的模型替换为 scheduler
 queue 与单 Run scheduling cycle。每个 cycle 针对一个 Run，读取 Runtime Pods、active assignments 和
@@ -148,8 +148,9 @@ selectors 和 Pod names 不能作为 metric labels。
 ## 实现顺序
 
 1. Review 本架构，并更新 Run affinity design，使本文成为 scheduling execution semantics 的权威来源。
-2. 在 queue/planner interface 后重构 scheduler internals，同时保留当前 one-Run observable behavior 与
-   existing metrics。
+2. 在 controller-runtime queue 和 snapshot/planning interface 后重构 scheduler internals，同时保留当前
+   one-Run observable behavior 与 existing metrics。该 core 步骤正在实现；它不会引入 assumed reservation
+   或 affinity semantics。
 3. 实现 Snapshot、PreFilter、Filter、Score、Reserve/Assume 和 Bind，并增加 deterministic selection、assumed
    capacity accounting 和 bind conflicts 的 unit tests。
 4. 实现 assumed-target matching 和 Run 间亲和性 bootstrap，并增加 integration 与 E2E coverage。

--- a/internal/scheduler/framework.go
+++ b/internal/scheduler/framework.go
@@ -1,0 +1,90 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+// schedulingSnapshot is the consistent scheduler input for one Run key. The
+// controller-runtime workqueue owns key activation; a worker builds one
+// snapshot and makes one placement decision for that key at a time.
+type schedulingSnapshot struct {
+	run        *v1alpha1.Run
+	request    corev1.ResourceList
+	pods       []corev1.Pod
+	usageByPod map[string]corev1.ResourceList
+	now        time.Time
+}
+
+type schedulingPlan struct {
+	action   schedulingPlanAction
+	selected *corev1.Pod
+}
+
+type schedulingPlanAction string
+
+const (
+	schedulingPlanWait schedulingPlanAction = "Wait"
+	schedulingPlanBind schedulingPlanAction = "Bind"
+)
+
+// loadSchedulingSnapshot performs the Snapshot and PreFilter framework
+// phases. Resource request validation and the Runtime selector are derived
+// once, before Pod filtering starts.
+func (r *RunReconciler) loadSchedulingSnapshot(ctx context.Context, run *v1alpha1.Run, request corev1.ResourceList) (*schedulingSnapshot, error) {
+	requirement, err := labels.NewRequirement("runtime", selection.Equals, []string{run.Spec.Runtime})
+	if err != nil {
+		return nil, fmt.Errorf("pre-filter runtime selector: %w", err)
+	}
+
+	var podList corev1.PodList
+	if err := r.List(ctx, &podList, &client.ListOptions{
+		Namespace:     run.Namespace,
+		LabelSelector: labels.NewSelector().Add(*requirement),
+	}); err != nil {
+		return nil, fmt.Errorf("snapshot runtime pods: %w", err)
+	}
+
+	usageByPod, err := r.assignedRunUsage(ctx, run.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot assigned run usage: %w", err)
+	}
+
+	return &schedulingSnapshot{
+		run:        run,
+		request:    request,
+		pods:       podList.Items,
+		usageByPod: usageByPod,
+		now:        time.Now(),
+	}, nil
+}
+
+// planSchedulingCycle applies the Filter and Score phases to one snapshot.
+// Reserve/Assume is intentionally not part of this core refactor; it requires
+// a separate, reviewed local reservation lifecycle.
+func (r *RunReconciler) planSchedulingCycle(snapshot *schedulingSnapshot) (schedulingPlan, error) {
+	candidates := make([]corev1.Pod, 0, len(snapshot.pods))
+	for i := range snapshot.pods {
+		pod := &snapshot.pods[i]
+		if r.isRuntimePodAvailable(pod, snapshot.now, snapshot.usageByPod[pod.Name], snapshot.request) {
+			candidates = append(candidates, *pod)
+		}
+	}
+	if len(candidates) == 0 {
+		return schedulingPlan{action: schedulingPlanWait}, nil
+	}
+
+	selected, err := r.Strategy.Select(candidates, snapshot.usageByPod, snapshot.run)
+	if err != nil {
+		return schedulingPlan{}, fmt.Errorf("score runtime pods: %w", err)
+	}
+	return schedulingPlan{action: schedulingPlanBind, selected: selected}, nil
+}

--- a/internal/scheduler/framework_test.go
+++ b/internal/scheduler/framework_test.go
@@ -1,0 +1,65 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	"github.com/kruntimes/kruntimes/internal/runtimepod"
+)
+
+func TestPlanSchedulingCycle(t *testing.T) {
+	now := time.Now()
+	run := &v1alpha1.Run{Spec: v1alpha1.RunSpec{Runtime: "bash"}}
+	request, err := run.Spec.ResourceRequests()
+	if err != nil {
+		t.Fatalf("resource requests: %v", err)
+	}
+	reconciler := &RunReconciler{
+		Strategy:                    &LeastLoaded{},
+		RuntimedHeartbeatStaleAfter: time.Minute,
+	}
+
+	plan, err := reconciler.planSchedulingCycle(&schedulingSnapshot{
+		run:     run,
+		request: request,
+		now:     now,
+	})
+	if err != nil {
+		t.Fatalf("plan empty snapshot: %v", err)
+	}
+	if plan.action != schedulingPlanWait || plan.selected != nil {
+		t.Fatalf("empty plan = %#v, want Wait without a selected Pod", plan)
+	}
+
+	pod := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "runtime-a",
+			Annotations: map[string]string{
+				runtimepod.CapacityAnnotation(v1alpha1.RuntimeResourceRuns): "2",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				{Type: v1alpha1.RuntimePodRuntimedReadyCondition, Status: corev1.ConditionTrue, LastProbeTime: metav1.NewTime(now)},
+			},
+		},
+	}
+	plan, err = reconciler.planSchedulingCycle(&schedulingSnapshot{
+		run:     run,
+		request: request,
+		pods:    []corev1.Pod{pod},
+		now:     now,
+	})
+	if err != nil {
+		t.Fatalf("plan schedulable snapshot: %v", err)
+	}
+	if plan.action != schedulingPlanBind || plan.selected == nil || plan.selected.Name != pod.Name {
+		t.Fatalf("schedulable plan = %#v, want Bind for %q", plan, pod.Name)
+	}
+}

--- a/internal/scheduler/reconciler.go
+++ b/internal/scheduler/reconciler.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -12,8 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -105,7 +104,6 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	if err != nil {
 		return r.applyInvalidResources(ctx, &run, err)
 	}
-
 	log.Info("Scheduling run", "runtime", run.Spec.Runtime)
 	start := time.Now()
 	defer func() {
@@ -116,34 +114,26 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{RequeueAfter: retryDelay}, nil
 	}
 
-	reqLabel, err := labels.NewRequirement("runtime", selection.Equals, []string{run.Spec.Runtime})
+	snapshot, err := r.loadSchedulingSnapshot(ctx, &run, request)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("build label requirement: %w", err)
+		return ctrl.Result{}, err
 	}
-	sel := labels.NewSelector().Add(*reqLabel)
-
-	var pods corev1.PodList
-	if err := r.List(ctx, &pods, &client.ListOptions{
-		Namespace:     req.Namespace,
-		LabelSelector: sel,
-	}); err != nil {
-		return ctrl.Result{}, fmt.Errorf("list runtime pods: %w", err)
-	}
-
-	usageByPod, err := r.assignedRunUsage(ctx, req.Namespace)
+	plan, err := r.planSchedulingCycle(snapshot)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("list assigned runs: %w", err)
-	}
-
-	now := time.Now()
-	var candidates []corev1.Pod
-	for _, pod := range pods.Items {
-		if r.isRuntimePodAvailable(&pod, now, usageByPod[pod.Name], request) {
-			candidates = append(candidates, pod)
+		noPodsTotal.WithLabelValues(run.Spec.Runtime).Inc()
+		run.Status.Phase = v1alpha1.RunFailed
+		run.Status.Message = fmt.Sprintf("pod selection failed: %v", err)
+		if err := r.Status().Update(ctx, &run); err != nil {
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, fmt.Errorf("update selection failure status: %w", err)
 		}
+		runsScheduled.WithLabelValues(run.Spec.Runtime, "selection_error").Inc()
+		return ctrl.Result{}, nil
 	}
 
-	if len(candidates) == 0 {
+	if plan.action == schedulingPlanWait {
 		noPodsTotal.WithLabelValues(run.Spec.Runtime).Inc()
 		log.Info("No available runtime pods", "runtime", run.Spec.Runtime)
 
@@ -158,29 +148,19 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		runsScheduled.WithLabelValues(run.Spec.Runtime, "no_pods").Inc()
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
-
-	selected, err := r.Strategy.Select(candidates, usageByPod, &run)
-	if err != nil {
-		noPodsTotal.WithLabelValues(run.Spec.Runtime).Inc()
-
-		run.Status.Phase = v1alpha1.RunFailed
-		run.Status.Message = fmt.Sprintf("pod selection failed: %v", err)
-		if err := r.Status().Update(ctx, &run); err != nil {
-			return ctrl.Result{}, fmt.Errorf("update run status: %w", err)
-		}
-		runsScheduled.WithLabelValues(run.Spec.Runtime, "selection_error").Inc()
-		return ctrl.Result{}, nil
+	if plan.action != schedulingPlanBind || plan.selected == nil {
+		return ctrl.Result{}, fmt.Errorf("apply scheduling plan: unsupported action %q", plan.action)
 	}
 
-	run.Status.AssignedPod = selected.Name
-	run.Status.AssignedPodUID = string(selected.UID)
+	run.Status.AssignedPod = plan.selected.Name
+	run.Status.AssignedPodUID = string(plan.selected.UID)
 	run.Status.Phase = v1alpha1.RunScheduled
 	scheduledAt := metav1.Now()
 	meta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{
 		Type:               runstatus.ConditionScheduled,
 		Status:             metav1.ConditionTrue,
 		Reason:             "Assigned",
-		Message:            fmt.Sprintf("assigned to runtime pod %s", selected.Name),
+		Message:            fmt.Sprintf("assigned to runtime pod %s", plan.selected.Name),
 		LastTransitionTime: scheduledAt,
 	})
 	if err := r.Status().Update(ctx, &run); err != nil {
@@ -190,7 +170,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, fmt.Errorf("update run status: %w", err)
 	}
 
-	log.Info("Run scheduled", "pod", selected.Name)
+	log.Info("Run scheduled", "pod", plan.selected.Name)
 	runsScheduled.WithLabelValues(run.Spec.Runtime, "scheduled").Inc()
 	observeRunQueueDuration(&run, scheduledAt.Time)
 	return ctrl.Result{}, nil
@@ -326,6 +306,11 @@ func (r *RunReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.pendingRunsForReleasedCapacity),
 			builder.WithPredicates(runCapacityReleasedPredicate()),
 		).
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.pendingRunsForRuntimePod),
+			builder.WithPredicates(runtimePodSchedulingPredicate()),
+		).
 		Complete(r)
 }
 
@@ -334,17 +319,32 @@ func (r *RunReconciler) pendingRunsForReleasedCapacity(ctx context.Context, obje
 	if !ok || run.Spec.Runtime == "" {
 		return nil
 	}
+	return r.pendingRunsForRuntime(ctx, run.Namespace, run.Spec.Runtime, "released runtime capacity")
+}
 
+func (r *RunReconciler) pendingRunsForRuntimePod(ctx context.Context, object client.Object) []reconcile.Request {
+	pod, ok := object.(*corev1.Pod)
+	if !ok {
+		return nil
+	}
+	runtimeName := pod.Labels["runtime"]
+	if runtimeName == "" {
+		return nil
+	}
+	return r.pendingRunsForRuntime(ctx, pod.Namespace, runtimeName, "runtime pod scheduling change")
+}
+
+func (r *RunReconciler) pendingRunsForRuntime(ctx context.Context, namespace, runtimeName, source string) []reconcile.Request {
 	var runs v1alpha1.RunList
-	if err := r.List(ctx, &runs, client.InNamespace(run.Namespace)); err != nil {
-		r.Log.Error(err, "unable to list pending runs for released runtime capacity", "run", client.ObjectKeyFromObject(run))
+	if err := r.List(ctx, &runs, client.InNamespace(namespace)); err != nil {
+		r.Log.Error(err, "unable to list pending runs", "source", source, "namespace", namespace, "runtime", runtimeName)
 		return nil
 	}
 
 	requests := make([]reconcile.Request, 0, len(runs.Items))
 	for i := range runs.Items {
 		pending := &runs.Items[i]
-		if pending.Spec.Runtime != run.Spec.Runtime {
+		if pending.Spec.Runtime != runtimeName {
 			continue
 		}
 		if pending.Status.Phase != "" && pending.Status.Phase != v1alpha1.RunPending {
@@ -353,6 +353,71 @@ func (r *RunReconciler) pendingRunsForReleasedCapacity(ctx context.Context, obje
 		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pending)})
 	}
 	return requests
+}
+
+func runtimePodSchedulingPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return runtimePodName(e.Object) != ""
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldPod, oldOK := e.ObjectOld.(*corev1.Pod)
+			newPod, newOK := e.ObjectNew.(*corev1.Pod)
+			if !oldOK || !newOK {
+				return false
+			}
+			if runtimePodName(oldPod) == "" && runtimePodName(newPod) == "" {
+				return false
+			}
+			return !reflect.DeepEqual(schedulingStateForRuntimePod(oldPod), schedulingStateForRuntimePod(newPod))
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return runtimePodName(e.Object) != ""
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+type runtimePodSchedulingState struct {
+	runtimeName   string
+	phase         corev1.PodPhase
+	deleting      bool
+	podReady      corev1.ConditionStatus
+	runtimedReady *corev1.PodCondition
+	capacity      map[string]string
+}
+
+func schedulingStateForRuntimePod(pod *corev1.Pod) runtimePodSchedulingState {
+	state := runtimePodSchedulingState{
+		runtimeName: runtimePodName(pod),
+		phase:       pod.Status.Phase,
+		deleting:    pod.DeletionTimestamp != nil,
+		capacity:    map[string]string{},
+	}
+	for _, condition := range pod.Status.Conditions {
+		switch condition.Type {
+		case corev1.PodReady:
+			state.podReady = condition.Status
+		case v1alpha1.RuntimePodRuntimedReadyCondition:
+			conditionCopy := condition
+			state.runtimedReady = &conditionCopy
+		}
+	}
+	for key, value := range pod.Annotations {
+		if len(key) >= len(v1alpha1.RuntimePodCapacityAnnotationPrefix) && key[:len(v1alpha1.RuntimePodCapacityAnnotationPrefix)] == v1alpha1.RuntimePodCapacityAnnotationPrefix {
+			state.capacity[key] = value
+		}
+	}
+	return state
+}
+
+func runtimePodName(object client.Object) string {
+	if object == nil {
+		return ""
+	}
+	return object.GetLabels()["runtime"]
 }
 
 func pendingRunPredicate() predicate.Predicate {

--- a/internal/scheduler/reconciler_test.go
+++ b/internal/scheduler/reconciler_test.go
@@ -434,6 +434,103 @@ func TestPendingRunsForReleasedCapacity(t *testing.T) {
 	}
 }
 
+func TestPendingRunsForRuntimePod(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add kruntimes scheme: %v", err)
+	}
+
+	pendingSameRuntime := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "pending-same-runtime", Namespace: "default"},
+		Spec:       v1alpha1.RunSpec{Runtime: "bash"},
+		Status:     v1alpha1.RunStatus{Phase: v1alpha1.RunPending},
+	}
+	pendingOtherRuntime := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "pending-other-runtime", Namespace: "default"},
+		Spec:       v1alpha1.RunSpec{Runtime: "python"},
+		Status:     v1alpha1.RunStatus{Phase: v1alpha1.RunPending},
+	}
+	scheduledSameRuntime := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "scheduled-same-runtime", Namespace: "default"},
+		Spec:       v1alpha1.RunSpec{Runtime: "bash"},
+		Status:     v1alpha1.RunStatus{Phase: v1alpha1.RunScheduled},
+	}
+	pendingOtherNamespace := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: "pending-other-namespace", Namespace: "other"},
+		Spec:       v1alpha1.RunSpec{Runtime: "bash"},
+		Status:     v1alpha1.RunStatus{Phase: v1alpha1.RunPending},
+	}
+	k8sClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pendingSameRuntime, pendingOtherRuntime, scheduledSameRuntime, pendingOtherNamespace).
+		Build()
+	reconciler := &RunReconciler{Client: k8sClient, Log: logr.Discard()}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "runtime-bash",
+		Namespace: "default",
+		Labels:    map[string]string{"runtime": "bash"},
+	}}
+
+	requests := reconciler.pendingRunsForRuntimePod(context.Background(), pod)
+	if len(requests) != 1 || requests[0].NamespacedName.String() != "default/pending-same-runtime" {
+		t.Fatalf("requests = %v, want [default/pending-same-runtime]", requests)
+	}
+	if requests := reconciler.pendingRunsForRuntimePod(context.Background(), &corev1.Pod{}); len(requests) != 0 {
+		t.Fatalf("requests without runtime label = %v, want none", requests)
+	}
+}
+
+func TestRuntimePodSchedulingPredicate(t *testing.T) {
+	predicate := runtimePodSchedulingPredicate()
+	now := metav1.Now()
+	base := func() *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"runtime": "bash"},
+				Annotations: map[string]string{
+					runtimepod.CapacityAnnotation(v1alpha1.RuntimeResourceRuns): "2",
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					{Type: v1alpha1.RuntimePodRuntimedReadyCondition, Status: corev1.ConditionTrue, LastProbeTime: now},
+				},
+			},
+		}
+	}
+
+	if !predicate.Create(event.CreateEvent{Object: base()}) {
+		t.Fatal("Create() = false, want true for Runtime Pod")
+	}
+	if predicate.Create(event.CreateEvent{Object: &corev1.Pod{}}) {
+		t.Fatal("Create() = true, want false for unrelated Pod")
+	}
+	if predicate.Update(event.UpdateEvent{ObjectOld: base(), ObjectNew: base()}) {
+		t.Fatal("Update() = true, want false for unchanged Runtime Pod")
+	}
+
+	readyChanged := base()
+	readyChanged.Status.Conditions[0].Status = corev1.ConditionFalse
+	if !predicate.Update(event.UpdateEvent{ObjectOld: base(), ObjectNew: readyChanged}) {
+		t.Fatal("Update() = false, want true when Pod readiness changes")
+	}
+
+	capacityChanged := base()
+	capacityChanged.Annotations[runtimepod.CapacityAnnotation(v1alpha1.RuntimeResourceRuns)] = "3"
+	if !predicate.Update(event.UpdateEvent{ObjectOld: base(), ObjectNew: capacityChanged}) {
+		t.Fatal("Update() = false, want true when Runtime Pod capacity changes")
+	}
+
+	if !predicate.Delete(event.DeleteEvent{Object: base()}) {
+		t.Fatal("Delete() = false, want true for Runtime Pod")
+	}
+}
+
 func TestRunCapacityReleasedPredicate(t *testing.T) {
 	pred := runCapacityReleasedPredicate()
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1511,6 +1511,51 @@ func TestSchedulerKeepsRunPendingWithoutRuntimePod(t *testing.T) {
 	}
 }
 
+func TestSchedulerReactivatesPendingRunWhenRuntimePodBecomesReady(t *testing.T) {
+	runtimeName := fmt.Sprintf("scheduler-wakeup-%d", time.Now().UnixNano())
+	run := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "e2e-runtime-wakeup-",
+			Namespace:    testNamespace,
+		},
+		Spec: v1alpha1.RunSpec{
+			Runtime: runtimeName,
+			Mode:    taskMode("echo runtime-ready"),
+		},
+	}
+	if err := k8sClient.Create(context.Background(), run); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	defer func() { _ = k8sClient.Delete(context.Background(), run) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	for {
+		time.Sleep(200 * time.Millisecond)
+		if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(run), run); err != nil {
+			t.Fatalf("get pending run: %v", err)
+		}
+		if run.Status.Phase == v1alpha1.RunPending &&
+			strings.Contains(run.Status.Message, "waiting for available runtime pods") {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for pending run observation, phase=%s msg=%s", run.Status.Phase, run.Status.Message)
+		default:
+		}
+	}
+
+	// The Runtime Pod create/ready events must reactivate this Run before the
+	// scheduler's 30-second no-capacity polling fallback.
+	started := time.Now()
+	ensureRuntime(t, runtimeName, bashRuntimeImage(), 9091)
+	waitForRun(t, run, 20*time.Second)
+	if elapsed := time.Since(started); elapsed >= 30*time.Second {
+		t.Fatalf("pending Run completed after %s, want Runtime Pod event wakeup before polling fallback", elapsed)
+	}
+}
+
 func TestSchedulerKeepsRunPendingWhenRuntimeAtCapacity(t *testing.T) {
 	runtimeName := "bash-capacity"
 	ensureRuntimeWithRunsCapacity(t, runtimeName, bashRuntimeImage(), 9091, 1)


### PR DESCRIPTION
## Summary
- split one-Run scheduling into explicit Snapshot/PreFilter and Filter/Score planning phases
- use controller-runtime's queue to reactivate matching Pending Runs when Runtime Pod readiness, runtimed heartbeat, capacity, lifecycle, or runtime label changes
- retain existing Pending, Failed, and Scheduled behavior; do not add assumed reservations or affinity semantics
- add E2E coverage that verifies a Pending Run is reactivated when a matching Runtime Pod becomes ready, before the polling fallback
- update the Scheduler Framework design status and implementation boundary

## Tests
- make test
- make test-integration
- E2E workflow: https://github.com/kruntimes/kruntimes/actions/runs/30422550204