### PR TITLE
feat(scheduler): reserve runtime pod capacity

### DIFF
--- a/docs/design/scheduler-framework.md
+++ b/docs/design/scheduler-framework.md
@@ -1,6 +1,6 @@
 # Scheduler Framework
 
-Status: **Accepted; Scheduler Framework core implementation in progress**
+Status: **Accepted; Reserve/Assume/Bind implementation complete**
 
 This document defines the target scheduling architecture for kruntimes. It
 replaces the current model of independently reconciling each Pending Run with
@@ -95,10 +95,11 @@ counters, or user-visible status fields.
 ### Reservation Lifecycle
 
 The assumed cache is keyed by immutable `(namespace, Run UID)`. Each entry
-stores the Run name and resource version used for the cycle, selected Pod name
-and UID, and the complete logical resource request. A mutex protects reserve,
-release, and snapshot accounting so concurrent queue workers cannot reserve the
-same capacity twice.
+stores the Run name, selected Pod name, and complete logical resource request.
+The Run object passed to Bind retains its observed resource version, so the
+Kubernetes status update itself detects concurrent changes. A mutex protects
+reserve, release, and snapshot accounting so concurrent queue workers cannot
+reserve the same capacity twice.
 
 Snapshot accounting is:
 
@@ -109,8 +110,10 @@ effectiveUsage[pod] = activeAssignedRunUsage[pod] + unconfirmedAssumedUsage[pod]
 Before adding assumed usage, the scheduler reconciles the cache against the
 Run list in the snapshot. An assumption is removed when its Run is observed as
 an active assignment to the same Pod, because the active Run usage now owns the
-reservation. It is also removed when the same Run UID is terminal, Pending, or
-assigned to a different Pod. This makes the handoff from assumed to actual
+reservation. It is also removed when the same Run UID is terminal, absent, or
+assigned to a different Pod. A Pending observation retains an assumption: an
+informer can still be behind a successful Bind, and dropping it during that
+window would permit overcommit. This makes the handoff from assumed to actual
 usage exact and prevents double-counting.
 
 `Reserve` atomically verifies that the selected Pod still has capacity after
@@ -217,7 +220,7 @@ names, selectors, and Pod names must not be metric labels.
    introduce assumed reservations or affinity semantics.
 3. Implement Reserve/Assume and Bind with unit tests for deterministic
    selection, assumed capacity accounting, handoff to actual assignments, and
-   bind conflicts.
+   bind conflicts. This step is complete.
 4. Implement assumed-target matching and Inter-Run Affinity bootstrap with
    integration and E2E coverage.
 5. Add priority only after a separate API and fairness design review.

--- a/docs/design/scheduler-framework.zh.md
+++ b/docs/design/scheduler-framework.zh.md
@@ -4,7 +4,7 @@ title: "Scheduler Framework"
 
 # Scheduler Framework
 
-状态：**Accepted；Scheduler Framework core 实现中**
+状态：**Accepted；Reserve/Assume/Bind 实现完成**
 
 本文定义 kruntimes 的目标调度架构。它将当前“每个 Pending Run 独立 reconcile”的模型替换为 scheduler
 queue 与单 Run scheduling cycle。每个 cycle 针对一个 Run，读取 Runtime Pods、active assignments 和
@@ -80,9 +80,9 @@ capacity counter 或 user-visible status 字段持久化。
 
 ### Reservation 生命周期
 
-assumed cache 按 immutable 的 `(namespace, Run UID)` 建键。每一项保存本 cycle 使用的 Run name 和
-resource version、选中的 Pod name 和 UID，以及完整 logical resource request。mutex 保护 reserve、release 和
-snapshot accounting，使并发 queue workers 不会重复预留同一份 capacity。
+assumed cache 按 immutable 的 `(namespace, Run UID)` 建键。每一项保存 Run name、选中的 Pod name 以及完整 logical
+resource request。传入 Bind 的 Run object 保留了观察到的 resource version，因此 Kubernetes 的 status update 自身会
+检测并发变更。mutex 保护 reserve、release 和 snapshot accounting，使并发 queue workers 不会重复预留同一份 capacity。
 
 snapshot accounting 为：
 
@@ -92,8 +92,9 @@ effectiveUsage[pod] = activeAssignedRunUsage[pod] + unconfirmedAssumedUsage[pod]
 
 在加入 assumed usage 前，scheduler 将 cache 与 snapshot 中的 Run list 对账。当对应 Run 被观察为同一 Pod 上的
 active assignment 时，删除 assumption，因为此时 active Run usage 接管 reservation。若同一 Run UID 已 terminal、
-变为 Pending，或被分配到其他 Pod，也删除 assumption。这样 assumed usage 到 actual usage 的 handoff 是精确的，
-不会 double-count。
+不存在，或被分配到其他 Pod，也删除 assumption。观察到 `Pending` 时必须保留 assumption：informer 可能尚未看到
+成功的 Bind，若在此窗口删除会允许 overcommit。这样 assumed usage 到 actual usage 的 handoff 是精确的，不会
+double-count。
 
 `Reserve` 会原子地确认选中 Pod 在考虑全部现有 assumptions 后仍有 capacity，然后写入完整 request。`Bind`
 将 Run status patch 为选中 Pod 的 name 和 UID。成功 patch 后故意不释放 assumption：它保留到 informer 观察到
