### PR TITLE
docs(function): propose inline source materialization

### DIFF
--- a/docs/design/_index.md
+++ b/docs/design/_index.md
@@ -8,6 +8,7 @@ implemented.
 ## Documents
 
 - [Function Mode and Agent Sandboxes](function-mode/)
+- [Function Inline Source Materialization](function-inline-source/)
 - [Function Mode Lifecycle and Invoke Dataplane](function-mode-lifecycle/)
 - [Function Runtime Server Contract](function-runtime-contract/)
 - [Workflow Data Sharing](workflow-data-sharing/)

--- a/docs/design/_index.zh.md
+++ b/docs/design/_index.zh.md
@@ -6,6 +6,7 @@
 ## 文档列表
 
 - [Function Mode 和 Agent Sandboxes](function-mode/)
+- [Function Inline Source 物化](function-inline-source/)
 - [Function Mode 生命周期与 Invoke Dataplane](function-mode-lifecycle/)
 - [Function Runtime Server 协议](function-runtime-contract/)
 - [Workflow Data Sharing](workflow-data-sharing/)

--- a/docs/design/function-inline-source.md
+++ b/docs/design/function-inline-source.md
@@ -1,0 +1,105 @@
+# Function Inline Source Materialization
+
+Status: **Proposed for review**
+
+Function-mode Runs can use either repository source or inline source. Repository
+source already preserves its file layout. Inline source currently does not: runtimed
+writes it to a fixed file named `script`. That is insufficient for function handlers
+whose runtime-defined handler notation identifies a file or module, such as Python
+`app.invoke` or Bash `handler.handle`.
+
+This document proposes the minimal API needed to materialize a single inline
+function source file predictably, without making runtimed understand any specific
+runtime language.
+
+## Proposed API
+
+Add `inlinePath` to `Run.spec.source`:
+
+```go
+type CodeSource struct {
+    Inline     string `json:"inline,omitempty"`
+    InlinePath string `json:"inlinePath,omitempty"`
+    Git        *GitSource `json:"git,omitempty"`
+}
+```
+
+For the first version, `inlinePath` is only valid for function-mode Runs and is
+required when `source.inline` is set for a function-mode Run. It is the relative
+path, below the prepared Run working directory, at which runtimed writes the inline
+source.
+
+```yaml
+apiVersion: kruntimes.io/v1alpha1
+kind: Run
+metadata:
+  name: kube-diagnose-agent
+spec:
+  runtime: python
+  source:
+    inlinePath: app.py
+    inline: |
+      def invoke(request):
+          return {"summary": "diagnosis complete"}
+  mode:
+    function:
+      handler: app.invoke
+```
+
+The same mechanism supports a Bash function runtime:
+
+```yaml
+spec:
+  runtime: bash
+  source:
+    inlinePath: handler.sh
+    inline: |
+      handle() {
+        printf '%s\n' "$1"
+      }
+  mode:
+    function:
+      handler: handler.handle
+```
+
+`inlinePath` describes source materialization only. `handler` remains the
+runtime-defined callable entrypoint. Runtimed validates the path but does not infer
+language-specific extensions or attempt to prove that it matches the handler. The
+Runtime Server remains responsible for validating and loading its handler format.
+
+## Validation and Preparation
+
+`inlinePath` must be a non-empty relative file path when it is required. Validation
+must reject absolute paths, `.` or `..` path segments, an empty basename, and values
+longer than 4096 bytes. Runtimed must create parent directories beneath the prepared
+working directory and write the inline content only to the validated path.
+
+Task-mode inline semantics remain unchanged in this proposal: without function mode,
+inline source continues to be written to the existing default `script` file.
+`inlinePath` is rejected for task-mode Runs so it cannot introduce ambiguity with
+`mode.task.entrypoint`.
+
+An inline source represents exactly one file. Functions needing a package, multiple
+files, generated dependencies, or another repository layout should use `source.git`
+or a referenced persistent workspace instead.
+
+## Why This Boundary
+
+Inferring `app.py` or `handler.sh` from a handler in runtimed would couple the shared
+source-preparation layer to built-in runtime conventions and prevent custom runtimes
+from defining their own handler formats. Restricting function mode to repository
+source would make the most useful small-function case unnecessarily awkward.
+
+The explicit path keeps the source contract generic and makes the generated file
+layout visible to users. It also leaves task process-start semantics unchanged until
+they receive their own API review.
+
+## Implementation Follow-Up
+
+After this API is approved:
+
+1. add the API field, CEL validation, generated deepcopy code, and CRD manifests;
+2. update generic source preparation to materialize the validated path;
+3. update function examples and validation tests for Python, Bash, repository, and
+   invalid-path cases;
+4. implement the function registration lifecycle from `Scheduled` through `Ready`.

