### PR TITLE
feat(python-runtime): add FunctionRuntime adapter

### DIFF
--- a/Dockerfile.python-runtime
+++ b/Dockerfile.python-runtime
@@ -29,7 +29,7 @@ WORKDIR /app
 
 COPY --from=dependencies /app/.venv ./.venv
 COPY runtimes/python/pb ./pb
-COPY runtimes/python/server.py runtimes/python/cmd/main.py ./
+COPY runtimes/python/function.py runtimes/python/server.py runtimes/python/cmd/main.py ./
 
 ENV PATH="/app/.venv/bin:$PATH"
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -151,7 +151,8 @@ wiring from accumulating avoidable conflicts.
   - [ ] implement built-in function adapters:
     - [x] Bash FunctionRuntime adapter with handler validation, registration
       fencing, one in-flight invocation, bounded output, and unregister drain;
-    - [ ] Python FunctionRuntime adapter;
+    - [x] Python FunctionRuntime adapter with handler validation, registration
+      fencing, one in-flight invocation, bounded output, and unregister drain;
   - [ ] add bounded invocation outputs/artifact references and structured logs
     keyed by Run UID and invocation ID;
 - [ ] Function-mode reliability and isolation: cover function registration,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -327,6 +327,10 @@ wiring from accumulating avoidable conflicts.
   Run. Preserve the default single in-flight invocation, define per-function
   concurrency limits and invocation/workspace isolation semantics, and retain
   Runtime Pod capacity enforcement.
+- [ ] Design persistent per-registration Function worker processes to reduce
+  Python invocation startup overhead. Review worker lifecycle, module state,
+  cancellation, concurrency, output limits, and isolation before replacing the
+  current per-invocation subprocess model.
 - Define compatibility and migration guarantees.
 - Document deprecation policy.
 - Clarify multi-tenant isolation strategy for production environments.

--- a/runtimes/python/cmd/main.py
+++ b/runtimes/python/cmd/main.py
@@ -16,9 +16,9 @@ def main():
     args = parser.parse_args()
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
-    runtime_pb2_grpc.add_RuntimeServicer_to_server(
-        PythonRuntime(work_dir=args.work_dir), server
-    )
+    runtime = PythonRuntime(work_dir=args.work_dir)
+    runtime_pb2_grpc.add_RuntimeServicer_to_server(runtime, server)
+    runtime_pb2_grpc.add_FunctionRuntimeServicer_to_server(runtime, server)
     if server.add_insecure_port(f"0.0.0.0:{args.port}") == 0:
         raise RuntimeError(f"failed to bind Python runtime to port {args.port}")
     server.start()

--- a/runtimes/python/function.py
+++ b/runtimes/python/function.py
@@ -113,4 +113,6 @@ def terminate_process_group(process, sig):
     try:
         os.killpg(process.pid, sig)
     except ProcessLookupError:
+        # The process may exit naturally between the caller's state check and
+        # signal delivery; termination is already complete in that case.
         pass