@@ -177,7 +178,7 @@ selectors 和 Pod names 不能作为 metric labels。
    one-Run observable behavior 与 existing metrics。该 core 步骤已完成；它不会引入 assumed reservation
    或 affinity semantics。
 3. 实现 Reserve/Assume 和 Bind，并增加 deterministic selection、assumed capacity accounting、handoff 到 actual
-   assignments 以及 bind conflicts 的 unit tests。
+   assignments 以及 bind conflicts 的 unit tests。此步骤已完成。
 4. 实现 assumed-target matching 和 Run 间亲和性 bootstrap，并增加 integration 与 E2E coverage。
 5. 只有经过独立 API 与 fairness design review 后，才加入 priority。
 

--- a/internal/scheduler/assumed_reservation_cache.go
+++ b/internal/scheduler/assumed_reservation_cache.go
@@ -1,0 +1,145 @@
+package scheduler
+
+import (
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+// assumedReservationCache owns assignments made after planning and before the
+// Run informer observes the persisted assignment. It keeps cleanup, resource
+// accounting, availability checks, and insertion in one critical section.
+type assumedReservationCache struct {
+	mu           sync.Mutex
+	reservations map[reservationKey]assumedReservation
+}
+
+// reservationKey identifies an assumed assignment by immutable Run UID. The
+// namespace is retained because the scheduler serves multiple namespaces.
+type reservationKey struct {
+	namespace string
+	runUID    types.UID
+}
+
+type assumedReservation struct {
+	runName string
+	podName string
+	request corev1.ResourceList
+}
+
+func reservationKeyFor(run *v1alpha1.Run) reservationKey {
+	return reservationKey{namespace: run.Namespace, runUID: run.UID}
+}
+
+func (c *assumedReservationCache) effectiveUsage(actual map[string]corev1.ResourceList, runs []v1alpha1.Run) map[string]corev1.ResourceList {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.syncLocked(runs)
+	return mergeUsage(actual, c.usageLocked())
+}
+
+func (c *assumedReservationCache) reserve(snapshot *schedulingSnapshot, pod *corev1.Pod, available func(corev1.ResourceList) bool) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.syncLocked(snapshot.runs)
+	usage := mergeUsage(snapshot.actualUsageByPod, c.usageLocked())
+	if !available(usage[pod.Name]) {
+		return false
+	}
+	c.assumeLocked(snapshot.run, pod.Name, snapshot.request)
+	return true
+}
+
+func (c *assumedReservationCache) observe(run *v1alpha1.Run) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := reservationKeyFor(run)
+	if _, ok := c.reservations[key]; ok && (run.Status.AssignedPod != "" || !isPendingRun(run)) {
+		delete(c.reservations, key)
+	}
+}
+
+func (c *assumedReservationCache) release(run *v1alpha1.Run) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.reservations, reservationKeyFor(run))
+}
+
+func (c *assumedReservationCache) assumeLocked(run *v1alpha1.Run, podName string, request corev1.ResourceList) {
+	if c.reservations == nil {
+		c.reservations = make(map[reservationKey]assumedReservation)
+	}
+	c.reservations[reservationKeyFor(run)] = assumedReservation{
+		runName: run.Name,
+		podName: podName,
+		request: cloneResourceList(request),
+	}
+}
+
+func (c *assumedReservationCache) syncLocked(runs []v1alpha1.Run) {
+	if len(c.reservations) == 0 {
+		return
+	}
+	byKey := make(map[reservationKey]*v1alpha1.Run, len(runs))
+	for i := range runs {
+		byKey[reservationKeyFor(&runs[i])] = &runs[i]
+	}
+	for key, reservation := range c.reservations {
+		run := byKey[key]
+		if run == nil || !isPendingRun(run) || run.Status.AssignedPod != "" || run.Name != reservation.runName {
+			delete(c.reservations, key)
+		}
+	}
+}
+
+func (c *assumedReservationCache) usageLocked() map[string]corev1.ResourceList {
+	usage := make(map[string]corev1.ResourceList)
+	for _, reservation := range c.reservations {
+		addUsage(usage, reservation.podName, reservation.request)
+	}
+	return usage
+}
+
+func isPendingRun(run *v1alpha1.Run) bool {
+	return run.Status.Phase == "" || run.Status.Phase == v1alpha1.RunPending
+}
+
+func mergeUsage(first, second map[string]corev1.ResourceList) map[string]corev1.ResourceList {
+	usage := make(map[string]corev1.ResourceList, len(first)+len(second))
+	for podName, resources := range first {
+		usage[podName] = cloneResourceList(resources)
+	}
+	for podName, resources := range second {
+		addUsage(usage, podName, resources)
+	}
+	return usage
+}
+
+func addUsage(usage map[string]corev1.ResourceList, podName string, request corev1.ResourceList) {
+	resources := usage[podName]
+	if resources == nil {
+		resources = corev1.ResourceList{}
+		usage[podName] = resources
+	}
+	for resourceName, quantity := range request {
+		total := resources[resourceName].DeepCopy()
+		total.Add(quantity)
+		resources[resourceName] = total
+	}
+}
+
+func cloneResourceList(resources corev1.ResourceList) corev1.ResourceList {
+	if resources == nil {
+		return nil
+	}
+	clone := make(corev1.ResourceList, len(resources))
+	for name, quantity := range resources {
+		clone[name] = quantity.DeepCopy()
+	}
+	return clone
+}

