### PR TITLE
docs(roadmap): split scheduler affinity work

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -84,17 +84,26 @@ wiring from accumulating avoidable conflicts.
   [Scheduler Framework](design/scheduler-framework.md) architecture before
   changing scheduler behavior.
   Initial implementation TODO:
-    - [ ] review Run queue ownership, snapshot, PreFilter, Filter, Score,
+  - [x] review Run queue ownership, snapshot, PreFilter, Filter, Score,
     Reserve/Assume, Bind, status, and retry semantics;
-  - [ ] review the [Run resource accounting](design/run-resource-accounting.md)
+  - [x] review the [Run resource accounting](design/run-resource-accounting.md)
     API before extending scheduler capacity checks beyond the built-in `runs`
     resource;
-  - [ ] refactor scheduler internals behind queue/planner interfaces while
+  - [x] refactor scheduler internals behind queue/planner interfaces while
     preserving current observable behavior and metrics;
-  - [ ] add deterministic selection, assumed-capacity, bind-conflict,
+  - [x] add deterministic selection, assumed-capacity, bind-conflict,
     and restart-recovery coverage;
-  - [ ] implement assumed affinity targets and Inter-Run Affinity
-    bootstrap, with integration and E2E coverage;
+  - [ ] implement assumed affinity targets and Inter-Run Affinity bootstrap:
+    - [ ] project namespace-local actual assignments and unconfirmed assumed
+      assignments into an immutable affinity-target snapshot;
+    - [ ] add required Run affinity and anti-affinity filtering with bounded
+      Pending waiting reasons;
+    - [ ] score preferred affinity and anti-affinity ahead of deterministic
+      capacity placement;
+    - [ ] allow an eligible label-matching Run to seed an empty Inter-Run
+      Affinity cohort, while keeping unsatisfiable dependencies Pending;
+    - [ ] add unit, integration, and E2E coverage for actual targets, assumed
+      targets, bootstrap, anti-affinity, capacity, and recovery;
   - [ ] define priority, fairness, and starvation policy in a separate API
     design before adding `Run.spec.priority` or equivalent API;
 - [ ] Function-mode Runs for agent sandboxes: define mutually exclusive

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -76,15 +76,22 @@ controller wiring 累积不必要的冲突。
   单 Run scheduling cycles。在改变 scheduler behavior 前，review
   [Scheduler Framework](design/scheduler-framework.md) architecture。
   初始实现 TODO：
-  - [ ] review Run queue ownership、snapshot、PreFilter、Filter、Score、Reserve/Assume、Bind、status 和
+  - [x] review Run queue ownership、snapshot、PreFilter、Filter、Score、Reserve/Assume、Bind、status 和
     retry semantics；
-  - [ ] 在将 scheduler capacity check 扩展到内建 `runs` resource 以外前，review
+  - [x] 在将 scheduler capacity check 扩展到内建 `runs` resource 以外前，review
     [Run resource accounting](design/run-resource-accounting.md) API；
-  - [ ] 在 queue/planner interfaces 后重构 scheduler internals，同时保留当前 observable behavior 和
+  - [x] 在 queue/planner interfaces 后重构 scheduler internals，同时保留当前 observable behavior 和
     metrics；
-  - [ ] 增加 deterministic selection、assumed-capacity、bind-conflict 和 restart-recovery coverage；
-  - [ ] 实现 assumed affinity targets 和 Run 间亲和性 bootstrap，并增加 integration 和 E2E
-    coverage；
+  - [x] 增加 deterministic selection、assumed-capacity、bind-conflict 和 restart-recovery coverage；
+  - [ ] 实现 assumed affinity targets 和 Run 间亲和性 bootstrap：
+    - [ ] 将 namespace-local actual assignment 和尚未确认的 assumed assignment 投影为不可变的
+      affinity-target snapshot；
+    - [ ] 增加 required Run affinity 和 anti-affinity filter，以及有界的 Pending waiting reason；
+    - [ ] 在 deterministic capacity placement 前，对 preferred affinity 和 anti-affinity 评分；
+    - [ ] 允许 label-matching 的 eligible Run seed 一个空的 Run 间亲和性 cohort，同时让不能满足的
+      dependency 保持 Pending；
+    - [ ] 增加 actual target、assumed target、bootstrap、anti-affinity、capacity 和 recovery 的
+      unit、integration 与 E2E coverage；
   - [ ] 在增加 `Run.spec.priority` 或等价 API 前，通过独立 API design 定义 priority、fairness 和
     starvation policy；
 - [ ] Agent sandbox 所需的 Function-mode Runs：定义 mutually exclusive 的


### PR DESCRIPTION
## Summary
- mark merged scheduler framework, resource-accounting, and reservation foundations complete
- split remaining assumed-target and Inter-Run Affinity work into independently reviewable implementation and test slices
- keep English and Chinese roadmaps aligned

## Validation
- GOBIN=/tmp/kruntimes-bin make site-build