--- a/docs/design/function-inline-source.zh.md
+++ b/docs/design/function-inline-source.zh.md
@@ -1,0 +1,95 @@
+# Function Inline Source 物化
+
+状态：**提案，等待 review**
+
+function-mode Run 可以使用 repository source 或 inline source。repository source 会保留原有
+文件布局；当前 inline source 不会：runtimed 会将其写到固定的 `script` 文件。对于由 runtime
+定义、并通过文件或 module 标识的 handler，这并不足够，例如 Python `app.invoke` 或 Bash
+`handler.handle`。
+
+本文提出一个最小 API，使单个 inline function source 能以可预测的文件路径物化，同时不让
+runtimed 理解具体 runtime 的语言。
+
+## 提议的 API
+
+在 `Run.spec.source` 增加 `inlinePath`：
+
+```go
+type CodeSource struct {
+    Inline     string `json:"inline,omitempty"`
+    InlinePath string `json:"inlinePath,omitempty"`
+    Git        *GitSource `json:"git,omitempty"`
+}
+```
+
+第一版中，`inlinePath` 只允许在 function-mode Run 中使用；当 function-mode Run 设置了
+`source.inline` 时它必须存在。它表示 runtimed 在准备后的 Run working directory 下写入
+inline source 的相对路径。
+
+```yaml
+apiVersion: kruntimes.io/v1alpha1
+kind: Run
+metadata:
+  name: kube-diagnose-agent
+spec:
+  runtime: python
+  source:
+    inlinePath: app.py
+    inline: |
+      def invoke(request):
+          return {"summary": "diagnosis complete"}
+  mode:
+    function:
+      handler: app.invoke
+```
+
+同一机制也适用于 Bash function runtime：
+
+```yaml
+spec:
+  runtime: bash
+  source:
+    inlinePath: handler.sh
+    inline: |
+      handle() {
+        printf '%s\n' "$1"
+      }
+  mode:
+    function:
+      handler: handler.handle
+```
+
+`inlinePath` 只描述 source 的物化方式。`handler` 仍然是由 runtime 定义的 callable
+entrypoint。runtimed 负责验证路径，但不推断语言相关扩展名，也不试图验证它是否和 handler
+匹配。Runtime Server 仍负责验证和加载其 handler 格式。
+
+## 验证与准备
+
+当 `inlinePath` 被要求时，它必须是非空的相对文件路径。验证必须拒绝绝对路径、`.` 或 `..`
+path segment、空 basename 以及超过 4096 bytes 的值。runtimed 必须只在准备后的 working
+directory 下创建父目录，并将 inline 内容写到已验证的路径。
+
+本提案不改变 task-mode inline 的语义：未使用 function mode 时，inline source 继续写到已有的
+默认 `script` 文件。task-mode Run 上的 `inlinePath` 会被拒绝，避免它和
+`mode.task.entrypoint` 产生歧义。
+
+一份 inline source 只表示一个文件。需要 package、多个文件、生成的依赖或其他 repository
+布局的 function，应使用 `source.git` 或引用 persistent workspace。
+
+## 为什么采用这个边界
+
+在 runtimed 中根据 handler 推断 `app.py` 或 `handler.sh`，会把共享 source-preparation 层和
+内置 runtime 的约定耦合起来，并阻止 custom runtime 定义自己的 handler 格式。限制 function
+mode 只能使用 repository source，又会使最常见的小型 function 场景不必要地复杂。
+
+显式路径使 source contract 保持通用，也让用户可以直接看出生成后的文件布局。同时，在 task
+process-start 语义经过单独 API review 前，它不会改变 task 的行为。
+
+## 后续实现
+
+该 API 获得批准后：
+
+1. 增加 API field、CEL validation、generated deepcopy code 和 CRD manifests；
+2. 更新通用 source preparation，使其物化已验证的路径；
+3. 更新 function 示例和 Python、Bash、repository、invalid-path 的 validation tests；
+4. 实现从 `Scheduled` 到 `Ready` 的 function registration lifecycle。

--- a/docs/design/function-mode.md
+++ b/docs/design/function-mode.md
@@ -103,6 +103,7 @@ metadata:
 spec:
   runtime: python
   source:
+    inlinePath: main.py
     inline: |
       def invoke(request):
           return {

--- a/docs/design/function-mode.zh.md
+++ b/docs/design/function-mode.zh.md
@@ -95,6 +95,7 @@ metadata:
 spec:
   runtime: python
   source:
+    inlinePath: main.py
     inline: |
       def invoke(request):
           return {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -117,6 +117,9 @@ wiring from accumulating avoidable conflicts.
     and active/non-terminal phase-classification tests;
   - [x] add immutable execution-input transitions and the function cleanup
     finalizer constant;
+  - [ ] review and approve the
+    [Function Inline Source Materialization](design/function-inline-source.md)
+    API before registering inline function Runs;
   - [ ] implement the function control-plane lifecycle in independently
     reviewable slices:
     - [ ] add a deterministic FunctionRuntime registration request builder,

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -105,6 +105,8 @@ controller wiring 累积不必要的冲突。
     active/non-terminal phase-classification tests；
   - [x] 增加 immutable execution-input transitions 和 function cleanup finalizer
     constant；
+  - [ ] 在注册 inline function Run 前 review 并批准
+    [Function Inline Source 物化](design/function-inline-source.md) API；
   - [ ] 实现 registration lifecycle、shared retry integration、reservation/idle timeout、
     finalization 和 restart recovery；
 - [ ] Runtime gateway invoke path：为每个 Runtime 创建一个 gateway Service，把这个


### PR DESCRIPTION
## Summary
- propose `Run.spec.source.inlinePath` for function-mode inline source materialization
- keep task-mode inline behavior unchanged and reject `inlinePath` for task Runs
- link the bilingual design and roadmap to the required API decision

## Validation
- `GOBIN=/tmp/kruntimes-bin make site-build`

This is an API design proposal. Runtime implementation follows only after the API decision is accepted.