--- a/internal/scheduler/assumed_reservation_cache_test.go
+++ b/internal/scheduler/assumed_reservation_cache_test.go
@@ -1,0 +1,86 @@
+package scheduler
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+func TestAssumedReservationCacheReserveAccountsForExistingAssumptions(t *testing.T) {
+	cache := &assumedReservationCache{}
+	pod := &corev1.Pod{}
+	pod.Name = "runtime-a"
+	first := reservationTestRun("first", "first-uid")
+	second := reservationTestRun("second", "second-uid")
+	request := runResourceRequest(1)
+
+	if reserved := cache.reserve(cacheSnapshot(first, request, *first, *second), pod, func(usage corev1.ResourceList) bool {
+		usedRuns := usage[corev1.ResourceName(v1alpha1.RuntimeResourceRuns)]
+		return usedRuns.IsZero()
+	}); !reserved {
+		t.Fatal("reserve first Run = false, want true")
+	}
+
+	if reserved := cache.reserve(cacheSnapshot(second, request, *first, *second), pod, func(usage corev1.ResourceList) bool {
+		usedRuns := usage[corev1.ResourceName(v1alpha1.RuntimeResourceRuns)]
+		return usedRuns.CmpInt64(1) < 0
+	}); reserved {
+		t.Fatal("reserve second Run = true, want false after first assumption")
+	}
+}
+
+func TestAssumedReservationCacheHandsOffToObservedAssignment(t *testing.T) {
+	cache := &assumedReservationCache{}
+	pod := &corev1.Pod{}
+	pod.Name = "runtime-a"
+	run := reservationTestRun("run-a", "run-a-uid")
+	request := runResourceRequest(1)
+
+	if reserved := cache.reserve(cacheSnapshot(run, request, *run), pod, func(corev1.ResourceList) bool { return true }); !reserved {
+		t.Fatal("reserve Run = false, want true")
+	}
+	if got := cache.effectiveUsage(nil, []v1alpha1.Run{*run})[pod.Name][corev1.ResourceName(v1alpha1.RuntimeResourceRuns)]; got.CmpInt64(1) != 0 {
+		t.Fatalf("assumed runs usage = %s, want 1", got.String())
+	}
+
+	run.Status.Phase = v1alpha1.RunScheduled
+	run.Status.AssignedPod = pod.Name
+	actual := map[string]corev1.ResourceList{pod.Name: request}
+	usage := cache.effectiveUsage(actual, []v1alpha1.Run{*run})
+	if got := usage[pod.Name][corev1.ResourceName(v1alpha1.RuntimeResourceRuns)]; got.CmpInt64(1) != 0 {
+		t.Fatalf("effective runs usage = %s, want 1", got.String())
+	}
+}
+
+func TestAssumedReservationCacheReleaseRemovesAssumption(t *testing.T) {
+	cache := &assumedReservationCache{}
+	pod := &corev1.Pod{}
+	pod.Name = "runtime-a"
+	run := reservationTestRun("run-a", "run-a-uid")
+
+	if reserved := cache.reserve(cacheSnapshot(run, runResourceRequest(1), *run), pod, func(corev1.ResourceList) bool { return true }); !reserved {
+		t.Fatal("reserve Run = false, want true")
+	}
+	cache.release(run)
+	if _, ok := cache.effectiveUsage(nil, []v1alpha1.Run{*run})[pod.Name]; ok {
+		t.Fatal("assumed reservation remains after release")
+	}
+}
+
+func cacheSnapshot(run *v1alpha1.Run, request corev1.ResourceList, runs ...v1alpha1.Run) *schedulingSnapshot {
+	return &schedulingSnapshot{
+		run:              run,
+		request:          request,
+		actualUsageByPod: map[string]corev1.ResourceList{},
+		runs:             runs,
+	}
+}
+
+func runResourceRequest(runs int64) corev1.ResourceList {
+	return corev1.ResourceList{
+		corev1.ResourceName(v1alpha1.RuntimeResourceRuns): *resource.NewQuantity(runs, resource.DecimalSI),
+	}
+}