--- a/runtimes/python/function.py
+++ b/runtimes/python/function.py
@@ -1,0 +1,116 @@
+import os
+import signal
+import threading
+import time
+
+from pb import runtime_pb2
+
+
+class FunctionInvocation:
+    def __init__(self):
+        self.done = threading.Event()
+        self._cancelled = threading.Event()
+        self._process = None
+        self._process_lock = threading.Lock()
+
+    def cancel(self):
+        self._cancelled.set()
+        with self._process_lock:
+            if self._process is not None:
+                terminate_process_group(self._process, signal.SIGTERM)
+
+    def cancelled(self):
+        return self._cancelled.is_set()
+
+    def set_process(self, process):
+        with self._process_lock:
+            self._process = process
+            if self._cancelled.is_set():
+                terminate_process_group(process, signal.SIGTERM)
+
+
+class FunctionEntry:
+    def __init__(self, registration, attempt, digest, working_dir, handler, env):
+        self.lifecycle_lock = threading.Lock()
+        self._lock = threading.RLock()
+        self._registration = registration
+        self._attempt = attempt
+        self._digest = digest
+        self.working_dir = working_dir
+        self.handler = handler
+        self.env = dict(env)
+        self._state = runtime_pb2.FUNCTION_REGISTRATION_STATE_READY
+        self._invocation = None
+        self._last_activity_unix_nano = 0
+
+    def registration_action(self, attempt, digest):
+        with self._lock:
+            if attempt < self._attempt:
+                return "stale", None
+            if attempt == self._attempt:
+                if digest != self._digest:
+                    return "different-digest", None
+                return "current", None
+
+            self._state = runtime_pb2.FUNCTION_REGISTRATION_STATE_DRAINING
+            return "replace", self._invocation
+
+    def registration_response(self):
+        with self._lock:
+            return runtime_pb2.RegisterFunctionResponse(
+                registration=clone_registration(self._registration),
+                state=self._state,
+            )
+
+    def status_response(self):
+        with self._lock:
+            return runtime_pb2.FunctionStatusResponse(
+                registration=clone_registration(self._registration),
+                state=self._state,
+                in_flight=1 if self._invocation is not None else 0,
+                last_activity_unix_nano=self._last_activity_unix_nano,
+            )
+
+    def matches_registration(self, registration_id):
+        with self._lock:
+            return self._registration.registration_id == registration_id
+
+    def start_invocation(self):
+        with self._lock:
+            if self._state != runtime_pb2.FUNCTION_REGISTRATION_STATE_READY:
+                return None, "not-ready"
+            if self._invocation is not None:
+                return None, "busy"
+            invocation = FunctionInvocation()
+            self._invocation = invocation
+            self._last_activity_unix_nano = time.time_ns()
+            return invocation, ""
+
+    def finish_invocation(self, invocation):
+        with self._lock:
+            if self._invocation is not invocation:
+                return
+            self._invocation = None
+            self._last_activity_unix_nano = time.time_ns()
+            invocation.done.set()
+
+    def begin_drain(self, registration_id):
+        with self._lock:
+            if self._registration.registration_id != registration_id:
+                return None, "stale"
+            self._state = runtime_pb2.FUNCTION_REGISTRATION_STATE_DRAINING
+            return self._invocation, ""
+
+
+def clone_registration(registration):
+    return runtime_pb2.FunctionRegistration(
+        run_uid=registration.run_uid,
+        registration_id=registration.registration_id,
+    )
+
+
+def terminate_process_group(process, sig):
+    try:
+        os.killpg(process.pid, sig)
+    except ProcessLookupError:
+        pass

