### PR TITLE
feat(runtimed): build function registration requests

### DIFF
--- a/internal/runtimed/function_registration.go
+++ b/internal/runtimed/function_registration.go
@@ -1,0 +1,87 @@
+package runtimed
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	pb "github.com/kruntimes/kruntimes/api/runtime/v1"
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	runretry "github.com/kruntimes/kruntimes/internal/retry"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// functionRegistrationRequest builds the idempotent, Pod-local registration
+// request for the current function Run attempt. The digest deliberately omits
+// workingDir because that path may change when the same immutable Run input is
+// assigned to another Runtime Pod.
+func functionRegistrationRequest(run *v1alpha1.Run, workingDir string) (*pb.RegisterFunctionRequest, error) {
+	if run == nil || run.UID == "" {
+		return nil, fmt.Errorf("function registration requires a Run UID")
+	}
+	if workingDir == "" {
+		return nil, fmt.Errorf("function registration requires a working directory")
+	}
+	function := run.Spec.Mode.Function
+	if function == nil {
+		return nil, fmt.Errorf("function registration requires function mode")
+	}
+	if function.Handler == "" {
+		return nil, fmt.Errorf("function registration requires a handler")
+	}
+
+	digest, err := functionRegistrationDigest(run)
+	if err != nil {
+		return nil, err
+	}
+
+	var idleTimeoutSeconds int64
+	if function.IdleTimeoutSeconds != nil {
+		idleTimeoutSeconds = int64(*function.IdleTimeoutSeconds)
+	}
+	return &pb.RegisterFunctionRequest{
+		RunUid:              string(run.UID),
+		RegistrationAttempt: runretry.CurrentAttempt(run.Status.Attempt),
+		WorkingDir:          workingDir,
+		Handler:             function.Handler,
+		Env:                 functionRegistrationEnv(run.Spec.Env),
+		IdleTimeoutSeconds:  idleTimeoutSeconds,
+		RegistrationDigest:  digest,
+	}, nil
+}
+
+// functionRegistrationDigest is stable for retries of the same immutable Run
+// input and changes when any input visible to FunctionRuntime changes.
+func functionRegistrationDigest(run *v1alpha1.Run) (string, error) {
+	function := run.Spec.Mode.Function
+	if function == nil {
+		return "", fmt.Errorf("function registration requires function mode")
+	}
+
+	identity := struct {
+		Source             *v1alpha1.CodeSource `json:"source,omitempty"`
+		Handler            string               `json:"handler"`
+		Env                map[string]string    `json:"env,omitempty"`
+		IdleTimeoutSeconds *int32               `json:"idleTimeoutSeconds,omitempty"`
+	}{
+		Source:             run.Spec.Source,
+		Handler:            function.Handler,
+		Env:                functionRegistrationEnv(run.Spec.Env),
+		IdleTimeoutSeconds: function.IdleTimeoutSeconds,
+	}
+	canonical, err := json.Marshal(identity)
+	if err != nil {
+		return "", fmt.Errorf("marshal function registration inputs: %w", err)
+	}
+	sum := sha256.Sum256(canonical)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func functionRegistrationEnv(env []corev1.EnvVar) map[string]string {
+	values := make(map[string]string, len(env))
+	for _, variable := range env {
+		values[variable.Name] = variable.Value
+	}
+	return values
+}

--- a/internal/runtimed/function_registration_test.go
+++ b/internal/runtimed/function_registration_test.go
@@ -1,0 +1,145 @@
+package runtimed
+
+import (
+	"testing"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestFunctionRegistrationRequest(t *testing.T) {
+	inline := "def handler(event): return event"
+	idleTimeout := int32(300)
+	run := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{UID: types.UID("run-uid")},
+		Spec: v1alpha1.RunSpec{
+			Source: &v1alpha1.CodeSource{Inline: &inline},
+			Mode: v1alpha1.RunMode{Function: &v1alpha1.RunFunctionMode{
+				Handler:            "app.handler",
+				IdleTimeoutSeconds: &idleTimeout,
+			}},
+			Env: []corev1.EnvVar{
+				{Name: "SECOND", Value: "two"},
+				{Name: "FIRST", Value: "one"},
+			},
+		},
+	}
+
+	request, err := functionRegistrationRequest(run, "/workspace/run-uid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.RunUid != "run-uid" {
+		t.Fatalf("RunUid = %q, want run-uid", request.RunUid)
+	}
+	if request.RegistrationAttempt != 1 {
+		t.Fatalf("RegistrationAttempt = %d, want 1", request.RegistrationAttempt)
+	}
+	if request.WorkingDir != "/workspace/run-uid" {
+		t.Fatalf("WorkingDir = %q, want /workspace/run-uid", request.WorkingDir)
+	}
+	if request.Handler != "app.handler" {
+		t.Fatalf("Handler = %q, want app.handler", request.Handler)
+	}
+	if request.IdleTimeoutSeconds != 300 {
+		t.Fatalf("IdleTimeoutSeconds = %d, want 300", request.IdleTimeoutSeconds)
+	}
+	if request.Env["FIRST"] != "one" || request.Env["SECOND"] != "two" {
+		t.Fatalf("Env = %#v, want both values", request.Env)
+	}
+	if request.RegistrationDigest == "" {
+		t.Fatal("RegistrationDigest is empty")
+	}
+}
+
+func TestFunctionRegistrationRequestUsesCurrentAttempt(t *testing.T) {
+	run := functionRegistrationTestRun()
+	run.Status.Attempt = 3
+
+	request, err := functionRegistrationRequest(run, "/workspace/run-uid")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if request.RegistrationAttempt != 3 {
+		t.Fatalf("RegistrationAttempt = %d, want 3", request.RegistrationAttempt)
+	}
+}
+
+func TestFunctionRegistrationDigestIsCanonicalAndExcludesWorkingDirectory(t *testing.T) {
+	run := functionRegistrationTestRun()
+	first, err := functionRegistrationRequest(run, "/workspace/first")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run.Spec.Env = []corev1.EnvVar{
+		{Name: "SECOND", Value: "two"},
+		{Name: "FIRST", Value: "one"},
+	}
+	second, err := functionRegistrationRequest(run, "/workspace/second")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.RegistrationDigest != second.RegistrationDigest {
+		t.Fatalf("digest changed for equivalent registration inputs: %q != %q", first.RegistrationDigest, second.RegistrationDigest)
+	}
+
+	run.Spec.Mode.Function.Handler = "app.other"
+	changedHandler, err := functionRegistrationRequest(run, "/workspace/second")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.RegistrationDigest == changedHandler.RegistrationDigest {
+		t.Fatal("digest did not change after handler changed")
+	}
+}
+
+func TestFunctionRegistrationRequestRejectsIncompleteFunctionRun(t *testing.T) {
+	missingUID := functionRegistrationTestRun()
+	missingUID.UID = ""
+	missingHandler := functionRegistrationTestRun()
+	missingHandler.Spec.Mode.Function.Handler = ""
+	tests := []struct {
+		name       string
+		run        *v1alpha1.Run
+		workingDir string
+	}{
+		{name: "missing-run-uid", run: missingUID, workingDir: "/workspace/run"},
+		{name: "missing-working-directory", run: functionRegistrationTestRun()},
+		{name: "missing-handler", run: missingHandler, workingDir: "/workspace/run"},
+		{
+			name: "task-mode",
+			run: &v1alpha1.Run{
+				ObjectMeta: metav1.ObjectMeta{UID: types.UID("run-uid")},
+				Spec:       v1alpha1.RunSpec{Mode: v1alpha1.RunMode{Task: &v1alpha1.RunTaskMode{}}},
+			},
+			workingDir: "/workspace/run",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := functionRegistrationRequest(tt.run, tt.workingDir); err == nil {
+				t.Fatal("functionRegistrationRequest() error = nil")
+			}
+		})
+	}
+}
+
+func functionRegistrationTestRun() *v1alpha1.Run {
+	inline := "def handler(event): return event"
+	return &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{UID: types.UID("run-uid")},
+		Spec: v1alpha1.RunSpec{
+			Source: &v1alpha1.CodeSource{Inline: &inline},
+			Mode: v1alpha1.RunMode{Function: &v1alpha1.RunFunctionMode{
+				Handler: "app.handler",
+			}},
+			Env: []corev1.EnvVar{
+				{Name: "FIRST", Value: "one"},
+				{Name: "SECOND", Value: "two"},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Adds the deterministic FunctionRuntime registration request builder needed by the accepted function lifecycle design.\n\nThe builder uses the shared 1-based attempt helper, creates a canonical SHA-256 digest of immutable runtime-visible inputs, excludes the transient working directory, and is covered by focused tests. It deliberately does not yet change lifecycle state or invoke FunctionRuntime RPCs.