--- a/internal/scheduler/framework.go
+++ b/internal/scheduler/framework.go
@@ -17,11 +17,13 @@ import (
 // controller-runtime workqueue owns key activation; a worker builds one
 // snapshot and makes one placement decision for that key at a time.
 type schedulingSnapshot struct {
-	run        *v1alpha1.Run
-	request    corev1.ResourceList
-	pods       []corev1.Pod
-	usageByPod map[string]corev1.ResourceList
-	now        time.Time
+	run              *v1alpha1.Run
+	request          corev1.ResourceList
+	pods             []corev1.Pod
+	actualUsageByPod map[string]corev1.ResourceList
+	usageByPod       map[string]corev1.ResourceList
+	runs             []v1alpha1.Run
+	now              time.Time
 }
 
 type schedulingPlan struct {
@@ -53,23 +55,24 @@ func (r *RunReconciler) loadSchedulingSnapshot(ctx context.Context, run *v1alpha
 		return nil, fmt.Errorf("snapshot runtime pods: %w", err)
 	}
 
-	usageByPod, err := r.assignedRunUsage(ctx, run.Namespace)
+	runs, actualUsageByPod, err := r.assignedRunUsage(ctx, run.Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot assigned run usage: %w", err)
 	}
+	usageByPod := r.effectiveUsage(actualUsageByPod, runs)
 
 	return &schedulingSnapshot{
-		run:        run,
-		request:    request,
-		pods:       podList.Items,
-		usageByPod: usageByPod,
-		now:        time.Now(),
+		run:              run,
+		request:          request,
+		pods:             podList.Items,
+		actualUsageByPod: actualUsageByPod,
+		usageByPod:       usageByPod,
+		runs:             runs,
+		now:              time.Now(),
 	}, nil
 }
 
 // planSchedulingCycle applies the Filter and Score phases to one snapshot.
-// Reserve/Assume is intentionally not part of this core refactor; it requires
-// a separate, reviewed local reservation lifecycle.
 func (r *RunReconciler) planSchedulingCycle(snapshot *schedulingSnapshot) (schedulingPlan, error) {
 	candidates := make([]corev1.Pod, 0, len(snapshot.pods))
 	for i := range snapshot.pods {

--- a/internal/scheduler/reconciler.go
+++ b/internal/scheduler/reconciler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -75,8 +74,7 @@ type RunReconciler struct {
 	Strategy                    Strategy
 	RuntimedHeartbeatStaleAfter time.Duration
 
-	reservationMu sync.Mutex
-	assumed       map[reservationKey]assumedReservation
+	assumptions assumedReservationCache
 }
 
 // +kubebuilder:rbac:groups=kruntimes.io,resources=runs,verbs=get;list;watch;update;patch

--- a/internal/scheduler/reconciler.go
+++ b/internal/scheduler/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -73,6 +74,9 @@ type RunReconciler struct {
 	Log                         logr.Logger
 	Strategy                    Strategy
 	RuntimedHeartbeatStaleAfter time.Duration
+
+	reservationMu sync.Mutex
+	assumed       map[reservationKey]assumedReservation
 }
 
 // +kubebuilder:rbac:groups=kruntimes.io,resources=runs,verbs=get;list;watch;update;patch
@@ -89,6 +93,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		}
 		return ctrl.Result{}, fmt.Errorf("get run: %w", err)
 	}
+	r.observeRun(&run)
 
 	// Treat empty phase (CRD default not yet applied) as Pending.
 	if run.Status.Phase != "" && run.Status.Phase != v1alpha1.RunPending {
@@ -152,27 +157,20 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, fmt.Errorf("apply scheduling plan: unsupported action %q", plan.action)
 	}
 
-	run.Status.AssignedPod = plan.selected.Name
-	run.Status.AssignedPodUID = string(plan.selected.UID)
-	run.Status.Phase = v1alpha1.RunScheduled
-	scheduledAt := metav1.Now()
-	meta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{
-		Type:               runstatus.ConditionScheduled,
-		Status:             metav1.ConditionTrue,
-		Reason:             "Assigned",
-		Message:            fmt.Sprintf("assigned to runtime pod %s", plan.selected.Name),
-		LastTransitionTime: scheduledAt,
-	})
-	if err := r.Status().Update(ctx, &run); err != nil {
+	reserved := r.reserve(snapshot, plan.selected)
+	if !reserved {
+		return ctrl.Result{Requeue: true}, nil
+	}
+	if err := r.bind(ctx, &run, plan.selected); err != nil {
 		if apierrors.IsConflict(err) {
 			return ctrl.Result{Requeue: true}, nil
 		}
-		return ctrl.Result{}, fmt.Errorf("update run status: %w", err)
+		return ctrl.Result{}, fmt.Errorf("bind run: %w", err)
 	}
 
 	log.Info("Run scheduled", "pod", plan.selected.Name)
 	runsScheduled.WithLabelValues(run.Spec.Runtime, "scheduled").Inc()
-	observeRunQueueDuration(&run, scheduledAt.Time)
+	observeRunQueueDuration(&run, time.Now())
 	return ctrl.Result{}, nil
 }
 
@@ -252,10 +250,10 @@ func defaultRuntimePodCapacity() corev1.ResourceList {
 	}
 }
 
-func (r *RunReconciler) assignedRunUsage(ctx context.Context, namespace string) (map[string]corev1.ResourceList, error) {
+func (r *RunReconciler) assignedRunUsage(ctx context.Context, namespace string) ([]v1alpha1.Run, map[string]corev1.ResourceList, error) {
 	var runs v1alpha1.RunList
 	if err := r.List(ctx, &runs, client.InNamespace(namespace)); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	usage := make(map[string]corev1.ResourceList)
@@ -281,7 +279,7 @@ func (r *RunReconciler) assignedRunUsage(ctx context.Context, namespace string) 
 			}
 		}
 	}