--- a/runtimes/python/server.py
+++ b/runtimes/python/server.py
@@ -24,15 +24,17 @@ MAX_FUNCTION_DRAIN_TIMEOUT_SECONDS = 5 * 60
 HANDLER_COMPONENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 FUNCTION_HANDLER_SCRIPT = """
+import contextlib
 import importlib
 import json
 import sys
 
 module_name, func_name = sys.argv[1].rsplit(".", 1)
-event = json.loads(sys.argv[2])
-result = getattr(importlib.import_module(module_name), func_name)(event)
-if result is not None:
-    print(json.dumps(result))
+event = json.loads(sys.stdin.read())
+with contextlib.redirect_stdout(sys.stderr):
+    result = getattr(importlib.import_module(module_name), func_name)(event)
+json.dump(result, sys.stdout)
+sys.stdout.write("\\n")
 """
 
 FUNCTION_VALIDATION_SCRIPT = """
@@ -523,10 +525,10 @@ class PythonRuntime(
                     "-c",
                     FUNCTION_HANDLER_SCRIPT,
                     entry.handler,
-                    input_payload,
                 ],
                 cwd=str(entry.working_dir),
                 env=env,
+                stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 start_new_session=True,
@@ -535,6 +537,14 @@ class PythonRuntime(
             context.abort(grpc.StatusCode.INTERNAL, f"invoke handler: {error}")
 
         invocation.set_process(process)
+        try:
+            process.stdin.write(input_payload.encode("utf-8"))
+            process.stdin.close()
+        except BrokenPipeError:
+            # A cancelled invocation may terminate the process before its
+            # request body is fully written. The normal cancellation path
+            # below returns the client-visible status.
+            pass
         stdout = BoundedBuffer(self.output_limit)
         stderr = BoundedBuffer(self.output_limit)
         stdout_reader = threading.Thread(

--- a/runtimes/python/server.py
+++ b/runtimes/python/server.py
@@ -1,18 +1,49 @@
 import json
 import os
+import re
+import secrets
 import signal
 import subprocess
 import sys
 import threading
+import time
 from pathlib import Path
 
 import grpc
 from pb import runtime_pb2
 from pb import runtime_pb2_grpc
+from function import FunctionEntry, clone_registration, terminate_process_group
 
 
 DEFAULT_OUTPUT_LIMIT_BYTES = 1024 * 1024
 OUTPUT_TRUNCATED_MARKER = "\n[output truncated]\n"
+DEFAULT_FUNCTION_INVOKE_TIMEOUT_SECONDS = 30
+MAX_FUNCTION_INVOKE_TIMEOUT_SECONDS = 5 * 60
+DEFAULT_FUNCTION_DRAIN_TIMEOUT_SECONDS = 30
+MAX_FUNCTION_DRAIN_TIMEOUT_SECONDS = 5 * 60
+HANDLER_COMPONENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+FUNCTION_HANDLER_SCRIPT = """
+import importlib
+import json
+import sys
+
+module_name, func_name = sys.argv[1].rsplit(".", 1)
+event = json.loads(sys.argv[2])
+result = getattr(importlib.import_module(module_name), func_name)(event)
+if result is not None:
+    print(json.dumps(result))
+"""
+
+FUNCTION_VALIDATION_SCRIPT = """
+import importlib
+import sys
+
+module_name, func_name = sys.argv[1].rsplit(".", 1)
+handler = getattr(importlib.import_module(module_name), func_name)
+if not callable(handler):
+    raise TypeError(f"handler {sys.argv[1]!r} is not callable")
+"""
 
 
 class BoundedBuffer:
@@ -42,14 +73,23 @@ class BoundedBuffer:
             output += OUTPUT_TRUNCATED_MARKER
         return output
 
+    @property
+    def truncated(self):
+        return self._truncated
 
-class PythonRuntime(runtime_pb2_grpc.RuntimeServicer):
+
+class PythonRuntime(
+    runtime_pb2_grpc.RuntimeServicer,
+    runtime_pb2_grpc.FunctionRuntimeServicer,
+):
     def __init__(self, work_dir="/workspace", output_limit=DEFAULT_OUTPUT_LIMIT_BYTES):
         self.base_dir = Path(work_dir)
         self.base_dir.mkdir(parents=True, exist_ok=True)
         self.output_limit = output_limit
         self._tasks = {}
         self._lock = threading.Lock()
+        self._functions = {}
+        self._functions_lock = threading.Lock()
 
     def Execute(self, request, context):
         task_id = request.id
@@ -142,6 +182,173 @@ class PythonRuntime(runtime_pb2_grpc.RuntimeServicer):
     def Health(self, request, context):
         return runtime_pb2.HealthResponse(healthy=True)
 
+    def RegisterFunction(self, request, context):
+        try:
+            working_dir, handler = self._validate_function_registration(request)
+        except ValueError as error:
+            context.abort(grpc.StatusCode.INVALID_ARGUMENT, str(error))
+
+        while True:
+            entry = self._function(request.run_uid)
+            if entry is None:
+                registration = runtime_pb2.FunctionRegistration(
+                    run_uid=request.run_uid,
+                    registration_id=self._new_function_id("reg_"),
+                )
+                candidate = FunctionEntry(
+                    registration,
+                    request.registration_attempt,
+                    request.registration_digest,
+                    working_dir,
+                    handler,
+                    request.env,
+                )
+                if self._add_function_if_absent(request.run_uid, candidate):
+                    return candidate.registration_response()
+                continue
+
+            with entry.lifecycle_lock:
+                if not self._is_current_function(request.run_uid, entry):
+                    continue
+                action, invocation = entry.registration_action(
+                    request.registration_attempt,
+                    request.registration_digest,
+                )
+                if action == "stale":
+                    context.abort(
+                        grpc.StatusCode.FAILED_PRECONDITION,
+                        "registration attempt is stale",
+                    )
+                if action == "different-digest":
+                    context.abort(
+                        grpc.StatusCode.ALREADY_EXISTS,
+                        "registration attempt already exists with a different digest",
+                    )
+                if action == "current":
+                    return entry.registration_response()
+
+                if invocation is not None:
+                    invocation.cancel()
+                    self._wait_for_invocation(
+                        context,
+                        invocation,
+                        DEFAULT_FUNCTION_DRAIN_TIMEOUT_SECONDS,
+                    )
+
+                registration = runtime_pb2.FunctionRegistration(
+                    run_uid=request.run_uid,
+                    registration_id=self._new_function_id("reg_"),
+                )
+                replacement = FunctionEntry(
+                    registration,
+                    request.registration_attempt,
+                    request.registration_digest,
+                    working_dir,
+                    handler,
+                    request.env,
+                )
+                if self._replace_function_if_current(request.run_uid, entry, replacement):
+                    return replacement.registration_response()
+
+    def FunctionStatus(self, request, context):
+        entry = self._match_function(request.registration, context)
+        return entry.status_response()
+
+    def InvokeFunction(self, request, context):
+        if len(request.invocation_id) > 128:
+            context.abort(
+                grpc.StatusCode.INVALID_ARGUMENT,
+                "invocation id must be no larger than 128 bytes",
+            )
+        if request.content_type != "application/json":
+            context.abort(
+                grpc.StatusCode.INVALID_ARGUMENT,
+                "Python functions support only application/json input",
+            )
+        if (
+            not request.input
+            or len(request.input) > DEFAULT_OUTPUT_LIMIT_BYTES
+        ):
+            context.abort(
+                grpc.StatusCode.INVALID_ARGUMENT,
+                "input must be valid JSON no larger than 1 MiB",
+            )
+        try:
+            input_payload = request.input.decode("utf-8")
+            json.loads(input_payload)
+        except (TypeError, UnicodeDecodeError, ValueError):
+            context.abort(
+                grpc.StatusCode.INVALID_ARGUMENT,
+                "input must be valid JSON no larger than 1 MiB",
+            )
+
+        entry = self._match_function(request.registration, context)
+        invocation, reason = entry.start_invocation()
+        if reason == "not-ready":
+            context.abort(
+                grpc.StatusCode.FAILED_PRECONDITION,
+                "function registration is not ready",
+            )
+        if reason == "busy":
+            context.abort(
+                grpc.StatusCode.RESOURCE_EXHAUSTED,
+                "function registration already has an in-flight invocation",
+            )
+
+        context.add_callback(invocation.cancel)
+        try:
+            output = self._invoke_function(
+                entry,
+                invocation,
+                input_payload,
+                request,
+                context,
+            )
+        finally:
+            entry.finish_invocation(invocation)
+
+        return runtime_pb2.InvokeFunctionResponse(
+            registration=clone_registration(request.registration),
+            invocation_id=request.invocation_id or self._new_function_id("inv_"),
+            output=output,
+            content_type="application/json",
+        )
+
+    def UnregisterFunction(self, request, context):
+        registration = request.registration
+        if not registration or not registration.run_uid or not registration.registration_id:
+            context.abort(
+                grpc.StatusCode.INVALID_ARGUMENT,
+                "registration run uid and id are required",
+            )
+
+        while True:
+            entry = self._function(registration.run_uid)
+            if entry is None:
+                return runtime_pb2.UnregisterFunctionResponse(
+                    registration=clone_registration(registration),
+                )
+            with entry.lifecycle_lock:
+                if not self._is_current_function(registration.run_uid, entry):
+                    continue
+                invocation, reason = entry.begin_drain(registration.registration_id)
+                if reason == "stale":
+                    context.abort(
+                        grpc.StatusCode.FAILED_PRECONDITION,
+                        "function registration is stale",
+                    )
+                if invocation is not None:
+                    if request.cancel_in_flight:
+                        invocation.cancel()
+                    drain_timeout = self._drain_timeout_seconds(
+                        request.drain_timeout_millis,
+                    )
+                    self._wait_for_invocation(context, invocation, drain_timeout)
+                self._delete_function_if_current(registration.run_uid, entry)
+                return runtime_pb2.UnregisterFunctionResponse(
+                    registration=clone_registration(registration),
+                )
+
     @staticmethod
     def _status_response(task_id, task):
         return runtime_pb2.StatusResponse(
@@ -152,6 +359,258 @@ class PythonRuntime(runtime_pb2_grpc.RuntimeServicer):
             stderr=task["stderr"].snapshot(),
             error_message=task["error_message"],
         )
+
+    def _function(self, run_uid):
+        with self._functions_lock:
+            return self._functions.get(run_uid)
+
+    def _add_function_if_absent(self, run_uid, entry):
+        with self._functions_lock:
+            if run_uid in self._functions:
+                return False
+            self._functions[run_uid] = entry
+            return True
+
+    def _is_current_function(self, run_uid, entry):
+        with self._functions_lock:
+            return self._functions.get(run_uid) is entry
+
+    def _replace_function_if_current(self, run_uid, current, replacement):
+        with self._functions_lock:
+            if self._functions.get(run_uid) is not current:
+                return False
+            self._functions[run_uid] = replacement
+            return True
+
+    def _delete_function_if_current(self, run_uid, entry):
+        with self._functions_lock:
+            if self._functions.get(run_uid) is entry:
+                del self._functions[run_uid]
+
+    def _match_function(self, registration, context):
+        if registration is None or not registration.run_uid or not registration.registration_id:
+            context.abort(
+                grpc.StatusCode.INVALID_ARGUMENT,
+                "registration run uid and id are required",
+            )
+        entry = self._function(registration.run_uid)
+        if entry is None:
+            context.abort(
+                grpc.StatusCode.NOT_FOUND,
+                "function registration not found",
+            )
+        if not entry.matches_registration(registration.registration_id):
+            context.abort(
+                grpc.StatusCode.FAILED_PRECONDITION,
+                "function registration is stale",
+            )
+        return entry
+
+    def _validate_function_registration(self, request):
+        if (
+            not request.run_uid
+            or request.registration_attempt < 1
+            or not request.registration_digest
+        ):
+            raise ValueError(
+                "run uid, positive registration attempt, and registration digest are required",
+            )
+        if len(request.registration_digest) > 128:
+            raise ValueError("registration digest must be no larger than 128 bytes")
+        working_dir = self._function_working_dir(request.working_dir)
+        handler = self._parse_python_handler(request.handler)
+        self._validate_python_handler(working_dir, handler, request.env)
+        return working_dir, handler
+
+    def _function_working_dir(self, working_dir):
+        if not working_dir:
+            raise ValueError("working directory is required")
+        try:
+            base_dir = self.base_dir.resolve(strict=True)
+            candidate = Path(working_dir).resolve(strict=True)
+            candidate.relative_to(base_dir)
+        except (OSError, ValueError):
+            raise ValueError("working directory must be within the runtime workspace")
+        if not candidate.is_dir():
+            raise ValueError("working directory must be a directory")
+        return candidate
+
+    @staticmethod
+    def _parse_python_handler(handler):
+        if not handler or "." not in handler:
+            raise ValueError("handler must use module.function form")
+        module_name, function_name = handler.rsplit(".", 1)
+        components = module_name.split(".")
+        if (
+            not module_name
+            or not all(HANDLER_COMPONENT.fullmatch(component) for component in components)
+            or not HANDLER_COMPONENT.fullmatch(function_name)
+        ):
+            raise ValueError("handler must use module.function form")
+        return handler
+
+    @staticmethod
+    def _python_handler_path(working_dir, handler):
+        module_name, _ = handler.rsplit(".", 1)
+        module_path = Path(*module_name.split("."))
+        candidates = (
+            working_dir / module_path.with_suffix(".py"),
+            working_dir / module_path / "__init__.py",
+        )
+        for candidate in candidates:
+            if not candidate.is_file():
+                continue
+            try:
+                resolved = candidate.resolve(strict=True)
+                resolved.relative_to(working_dir)
+            except (OSError, ValueError):
+                continue
+            return resolved
+        raise ValueError("handler module must be a file within the working directory")
+
+    def _validate_python_handler(self, working_dir, handler, function_env):
+        self._python_handler_path(working_dir, handler)
+        env = os.environ.copy()
+        env.update(function_env)
+        try:
+            result = subprocess.run(
+                [sys.executable, "-c", FUNCTION_VALIDATION_SCRIPT, handler],
+                cwd=str(working_dir),
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=DEFAULT_FUNCTION_DRAIN_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as error:
+            raise ValueError("handler validation timed out") from error
+        if result.returncode != 0:
+            details = result.stderr.decode("utf-8", errors="replace").strip()
+            raise ValueError(f"handler {handler!r} is not importable: {details[:4096]}")
+
+    @staticmethod
+    def _new_function_id(prefix):
+        return f"{prefix}{secrets.token_hex(16)}"
+
+    @staticmethod
+    def _drain_timeout_seconds(timeout_millis):
+        if timeout_millis <= 0:
+            return DEFAULT_FUNCTION_DRAIN_TIMEOUT_SECONDS
+        return min(
+            timeout_millis / 1000,
+            MAX_FUNCTION_DRAIN_TIMEOUT_SECONDS,
+        )
+
+    @staticmethod
+    def _wait_for_invocation(context, invocation, timeout_seconds):
+        deadline = time.monotonic() + timeout_seconds
+        remaining = context.time_remaining()
+        if remaining is not None:
+            deadline = min(deadline, time.monotonic() + max(remaining, 0))
+        if invocation.done.wait(max(deadline - time.monotonic(), 0)):
+            return
+        context.abort(
+            grpc.StatusCode.DEADLINE_EXCEEDED,
+            "function invocation did not drain before the deadline",
+        )
+
+    def _invoke_function(self, entry, invocation, input_payload, request, context):
+        env = os.environ.copy()
+        env.update(entry.env)
+        try:
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    FUNCTION_HANDLER_SCRIPT,
+                    entry.handler,
+                    input_payload,
+                ],
+                cwd=str(entry.working_dir),
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                start_new_session=True,
+            )
+        except OSError as error:
+            context.abort(grpc.StatusCode.INTERNAL, f"invoke handler: {error}")
+
+        invocation.set_process(process)
+        stdout = BoundedBuffer(self.output_limit)
+        stderr = BoundedBuffer(self.output_limit)
+        stdout_reader = threading.Thread(
+            target=self._read_function_stream,
+            args=(stdout, process.stdout),
+            daemon=True,
+        )
+        stderr_reader = threading.Thread(
+            target=self._read_function_stream,
+            args=(stderr, process.stderr),
+            daemon=True,
+        )
+        stdout_reader.start()
+        stderr_reader.start()
+
+        timeout = self._function_invoke_timeout_seconds(request.timeout_millis, context)
+        deadline = time.monotonic() + timeout
+        deadline_expired = False
+        while process.poll() is None:
+            if invocation.cancelled():
+                self._stop_process(process)
+                break
+            if time.monotonic() >= deadline:
+                deadline_expired = True
+                self._stop_process(process)
+                break
+            time.sleep(0.01)
+
+        stdout_reader.join()
+        stderr_reader.join()
+        if invocation.cancelled() and not deadline_expired:
+            context.abort(grpc.StatusCode.CANCELLED, "function invocation was cancelled")
+        if deadline_expired:
+            context.abort(grpc.StatusCode.DEADLINE_EXCEEDED, "function invocation timed out")
+        if process.returncode != 0:
+            context.abort(
+                grpc.StatusCode.INTERNAL,
+                f"invoke handler: {stderr.snapshot()[:4096]}",
+            )
+        if stdout.truncated:
+            context.abort(
+                grpc.StatusCode.RESOURCE_EXHAUSTED,
+                "function response exceeds the configured output limit",
+            )
+        return stdout.snapshot().encode("utf-8")
+
+    @staticmethod
+    def _read_function_stream(buffer, stream):
+        try:
+            while True:
+                chunk = stream.read(4096)
+                if not chunk:
+                    return
+                buffer.write(chunk)
+        finally:
+            stream.close()
+
+    @staticmethod
+    def _function_invoke_timeout_seconds(timeout_millis, context):
+        timeout = DEFAULT_FUNCTION_INVOKE_TIMEOUT_SECONDS
+        if timeout_millis > 0:
+            timeout = timeout_millis / 1000
+        timeout = min(timeout, MAX_FUNCTION_INVOKE_TIMEOUT_SECONDS)
+        remaining = context.time_remaining()
+        if remaining is not None:
+            timeout = min(timeout, max(remaining, 0))
+        return timeout
+
+    @staticmethod
+    def _stop_process(process):
+        terminate_process_group(process, signal.SIGTERM)
+        try:
+            process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            terminate_process_group(process, signal.SIGKILL)
+            process.wait()
 
     def _finish_task(self, task_id, **updates):
         with self._lock:

--- a/runtimes/python/server_test.py
+++ b/runtimes/python/server_test.py
@@ -1,6 +1,7 @@
 import tempfile
 import time
 import unittest
+import json
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -157,6 +158,7 @@ def handler(event):
     def test_function_runtime_register_invoke_and_unregister(self):
         wd = self._prepare_inline("""
 def handler(event):