-	return usage, nil
+	return runs.Items, usage, nil
 }
 
 func pendingRetryDelay(run *v1alpha1.Run) time.Duration {

--- a/internal/scheduler/reservation.go
+++ b/internal/scheduler/reservation.go
@@ -1,0 +1,163 @@
+package scheduler
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	"github.com/kruntimes/kruntimes/internal/runstatus"
+)
+
+// reservationKey identifies an assumed assignment by the immutable Run UID.
+// The namespace is retained because the scheduler serves multiple namespaces.
+type reservationKey struct {
+	namespace string
+	runUID    types.UID
+}
+
+type assumedReservation struct {
+	runName string
+	podName string
+	request corev1.ResourceList
+}
+
+func reservationKeyFor(run *v1alpha1.Run) reservationKey {
+	return reservationKey{namespace: run.Namespace, runUID: run.UID}
+}
+
+// effectiveUsage combines observed assignments with local assumptions. It
+// also removes assumptions once the informer has observed their corresponding
+// assignment, terminal state, or a different assignment.
+func (r *RunReconciler) effectiveUsage(actual map[string]corev1.ResourceList, runs []v1alpha1.Run) map[string]corev1.ResourceList {
+	r.reservationMu.Lock()
+	defer r.reservationMu.Unlock()
+	r.syncAssumptionsLocked(runs)
+	return mergeUsage(actual, r.assumedUsageLocked())
+}
+
+func (r *RunReconciler) reserve(snapshot *schedulingSnapshot, pod *corev1.Pod) bool {
+	r.reservationMu.Lock()
+	defer r.reservationMu.Unlock()
+
+	r.syncAssumptionsLocked(snapshot.runs)
+	usage := mergeUsage(snapshot.actualUsageByPod, r.assumedUsageLocked())
+	if !r.isRuntimePodAvailable(pod, snapshot.now, usage[pod.Name], snapshot.request) {
+		return false
+	}
+	if r.assumed == nil {
+		r.assumed = make(map[reservationKey]assumedReservation)
+	}
+	r.assumed[reservationKeyFor(snapshot.run)] = assumedReservation{
+		runName: snapshot.run.Name,
+		podName: pod.Name,
+		request: cloneResourceList(snapshot.request),
+	}
+	return true
+}
+
+// bind persists an assumed assignment. The assumption remains in the local
+// cache until an informer-observed Run assignment takes over its accounting.
+func (r *RunReconciler) bind(ctx context.Context, run *v1alpha1.Run, pod *corev1.Pod) error {
+	run.Status.AssignedPod = pod.Name
+	run.Status.AssignedPodUID = string(pod.UID)
+	run.Status.Phase = v1alpha1.RunScheduled
+	scheduledAt := metav1.Now()
+	meta.SetStatusCondition(&run.Status.Conditions, metav1.Condition{
+		Type:               runstatus.ConditionScheduled,
+		Status:             metav1.ConditionTrue,
+		Reason:             "Assigned",
+		Message:            "assigned to runtime pod " + pod.Name,
+		LastTransitionTime: scheduledAt,
+	})
+	if err := r.Status().Update(ctx, run); err != nil {
+		r.releaseReservation(run)
+		return err
+	}
+	return nil
+}
+
+func (r *RunReconciler) observeRun(run *v1alpha1.Run) {
+	r.reservationMu.Lock()
+	defer r.reservationMu.Unlock()
+	key := reservationKeyFor(run)
+	_, ok := r.assumed[key]
+	if !ok {
+		return
+	}
+	if run.Status.AssignedPod != "" || !isPendingRun(run) {
+		delete(r.assumed, key)
+	}
+}
+
+func (r *RunReconciler) releaseReservation(run *v1alpha1.Run) {
+	r.reservationMu.Lock()
+	defer r.reservationMu.Unlock()
+	delete(r.assumed, reservationKeyFor(run))
+}
+
+func (r *RunReconciler) syncAssumptionsLocked(runs []v1alpha1.Run) {
+	if len(r.assumed) == 0 {
+		return
+	}
+	byKey := make(map[reservationKey]*v1alpha1.Run, len(runs))
+	for i := range runs {
+		byKey[reservationKeyFor(&runs[i])] = &runs[i]
+	}
+	for key, reservation := range r.assumed {
+		run := byKey[key]
+		if run == nil || !isPendingRun(run) || run.Status.AssignedPod != "" || run.Name != reservation.runName {
+			delete(r.assumed, key)
+		}
+	}
+}
+
+func (r *RunReconciler) assumedUsageLocked() map[string]corev1.ResourceList {
+	usage := make(map[string]corev1.ResourceList)
+	for _, reservation := range r.assumed {
+		addUsage(usage, reservation.podName, reservation.request)
+	}
+	return usage
+}
+
+func isPendingRun(run *v1alpha1.Run) bool {
+	return run.Status.Phase == "" || run.Status.Phase == v1alpha1.RunPending
+}
+
+func mergeUsage(first, second map[string]corev1.ResourceList) map[string]corev1.ResourceList {
+	usage := make(map[string]corev1.ResourceList, len(first)+len(second))
+	for podName, resources := range first {
+		usage[podName] = cloneResourceList(resources)
+	}
+	for podName, resources := range second {
+		addUsage(usage, podName, resources)
+	}
+	return usage
+}
+
+func addUsage(usage map[string]corev1.ResourceList, podName string, request corev1.ResourceList) {
+	resources := usage[podName]
+	if resources == nil {
+		resources = corev1.ResourceList{}
+		usage[podName] = resources
+	}
+	for resourceName, quantity := range request {
+		total := resources[resourceName].DeepCopy()
+		total.Add(quantity)
+		resources[resourceName] = total
+	}
+}
+
+func cloneResourceList(resources corev1.ResourceList) corev1.ResourceList {
+	if resources == nil {
+		return nil
+	}
+	clone := make(corev1.ResourceList, len(resources))
+	for name, quantity := range resources {
+		clone[name] = quantity.DeepCopy()
+	}
+	return clone
+}

--- a/internal/scheduler/reservation.go
+++ b/internal/scheduler/reservation.go
@@ -6,57 +6,22 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kruntimes/kruntimes/api/v1alpha1"
 	"github.com/kruntimes/kruntimes/internal/runstatus"
 )
 
-// reservationKey identifies an assumed assignment by the immutable Run UID.
-// The namespace is retained because the scheduler serves multiple namespaces.
-type reservationKey struct {
-	namespace string
-	runUID    types.UID
-}
-
-type assumedReservation struct {
-	runName string
-	podName string
-	request corev1.ResourceList
-}
-
-func reservationKeyFor(run *v1alpha1.Run) reservationKey {
-	return reservationKey{namespace: run.Namespace, runUID: run.UID}
-}
-
 // effectiveUsage combines observed assignments with local assumptions. It
 // also removes assumptions once the informer has observed their corresponding
 // assignment, terminal state, or a different assignment.
 func (r *RunReconciler) effectiveUsage(actual map[string]corev1.ResourceList, runs []v1alpha1.Run) map[string]corev1.ResourceList {
-	r.reservationMu.Lock()
-	defer r.reservationMu.Unlock()
-	r.syncAssumptionsLocked(runs)
-	return mergeUsage(actual, r.assumedUsageLocked())
+	return r.assumptions.effectiveUsage(actual, runs)
 }
 
 func (r *RunReconciler) reserve(snapshot *schedulingSnapshot, pod *corev1.Pod) bool {
-	r.reservationMu.Lock()
-	defer r.reservationMu.Unlock()
-
-	r.syncAssumptionsLocked(snapshot.runs)
-	usage := mergeUsage(snapshot.actualUsageByPod, r.assumedUsageLocked())
-	if !r.isRuntimePodAvailable(pod, snapshot.now, usage[pod.Name], snapshot.request) {
-		return false
-	}
-	if r.assumed == nil {
-		r.assumed = make(map[reservationKey]assumedReservation)
-	}
-	r.assumed[reservationKeyFor(snapshot.run)] = assumedReservation{
-		runName: snapshot.run.Name,
-		podName: pod.Name,
-		request: cloneResourceList(snapshot.request),
-	}
-	return true
+	return r.assumptions.reserve(snapshot, pod, func(usage corev1.ResourceList) bool {
+		return r.isRuntimePodAvailable(pod, snapshot.now, usage, snapshot.request)
+	})
 }
 
 // bind persists an assumed assignment. The assumption remains in the local
@@ -81,83 +46,9 @@ func (r *RunReconciler) bind(ctx context.Context, run *v1alpha1.Run, pod *corev1
 }
 
 func (r *RunReconciler) observeRun(run *v1alpha1.Run) {
-	r.reservationMu.Lock()
-	defer r.reservationMu.Unlock()
-	key := reservationKeyFor(run)
-	_, ok := r.assumed[key]
-	if !ok {
-		return
-	}
-	if run.Status.AssignedPod != "" || !isPendingRun(run) {
-		delete(r.assumed, key)
-	}
+	r.assumptions.observe(run)
 }
 
 func (r *RunReconciler) releaseReservation(run *v1alpha1.Run) {
-	r.reservationMu.Lock()
-	defer r.reservationMu.Unlock()
-	delete(r.assumed, reservationKeyFor(run))
-}
-
-func (r *RunReconciler) syncAssumptionsLocked(runs []v1alpha1.Run) {
-	if len(r.assumed) == 0 {
-		return
-	}
-	byKey := make(map[reservationKey]*v1alpha1.Run, len(runs))
-	for i := range runs {
-		byKey[reservationKeyFor(&runs[i])] = &runs[i]
-	}
-	for key, reservation := range r.assumed {
-		run := byKey[key]
-		if run == nil || !isPendingRun(run) || run.Status.AssignedPod != "" || run.Name != reservation.runName {
-			delete(r.assumed, key)
-		}
-	}
-}
-
-func (r *RunReconciler) assumedUsageLocked() map[string]corev1.ResourceList {
-	usage := make(map[string]corev1.ResourceList)
-	for _, reservation := range r.assumed {
-		addUsage(usage, reservation.podName, reservation.request)
-	}
-	return usage
-}
-
-func isPendingRun(run *v1alpha1.Run) bool {
-	return run.Status.Phase == "" || run.Status.Phase == v1alpha1.RunPending
-}
-
-func mergeUsage(first, second map[string]corev1.ResourceList) map[string]corev1.ResourceList {
-	usage := make(map[string]corev1.ResourceList, len(first)+len(second))
-	for podName, resources := range first {
-		usage[podName] = cloneResourceList(resources)
-	}
-	for podName, resources := range second {
-		addUsage(usage, podName, resources)
-	}
-	return usage
-}
-
-func addUsage(usage map[string]corev1.ResourceList, podName string, request corev1.ResourceList) {
-	resources := usage[podName]
-	if resources == nil {
-		resources = corev1.ResourceList{}
-		usage[podName] = resources
-	}
-	for resourceName, quantity := range request {
-		total := resources[resourceName].DeepCopy()
-		total.Add(quantity)
-		resources[resourceName] = total
-	}
-}
-
-func cloneResourceList(resources corev1.ResourceList) corev1.ResourceList {
-	if resources == nil {
-		return nil
-	}
-	clone := make(corev1.ResourceList, len(resources))
-	for name, quantity := range resources {
-		clone[name] = quantity.DeepCopy()
-	}
-	return clone
+	r.assumptions.release(run)
 }