+    print("handler log")
     return {"status": "ok", "value": event["value"]}
 """, filename="app.py")
         registration = self._register_function(wd)
@@ -190,6 +192,53 @@ def handler(event):
                 runtime_pb2.FunctionStatusRequest(registration=registration)
             )
         self.assertEqual(ctx.exception.code(), grpc.StatusCode.NOT_FOUND)
+
+    def test_function_runtime_preserves_json_response_for_logs_and_none(self):
+        wd = self._prepare_inline("""
+def handler(event):
+    print("handler log")
+    return event.get("result")
+""", filename="app.py")
+        registration = self._register_function(wd)
+
+        response = self.function_stub.InvokeFunction(
+            runtime_pb2.InvokeFunctionRequest(
+                registration=registration,
+                content_type="application/json",
+                input=b'{"result":{"status":"ok"}}',
+            )
+        )
+        self.assertEqual(response.output, b'{"status": "ok"}\n')
+
+        null_response = self.function_stub.InvokeFunction(
+            runtime_pb2.InvokeFunctionRequest(
+                registration=registration,
+                content_type="application/json",
+                input=b'{"result":null}',
+            )
+        )
+        self.assertEqual(null_response.output, b"null\n")
+
+    def test_function_runtime_accepts_one_mebibyte_input(self):
+        wd = self._prepare_inline("""
+def handler(event):
+    return {"size": len(event["payload"])}
+""", filename="app.py")
+        registration = self._register_function(wd)
+        payload = json.dumps({"payload": "x" * (1024 * 1024 - 64)}).encode()
+        self.assertLessEqual(len(payload), 1024 * 1024)
+
+        response = self.function_stub.InvokeFunction(
+            runtime_pb2.InvokeFunctionRequest(
+                registration=registration,
+                content_type="application/json",
+                input=payload,
+            )
+        )
+        self.assertEqual(
+            response.output,
+            f'{{"size": {1024 * 1024 - 64}}}\n'.encode(),
+        )
 
     def test_function_runtime_registration_fencing(self):
         wd = self._prepare_inline("""