--- a/internal/scheduler/reservation_test.go
+++ b/internal/scheduler/reservation_test.go
@@ -52,65 +52,26 @@ func TestReservationPreventsOvercommitBeforeBindIsObserved(t *testing.T) {
 	}
 }
 
-func TestEffectiveUsageHandsOffAssumptionToObservedAssignment(t *testing.T) {
-	now := time.Now()
-	run := reservationTestRun("run-a", "run-a-uid")
-	pod := reservationTestPod(now, "runtime-a", 2)
-	reconciler := &RunReconciler{
-		assumed: map[reservationKey]assumedReservation{
-			reservationKeyFor(run): {
-				runName: run.Name,
-				podName: pod.Name,
-				request: defaultRuntimePodCapacity(),
-			},
-		},
-	}
-
-	request, err := run.Spec.ResourceRequests()
-	if err != nil {
-		t.Fatalf("resource requests: %v", err)
-	}
-	run.Status.Phase = v1alpha1.RunScheduled
-	run.Status.AssignedPod = pod.Name
-	actual := map[string]corev1.ResourceList{pod.Name: request}
-	usage := reconciler.effectiveUsage(actual, []v1alpha1.Run{*run})
-
-	want := request[corev1.ResourceName(v1alpha1.RuntimeResourceRuns)]
-	if got := usage[pod.Name][corev1.ResourceName(v1alpha1.RuntimeResourceRuns)]; got.Cmp(want) != 0 {
-		t.Fatalf("effective runs usage = %s, want %s", got.String(), want.String())
-	}
-	if len(reconciler.assumed) != 0 {
-		t.Fatalf("assumed reservations = %#v, want empty after observed assignment", reconciler.assumed)
-	}
-}
-
-func TestReleaseReservation(t *testing.T) {
-	run := reservationTestRun("run-a", "run-a-uid")
-	reconciler := &RunReconciler{
-		assumed: map[reservationKey]assumedReservation{
-			reservationKeyFor(run): {runName: run.Name, podName: "runtime-a"},
-		},
-	}
-	reconciler.releaseReservation(run)
-	if len(reconciler.assumed) != 0 {
-		t.Fatalf("assumed reservations = %#v, want empty", reconciler.assumed)
-	}
-}
-
 func TestBindReleasesReservationOnStatusUpdateFailure(t *testing.T) {
 	run := reservationTestRun("run-a", "run-a-uid")
 	pod := reservationTestPod(time.Now(), "runtime-a", 1)
 	reconciler := &RunReconciler{
 		Client: statusUpdateErrorClient{err: errors.New("status update failed")},
-		assumed: map[reservationKey]assumedReservation{
-			reservationKeyFor(run): {runName: run.Name, podName: pod.Name},
-		},
+	}
+	if reserved := reconciler.reserve(&schedulingSnapshot{
+		run:              run,
+		request:          runResourceRequest(1),
+		actualUsageByPod: map[string]corev1.ResourceList{},
+		runs:             []v1alpha1.Run{*run},
+		now:              time.Now(),
+	}, pod); !reserved {
+		t.Fatal("reserve Run = false, want true")
 	}
 	if err := reconciler.bind(context.Background(), run, pod); err == nil {
 		t.Fatal("bind error = nil, want status update error")
 	}
-	if len(reconciler.assumed) != 0 {
-		t.Fatalf("assumed reservations = %#v, want empty after bind failure", reconciler.assumed)
+	if _, ok := reconciler.assumptions.effectiveUsage(nil, []v1alpha1.Run{*run})[pod.Name]; ok {
+		t.Fatal("assumed reservation remains after bind failure")
 	}
 }
 

--- a/internal/scheduler/reservation_test.go
+++ b/internal/scheduler/reservation_test.go
@@ -1,0 +1,160 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	"github.com/kruntimes/kruntimes/internal/runtimepod"
+)
+
+func TestReservationPreventsOvercommitBeforeBindIsObserved(t *testing.T) {
+	now := time.Now()
+	pod := reservationTestPod(now, "runtime-a", 1)
+	first := reservationTestRun("first", "first-uid")
+	second := reservationTestRun("second", "second-uid")
+	reconciler := &RunReconciler{RuntimedHeartbeatStaleAfter: time.Minute}
+	request, err := first.Spec.ResourceRequests()
+	if err != nil {
+		t.Fatalf("resource requests: %v", err)
+	}
+
+	firstSnapshot := &schedulingSnapshot{
+		run:              first,
+		request:          request,
+		actualUsageByPod: map[string]corev1.ResourceList{},
+		runs:             []v1alpha1.Run{*first, *second},
+		now:              now,
+	}
+	if !reconciler.reserve(firstSnapshot, pod) {
+		t.Fatal("reserve first Run = false, want true")
+	}
+
+	// The informer may still report the first Run as Pending while its Bind is
+	// in flight. That observation must not discard its assumption.
+	secondSnapshot := &schedulingSnapshot{
+		run:              second,
+		request:          request,
+		actualUsageByPod: map[string]corev1.ResourceList{},
+		runs:             []v1alpha1.Run{*first, *second},
+		now:              now,
+	}
+	if reconciler.reserve(secondSnapshot, pod) {
+		t.Fatal("reserve second Run = true, want false after first assumed assignment")
+	}
+}
+
+func TestEffectiveUsageHandsOffAssumptionToObservedAssignment(t *testing.T) {
+	now := time.Now()
+	run := reservationTestRun("run-a", "run-a-uid")
+	pod := reservationTestPod(now, "runtime-a", 2)
+	reconciler := &RunReconciler{
+		assumed: map[reservationKey]assumedReservation{
+			reservationKeyFor(run): {
+				runName: run.Name,
+				podName: pod.Name,
+				request: defaultRuntimePodCapacity(),
+			},
+		},
+	}
+
+	request, err := run.Spec.ResourceRequests()
+	if err != nil {
+		t.Fatalf("resource requests: %v", err)
+	}
+	run.Status.Phase = v1alpha1.RunScheduled
+	run.Status.AssignedPod = pod.Name
+	actual := map[string]corev1.ResourceList{pod.Name: request}
+	usage := reconciler.effectiveUsage(actual, []v1alpha1.Run{*run})
+
+	want := request[corev1.ResourceName(v1alpha1.RuntimeResourceRuns)]
+	if got := usage[pod.Name][corev1.ResourceName(v1alpha1.RuntimeResourceRuns)]; got.Cmp(want) != 0 {
+		t.Fatalf("effective runs usage = %s, want %s", got.String(), want.String())
+	}
+	if len(reconciler.assumed) != 0 {
+		t.Fatalf("assumed reservations = %#v, want empty after observed assignment", reconciler.assumed)
+	}
+}
+
+func TestReleaseReservation(t *testing.T) {
+	run := reservationTestRun("run-a", "run-a-uid")
+	reconciler := &RunReconciler{
+		assumed: map[reservationKey]assumedReservation{
+			reservationKeyFor(run): {runName: run.Name, podName: "runtime-a"},
+		},
+	}
+	reconciler.releaseReservation(run)
+	if len(reconciler.assumed) != 0 {
+		t.Fatalf("assumed reservations = %#v, want empty", reconciler.assumed)
+	}
+}
+
+func TestBindReleasesReservationOnStatusUpdateFailure(t *testing.T) {
+	run := reservationTestRun("run-a", "run-a-uid")
+	pod := reservationTestPod(time.Now(), "runtime-a", 1)
+	reconciler := &RunReconciler{
+		Client: statusUpdateErrorClient{err: errors.New("status update failed")},
+		assumed: map[reservationKey]assumedReservation{
+			reservationKeyFor(run): {runName: run.Name, podName: pod.Name},
+		},
+	}
+	if err := reconciler.bind(context.Background(), run, pod); err == nil {
+		t.Fatal("bind error = nil, want status update error")
+	}
+	if len(reconciler.assumed) != 0 {
+		t.Fatalf("assumed reservations = %#v, want empty after bind failure", reconciler.assumed)
+	}
+}
+
+type statusUpdateErrorClient struct {
+	client.Client
+	err error
+}
+
+func (c statusUpdateErrorClient) Status() client.SubResourceWriter {
+	return statusUpdateErrorWriter{err: c.err}
+}
+
+type statusUpdateErrorWriter struct {
+	client.SubResourceWriter
+	err error
+}
+
+func (w statusUpdateErrorWriter) Update(context.Context, client.Object, ...client.SubResourceUpdateOption) error {
+	return w.err
+}
+
+func reservationTestRun(name string, uid types.UID) *v1alpha1.Run {
+	return &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", UID: uid},
+		Spec:       v1alpha1.RunSpec{Runtime: "bash"},
+		Status:     v1alpha1.RunStatus{Phase: v1alpha1.RunPending},
+	}
+}
+
+func reservationTestPod(now time.Time, name string, capacity int64) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			UID:  types.UID(name + "-uid"),
+			Annotations: map[string]string{
+				runtimepod.CapacityAnnotation(v1alpha1.RuntimeResourceRuns): resource.NewQuantity(capacity, resource.DecimalSI).String(),
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+				{Type: v1alpha1.RuntimePodRuntimedReadyCondition, Status: corev1.ConditionTrue, LastProbeTime: metav1.NewTime(now)},
+			},
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- add scheduler-local assumed reservations keyed by namespace and Run UID
- account for assumed resources during filtering and scoring, and release them when Bind fails
- document the Reserve/Assume/Bind lifecycle and cover overcommit, handoff, and failure paths

## Verification
- make test
- make test-integration
- make site-build