--- a/runtimes/python/server_test.py
+++ b/runtimes/python/server_test.py
@@ -17,10 +17,15 @@ class TestPythonRuntime(unittest.TestCase):
         self.server = grpc.server(ThreadPoolExecutor(max_workers=4))
         self.servicer = PythonRuntime(str(self.work_dir))
         runtime_pb2_grpc.add_RuntimeServicer_to_server(self.servicer, self.server)
+        runtime_pb2_grpc.add_FunctionRuntimeServicer_to_server(
+            self.servicer,
+            self.server,
+        )
         port = self.server.add_insecure_port("localhost:0")
         self.server.start()
         self.channel = grpc.insecure_channel(f"localhost:{port}")
         self.stub = runtime_pb2_grpc.RuntimeStub(self.channel)
+        self.function_stub = runtime_pb2_grpc.FunctionRuntimeStub(self.channel)
 
     def tearDown(self):
         self.server.stop(0)
@@ -43,6 +48,34 @@ class TestPythonRuntime(unittest.TestCase):
         td = Path(tempfile.mkdtemp(dir=str(self.work_dir)))
         (td / filename).write_text(code)
         return str(td)
+
+    def _register_function(self, working_dir, run_uid="function-run", attempt=1,
+                           digest="sha256:initial"):
+        response = self.function_stub.RegisterFunction(
+            runtime_pb2.RegisterFunctionRequest(
+                run_uid=run_uid,
+                registration_attempt=attempt,
+                working_dir=working_dir,
+                handler="app.handler",
+                registration_digest=digest,
+            )
+        )
+        self.assertEqual(
+            response.state,
+            runtime_pb2.FUNCTION_REGISTRATION_STATE_READY,
+        )
+        return response.registration
+
+    def _wait_for_function_in_flight(self, registration, timeout=5):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            status = self.function_stub.FunctionStatus(
+                runtime_pb2.FunctionStatusRequest(registration=registration)
+            )
+            if status.in_flight:
+                return
+            time.sleep(0.05)
+        self.fail("timed out waiting for function invocation")
 
     def _prepare_process_tree(self, child_pid_file):
         child_code = f"""
@@ -120,6 +153,134 @@ def handler(event):
         status = self._wait("test3")
         self.assertEqual(status.state, runtime_pb2.EXECUTION_STATE_SUCCEEDED)
         self.assertIn("ok", status.stdout)
+
+    def test_function_runtime_register_invoke_and_unregister(self):
+        wd = self._prepare_inline("""
+def handler(event):
+    return {"status": "ok", "value": event["value"]}
+""", filename="app.py")
+        registration = self._register_function(wd)
+
+        response = self.function_stub.InvokeFunction(
+            runtime_pb2.InvokeFunctionRequest(
+                registration=registration,
+                invocation_id="invoke-1",
+                content_type="application/json",
+                input=b'{"value":"hello"}',
+            )
+        )
+        self.assertEqual(response.invocation_id, "invoke-1")
+        self.assertEqual(response.content_type, "application/json")
+        self.assertEqual(response.output, b'{"status": "ok", "value": "hello"}\n')
+
+        generated = self.function_stub.InvokeFunction(
+            runtime_pb2.InvokeFunctionRequest(
+                registration=registration,
+                content_type="application/json",
+                input=b'{"value":"generated"}',
+            )
+        )
+        self.assertTrue(generated.invocation_id.startswith("inv_"))
+
+        self.function_stub.UnregisterFunction(
+            runtime_pb2.UnregisterFunctionRequest(registration=registration)
+        )
+        with self.assertRaises(grpc.RpcError) as ctx:
+            self.function_stub.FunctionStatus(
+                runtime_pb2.FunctionStatusRequest(registration=registration)
+            )
+        self.assertEqual(ctx.exception.code(), grpc.StatusCode.NOT_FOUND)
+
+    def test_function_runtime_registration_fencing(self):
+        wd = self._prepare_inline("""
+def handler(event):
+    return event
+""", filename="app.py")
+        first = self._register_function(wd, digest="sha256:first")
+        second = self._register_function(
+            wd,
+            attempt=2,
+            digest="sha256:second",
+        )
+        self.assertNotEqual(first.registration_id, second.registration_id)
+
+        with self.assertRaises(grpc.RpcError) as ctx:
+            self.function_stub.InvokeFunction(
+                runtime_pb2.InvokeFunctionRequest(
+                    registration=first,
+                    content_type="application/json",
+                    input=b'{}',
+                )
+            )
+        self.assertEqual(ctx.exception.code(), grpc.StatusCode.FAILED_PRECONDITION)
+
+    def test_function_runtime_rejects_invalid_input_and_bounds_output(self):
+        self.servicer.output_limit = 128
+        wd = self._prepare_inline("""
+def handler(event):
+    return "x" * 4096
+""", filename="app.py")
+        registration = self._register_function(wd)
+
+        with self.assertRaises(grpc.RpcError) as ctx:
+            self.function_stub.InvokeFunction(
+                runtime_pb2.InvokeFunctionRequest(
+                    registration=registration,
+                    content_type="text/plain",
+                    input=b'{}',
+                )
+            )
+        self.assertEqual(ctx.exception.code(), grpc.StatusCode.INVALID_ARGUMENT)
+
+        with self.assertRaises(grpc.RpcError) as ctx:
+            self.function_stub.InvokeFunction(
+                runtime_pb2.InvokeFunctionRequest(
+                    registration=registration,
+                    content_type="application/json",
+                    input=b"\xff",
+                )
+            )
+        self.assertEqual(ctx.exception.code(), grpc.StatusCode.INVALID_ARGUMENT)
+
+        with self.assertRaises(grpc.RpcError) as ctx:
+            self.function_stub.InvokeFunction(
+                runtime_pb2.InvokeFunctionRequest(
+                    registration=registration,
+                    content_type="application/json",
+                    input=b'{}',
+                )
+            )
+        self.assertEqual(ctx.exception.code(), grpc.StatusCode.RESOURCE_EXHAUSTED)
+
+    def test_function_runtime_unregister_cancels_in_flight_invocation(self):
+        wd = self._prepare_inline("""
+import time
+
+def handler(event):
+    time.sleep(30)
+    return {"status": "late"}
+""", filename="app.py")
+        registration = self._register_function(wd)
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(
+                self.function_stub.InvokeFunction,
+                runtime_pb2.InvokeFunctionRequest(
+                    registration=registration,
+                    content_type="application/json",
+                    input=b'{}',
+                ),
+            )
+            self._wait_for_function_in_flight(registration)
+            self.function_stub.UnregisterFunction(
+                runtime_pb2.UnregisterFunctionRequest(
+                    registration=registration,
+                    cancel_in_flight=True,
+                )
+            )
+            with self.assertRaises(grpc.RpcError) as ctx:
+                future.result(timeout=10)
+        self.assertEqual(ctx.exception.code(), grpc.StatusCode.CANCELLED)
 
     def test_list_and_cancel(self):
         wd = self._prepare_inline("import time; time.sleep(30)")


### PR DESCRIPTION
Implements the accepted FunctionRuntime contract for the built-in Python runtime.\n\nIncludes handler and workspace validation, registration fencing, bounded JSON invocation, one in-flight invocation per registration, unregister drain/cancel behavior, runtime image wiring, contract tests, and the completed roadmap subtask.