### PR TITLE
feat(scheduler): apply Run affinity in framework

### DIFF
--- a/internal/scheduler/affinity.go
+++ b/internal/scheduler/affinity.go
@@ -1,0 +1,147 @@
+package scheduler
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+type affinityTarget struct {
+	podName string
+	labels  map[string]string
+}
+
+type affinityRule struct {
+	selector labels.Selector
+	weight   int32
+	pods     map[string]bool
+	seedable bool
+}
+
+type runAffinity struct {
+	required      []affinityRule
+	requiredAnti  []affinityRule
+	preferred     []affinityRule
+	preferredAnti []affinityRule
+}
+
+func newRunAffinity(run *v1alpha1.Run, targets []affinityTarget) (runAffinity, error) {
+	if run == nil || run.Spec.Affinity == nil {
+		return runAffinity{}, nil
+	}
+	build := func(term v1alpha1.RunAffinityTerm, weight int32, allowSeed bool) (affinityRule, error) {
+		if term.TopologyKey != v1alpha1.RunAffinityTopologyRuntimePod {
+			return affinityRule{}, fmt.Errorf("unsupported run affinity topology key %q", term.TopologyKey)
+		}
+		if term.LabelSelector == nil {
+			return affinityRule{}, fmt.Errorf("run affinity term has no label selector")
+		}
+		selector, err := metav1.LabelSelectorAsSelector(term.LabelSelector)
+		if err != nil {
+			return affinityRule{}, fmt.Errorf("parse run affinity selector: %w", err)
+		}
+		pods := map[string]bool{}
+		for _, target := range targets {
+			if selector.Matches(labels.Set(target.labels)) {
+				pods[target.podName] = true
+			}
+		}
+		return affinityRule{selector: selector, weight: weight, pods: pods, seedable: allowSeed && len(pods) == 0 && selector.Matches(labels.Set(run.Labels))}, nil
+	}
+	var result runAffinity
+	appendRules := func(rules *v1alpha1.RunAffinityRules, anti bool) error {
+		if rules == nil {
+			return nil
+		}
+		for _, term := range rules.RequiredDuringSchedulingIgnoredDuringExecution {
+			rule, err := build(term, 0, !anti)
+			if err != nil {
+				return err
+			}
+			if anti {
+				result.requiredAnti = append(result.requiredAnti, rule)
+			} else {
+				result.required = append(result.required, rule)
+			}
+		}
+		for _, weighted := range rules.PreferredDuringSchedulingIgnoredDuringExecution {
+			rule, err := build(weighted.RunAffinityTerm, weighted.Weight, false)
+			if err != nil {
+				return err
+			}
+			if anti {
+				result.preferredAnti = append(result.preferredAnti, rule)
+			} else {
+				result.preferred = append(result.preferred, rule)
+			}
+		}
+		return nil
+	}
+	if err := appendRules(run.Spec.Affinity.RunAffinity, false); err != nil {
+		return runAffinity{}, err
+	}
+	if err := appendRules(run.Spec.Affinity.RunAntiAffinity, true); err != nil {
+		return runAffinity{}, err
+	}
+	return result, nil
+}
+
+func (a runAffinity) matchesRequired(podName string) bool {
+	for _, rule := range a.required {
+		if !rule.pods[podName] && !rule.seedable {
+			return false
+		}
+	}
+	for _, rule := range a.requiredAnti {
+		if rule.pods[podName] {
+			return false
+		}
+	}
+	return true
+}
+
+func (a runAffinity) preferredCandidates(candidates []corev1.Pod) []corev1.Pod {
+	if len(candidates) < 2 || (len(a.preferred) == 0 && len(a.preferredAnti) == 0) {
+		return candidates
+	}
+	var best int32
+	scores := make([]int32, len(candidates))
+	for i, pod := range candidates {
+		for _, rule := range a.preferred {
+			if rule.pods[pod.Name] {
+				scores[i] += rule.weight
+			}
+		}
+		for _, rule := range a.preferredAnti {
+			if !rule.pods[pod.Name] {
+				scores[i] += rule.weight
+			}
+		}
+		if i == 0 || scores[i] > best {
+			best = scores[i]
+		}
+	}
+	selected := make([]corev1.Pod, 0, len(candidates))
+	for i, pod := range candidates {
+		if scores[i] == best {
+			selected = append(selected, pod)
+		}
+	}
+	return selected
+}
+
+func isActiveAffinityTarget(run *v1alpha1.Run) bool {
+	if run == nil || run.Status.AssignedPod == "" {
+		return false
+	}
+	switch run.Status.Phase {
+	case v1alpha1.RunScheduled, v1alpha1.RunRunning, v1alpha1.RunReady:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/scheduler/affinity.go
+++ b/internal/scheduler/affinity.go
@@ -29,6 +29,22 @@ type runAffinity struct {
 	preferredAnti []affinityRule
 }
 
+type runAffinityFilter struct {
+	affinity runAffinity
+}
+
+func newRunAffinityFilter(_ *RunReconciler, _ *schedulingSnapshot, preFilter *schedulingPreFilterState) (filterPlugin, error) {
+	return &runAffinityFilter{affinity: preFilter.affinity}, nil
+}
+
+func (f *runAffinityFilter) Name() string {
+	return "RunAffinity"
+}
+
+func (f *runAffinityFilter) Filter(_ *schedulingSnapshot, pod *corev1.Pod) filterResult {
+	return f.affinity.filter(pod.Name)
+}
+
 func newRunAffinity(run *v1alpha1.Run, targets []affinityTarget) (runAffinity, error) {
 	if run == nil || run.Spec.Affinity == nil {
 		return runAffinity{}, nil
@@ -90,18 +106,18 @@ func newRunAffinity(run *v1alpha1.Run, targets []affinityTarget) (runAffinity, e
 	return result, nil
 }
 
-func (a runAffinity) matchesRequired(podName string) bool {
+func (a runAffinity) filter(podName string) filterResult {
 	for _, rule := range a.required {
 		if !rule.pods[podName] && !rule.seedable {
-			return false
+			return filterResult{reason: filterReasonRunAffinity}
 		}
 	}
 	for _, rule := range a.requiredAnti {
 		if rule.pods[podName] {
-			return false
+			return filterResult{reason: filterReasonRunAntiAffinity}
 		}
 	}
-	return true
+	return filterResult{feasible: true}
 }
 
 func (a runAffinity) preferredCandidates(candidates []corev1.Pod) []corev1.Pod {

--- a/internal/scheduler/affinity_test.go
+++ b/internal/scheduler/affinity_test.go
@@ -1,0 +1,80 @@
+package scheduler
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kruntimes/kruntimes/api/v1alpha1"
+)
+
+func TestRunAffinityFiltersActualTargetsAndScoresPreferences(t *testing.T) {
+	run := affinityTestRun("next", map[string]string{"stage": "test"}, &v1alpha1.RunAffinity{
+		RunAffinity: &v1alpha1.RunAffinityRules{
+			RequiredDuringSchedulingIgnoredDuringExecution:  []v1alpha1.RunAffinityTerm{affinityTestTerm("stage", "build")},
+			PreferredDuringSchedulingIgnoredDuringExecution: []v1alpha1.WeightedRunAffinityTerm{{Weight: 10, RunAffinityTerm: affinityTestTerm("zone", "blue")}},
+		},
+		RunAntiAffinity: &v1alpha1.RunAffinityRules{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1alpha1.RunAffinityTerm{affinityTestTerm("blocked", "true")},
+		},
+	})
+	affinity, err := newRunAffinity(run, []affinityTarget{
+		{podName: "pod-a", labels: map[string]string{"stage": "build", "zone": "blue"}},
+		{podName: "pod-b", labels: map[string]string{"stage": "build", "blocked": "true"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !affinity.matchesRequired("pod-a") || affinity.matchesRequired("pod-b") || affinity.matchesRequired("pod-c") {
+		t.Fatalf("required filter results are incorrect")
+	}
+	candidates := affinity.preferredCandidates([]corev1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: "pod-a"}}, {ObjectMeta: metav1.ObjectMeta{Name: "pod-c"}}})
+	if len(candidates) != 1 || candidates[0].Name != "pod-a" {
+		t.Fatalf("preferred candidates = %#v, want pod-a", candidates)
+	}
+}
+
+func TestRunAffinityBootstrapRequiresMatchingRunLabel(t *testing.T) {
+	term := affinityTestTerm("cohort", "build")
+	matching := affinityTestRun("first", map[string]string{"cohort": "build"}, &v1alpha1.RunAffinity{RunAffinity: &v1alpha1.RunAffinityRules{RequiredDuringSchedulingIgnoredDuringExecution: []v1alpha1.RunAffinityTerm{term}}})
+	affinity, err := newRunAffinity(matching, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !affinity.matchesRequired("pod-a") {
+		t.Fatal("matching first cohort member should seed required affinity")
+	}
+
+	nonMatching := affinityTestRun("other", map[string]string{"cohort": "test"}, matching.Spec.Affinity)
+	affinity, err = newRunAffinity(nonMatching, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if affinity.matchesRequired("pod-a") {
+		t.Fatal("non-matching Run must not seed required affinity")
+	}
+}
+
+func TestAssumedReservationAffinityTarget(t *testing.T) {
+	cache := &assumedReservationCache{}
+	run := affinityTestRun("build", map[string]string{"stage": "build"}, nil)
+	run.UID = types.UID("build-uid")
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "runtime-a"}}
+	if !cache.reserve(cacheSnapshot(run, runResourceRequest(1), *run), pod, func(corev1.ResourceList) bool { return true }) {
+		t.Fatal("reserve = false")
+	}
+	targets := cache.affinityTargets([]v1alpha1.Run{*run})
+	if len(targets) != 1 || targets[0].podName != pod.Name || targets[0].labels["stage"] != "build" {
+		t.Fatalf("targets = %#v", targets)
+	}
+}
+
+func affinityTestRun(name string, labels map[string]string, affinity *v1alpha1.RunAffinity) *v1alpha1.Run {
+	return &v1alpha1.Run{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", Labels: labels}, Spec: v1alpha1.RunSpec{Affinity: affinity}}
+}
+
+func affinityTestTerm(key, value string) v1alpha1.RunAffinityTerm {
+	return v1alpha1.RunAffinityTerm{TopologyKey: v1alpha1.RunAffinityTopologyRuntimePod, LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{key: value}}}
+}

--- a/internal/scheduler/affinity_test.go
+++ b/internal/scheduler/affinity_test.go
@@ -27,7 +27,7 @@ func TestRunAffinityFiltersActualTargetsAndScoresPreferences(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !affinity.matchesRequired("pod-a") || affinity.matchesRequired("pod-b") || affinity.matchesRequired("pod-c") {
+	if !affinity.filter("pod-a").feasible || affinity.filter("pod-b").feasible || affinity.filter("pod-c").feasible {
 		t.Fatalf("required filter results are incorrect")
 	}
 	candidates := affinity.preferredCandidates([]corev1.Pod{{ObjectMeta: metav1.ObjectMeta{Name: "pod-a"}}, {ObjectMeta: metav1.ObjectMeta{Name: "pod-c"}}})
@@ -43,7 +43,7 @@ func TestRunAffinityBootstrapRequiresMatchingRunLabel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !affinity.matchesRequired("pod-a") {
+	if !affinity.filter("pod-a").feasible {
 		t.Fatal("matching first cohort member should seed required affinity")
 	}
 
@@ -52,7 +52,7 @@ func TestRunAffinityBootstrapRequiresMatchingRunLabel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if affinity.matchesRequired("pod-a") {
+	if affinity.filter("pod-a").feasible {
 		t.Fatal("non-matching Run must not seed required affinity")
 	}
 }

--- a/internal/scheduler/assumed_reservation_cache.go
+++ b/internal/scheduler/assumed_reservation_cache.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"maps"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
@@ -28,6 +29,7 @@ type assumedReservation struct {
 	runName string
 	podName string
 	request corev1.ResourceList
+	labels  map[string]string
 }
 
 func reservationKeyFor(run *v1alpha1.Run) reservationKey {
@@ -35,10 +37,29 @@ func reservationKeyFor(run *v1alpha1.Run) reservationKey {
 }
 
 func (c *assumedReservationCache) effectiveUsage(actual map[string]corev1.ResourceList, runs []v1alpha1.Run) map[string]corev1.ResourceList {
+	usage, _ := c.snapshot(actual, runs)
+	return usage
+}
+
+// snapshot returns capacity accounting and affinity targets from one cache
+// observation, so a scheduling cycle cannot combine usage from one assumption
+// set with targets from another.
+func (c *assumedReservationCache) snapshot(actual map[string]corev1.ResourceList, runs []v1alpha1.Run) (map[string]corev1.ResourceList, []affinityTarget) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.syncLocked(runs)
-	return mergeUsage(actual, c.usageLocked())
+
+	targets := make([]affinityTarget, 0, len(runs)+len(c.reservations))
+	for i := range runs {
+		run := &runs[i]
+		if isActiveAffinityTarget(run) {
+			targets = append(targets, affinityTarget{podName: run.Status.AssignedPod, labels: maps.Clone(run.Labels)})
+		}
+	}
+	for _, reservation := range c.reservations {
+		targets = append(targets, affinityTarget{podName: reservation.podName, labels: maps.Clone(reservation.labels)})
+	}
+	return mergeUsage(actual, c.usageLocked()), targets
 }
 
 func (c *assumedReservationCache) reserve(snapshot *schedulingSnapshot, pod *corev1.Pod, available func(corev1.ResourceList) bool) bool {
@@ -78,7 +99,17 @@ func (c *assumedReservationCache) assumeLocked(run *v1alpha1.Run, podName string
 		runName: run.Name,
 		podName: podName,
 		request: cloneResourceList(request),
+		labels:  maps.Clone(run.Labels),
 	}
+}
+
+// affinityTargets returns immutable placement targets from active observed Runs
+// and still-pending reservations. Keeping this view in the reservation cache
+// makes a selected placement available to a later scheduling cycle before the
+// informer observes the status update.
+func (c *assumedReservationCache) affinityTargets(runs []v1alpha1.Run) []affinityTarget {
+	_, targets := c.snapshot(nil, runs)
+	return targets
 }
 
 func (c *assumedReservationCache) syncLocked(runs []v1alpha1.Run) {

--- a/internal/scheduler/filter_runtime_pod.go
+++ b/internal/scheduler/filter_runtime_pod.go
@@ -1,0 +1,22 @@
+package scheduler
+
+import corev1 "k8s.io/api/core/v1"
+
+type runtimePodAvailabilityFilter struct {
+	reconciler *RunReconciler
+}
+
+func newRuntimePodAvailabilityFilter(reconciler *RunReconciler, _ *schedulingSnapshot, _ *schedulingPreFilterState) (filterPlugin, error) {
+	return &runtimePodAvailabilityFilter{reconciler: reconciler}, nil
+}
+
+func (f *runtimePodAvailabilityFilter) Name() string {
+	return "RuntimePodAvailability"
+}
+
+func (f *runtimePodAvailabilityFilter) Filter(snapshot *schedulingSnapshot, pod *corev1.Pod) filterResult {
+	if f.reconciler.isRuntimePodAvailable(pod, snapshot.now, snapshot.usageByPod[pod.Name], snapshot.request) {
+		return filterResult{feasible: true}
+	}
+	return filterResult{reason: filterReasonRuntimePodUnavailable}
+}

--- a/internal/scheduler/framework.go
+++ b/internal/scheduler/framework.go
@@ -28,8 +28,9 @@ type schedulingSnapshot struct {
 }
 
 type schedulingPlan struct {
-	action   schedulingPlanAction
-	selected *corev1.Pod
+	action     schedulingPlanAction
+	selected   *corev1.Pod
+	rejections map[filterReason]int
 }
 
 type schedulingPlanAction string
@@ -38,6 +39,55 @@ const (
 	schedulingPlanWait schedulingPlanAction = "Wait"
 	schedulingPlanBind schedulingPlanAction = "Bind"
 )
+
+func (p schedulingPlan) waitingMessage(runtime string) string {
+	message := fmt.Sprintf("waiting for available runtime pods for runtime %q", runtime)
+	if p.rejections[filterReasonRunAffinity] > 0 {
+		return fmt.Sprintf("waiting for available runtime pods satisfying required Run affinity for runtime %q", runtime)
+	}
+	if p.rejections[filterReasonRunAntiAffinity] > 0 {
+		return fmt.Sprintf("waiting for available runtime pods satisfying required Run anti-affinity for runtime %q", runtime)
+	}
+	return message
+}
+
+// filterReason is a bounded reason returned when a candidate Runtime Pod is
+// rejected. It is safe to use in status messages and metric labels.
+type filterReason string
+
+const (
+	filterReasonRuntimePodUnavailable filterReason = "RuntimePodUnavailable"
+	filterReasonRunAffinity           filterReason = "UnsatisfiedRunAffinity"
+	filterReasonRunAntiAffinity       filterReason = "UnsatisfiedRunAntiAffinity"
+)
+
+type filterResult struct {
+	feasible bool
+	reason   filterReason
+}
+
+// schedulingPreFilterState contains Run-specific state prepared once before
+// candidate Pods are evaluated. Filter and Score use the same immutable state.
+type schedulingPreFilterState struct {
+	affinity runAffinity
+}
+
+// filterPlugin evaluates one hard scheduling constraint. Plugins receive an
+// immutable snapshot and must not mutate Kubernetes objects, reservations, or
+// placement state.
+type filterPlugin interface {
+	Name() string
+	Filter(*schedulingSnapshot, *corev1.Pod) filterResult
+}
+
+// filterPluginFactory prepares a plugin once per scheduling cycle. It keeps
+// selector compilation and other Run-specific work out of the Pod loop.
+type filterPluginFactory func(*RunReconciler, *schedulingSnapshot, *schedulingPreFilterState) (filterPlugin, error)
+
+var defaultFilterPluginFactories = []filterPluginFactory{
+	newRuntimePodAvailabilityFilter,
+	newRunAffinityFilter,
+}
 
 // loadSchedulingSnapshot performs the Snapshot and PreFilter framework
 // phases. Resource request validation and the Runtime selector are derived
@@ -76,27 +126,60 @@ func (r *RunReconciler) loadSchedulingSnapshot(ctx context.Context, run *v1alpha
 
 // planSchedulingCycle applies the Filter and Score phases to one snapshot.
 func (r *RunReconciler) planSchedulingCycle(snapshot *schedulingSnapshot) (schedulingPlan, error) {
-	affinity, err := newRunAffinity(snapshot.run, snapshot.affinityTargets)
+	preFilter, err := r.preFilter(snapshot)
 	if err != nil {
-		return schedulingPlan{}, fmt.Errorf("pre-filter run affinity: %w", err)
+		return schedulingPlan{}, err
+	}
+	filters, err := r.registeredFilterPlugins(snapshot, preFilter)
+	if err != nil {
+		return schedulingPlan{}, err
 	}
 	candidates := make([]corev1.Pod, 0, len(snapshot.pods))
+	rejections := make(map[filterReason]int)
 	for i := range snapshot.pods {
 		pod := &snapshot.pods[i]
-		if r.isRuntimePodAvailable(pod, snapshot.now, snapshot.usageByPod[pod.Name], snapshot.request) {
-			if affinity.matchesRequired(pod.Name) {
-				candidates = append(candidates, *pod)
+		feasible := true
+		for _, filter := range filters {
+			result := filter.Filter(snapshot, pod)
+			if result.feasible {
+				continue
 			}
+			rejections[result.reason]++
+			feasible = false
+			break
+		}
+		if feasible {
+			candidates = append(candidates, *pod)
 		}
 	}
 	if len(candidates) == 0 {
-		return schedulingPlan{action: schedulingPlanWait}, nil
+		return schedulingPlan{action: schedulingPlanWait, rejections: rejections}, nil
 	}
 
-	candidates = affinity.preferredCandidates(candidates)
+	candidates = preFilter.affinity.preferredCandidates(candidates)
 	selected, err := r.Strategy.Select(candidates, snapshot.usageByPod, snapshot.run)
 	if err != nil {
 		return schedulingPlan{}, fmt.Errorf("score runtime pods: %w", err)
 	}
 	return schedulingPlan{action: schedulingPlanBind, selected: selected}, nil
+}
+
+func (r *RunReconciler) preFilter(snapshot *schedulingSnapshot) (*schedulingPreFilterState, error) {
+	affinity, err := newRunAffinity(snapshot.run, snapshot.affinityTargets)
+	if err != nil {
+		return nil, fmt.Errorf("pre-filter run affinity: %w", err)
+	}
+	return &schedulingPreFilterState{affinity: affinity}, nil
+}
+
+func (r *RunReconciler) registeredFilterPlugins(snapshot *schedulingSnapshot, preFilter *schedulingPreFilterState) ([]filterPlugin, error) {
+	plugins := make([]filterPlugin, 0, len(defaultFilterPluginFactories))
+	for _, factory := range defaultFilterPluginFactories {
+		plugin, err := factory(r, snapshot, preFilter)
+		if err != nil {
+			return nil, err
+		}
+		plugins = append(plugins, plugin)
+	}
+	return plugins, nil
 }

--- a/internal/scheduler/framework.go
+++ b/internal/scheduler/framework.go
@@ -28,9 +28,9 @@ type schedulingSnapshot struct {
 }
 
 type schedulingPlan struct {
-	action     schedulingPlanAction
-	selected   *corev1.Pod
-	rejections map[filterReason]int
+	action         schedulingPlanAction
+	selected       *corev1.Pod
+	pendingMessage string
 }
 
 type schedulingPlanAction string
@@ -40,12 +40,12 @@ const (
 	schedulingPlanBind schedulingPlanAction = "Bind"
 )
 
-func (p schedulingPlan) waitingMessage(runtime string) string {
+func waitingMessageForFilterRejections(runtime string, rejections map[filterReason]int) string {
 	message := fmt.Sprintf("waiting for available runtime pods for runtime %q", runtime)
-	if p.rejections[filterReasonRunAffinity] > 0 {
+	if rejections[filterReasonRunAffinity] > 0 {
 		return fmt.Sprintf("waiting for available runtime pods satisfying required Run affinity for runtime %q", runtime)
 	}
-	if p.rejections[filterReasonRunAntiAffinity] > 0 {
+	if rejections[filterReasonRunAntiAffinity] > 0 {
 		return fmt.Sprintf("waiting for available runtime pods satisfying required Run anti-affinity for runtime %q", runtime)
 	}
 	return message
@@ -153,7 +153,10 @@ func (r *RunReconciler) planSchedulingCycle(snapshot *schedulingSnapshot) (sched
 		}
 	}
 	if len(candidates) == 0 {
-		return schedulingPlan{action: schedulingPlanWait, rejections: rejections}, nil
+		return schedulingPlan{
+			action:         schedulingPlanWait,
+			pendingMessage: waitingMessageForFilterRejections(snapshot.run.Spec.Runtime, rejections),
+		}, nil
 	}
 
 	candidates = preFilter.affinity.preferredCandidates(candidates)

--- a/internal/scheduler/framework.go
+++ b/internal/scheduler/framework.go
@@ -23,6 +23,7 @@ type schedulingSnapshot struct {
 	actualUsageByPod map[string]corev1.ResourceList
 	usageByPod       map[string]corev1.ResourceList
 	runs             []v1alpha1.Run
+	affinityTargets  []affinityTarget
 	now              time.Time
 }
 
@@ -59,7 +60,7 @@ func (r *RunReconciler) loadSchedulingSnapshot(ctx context.Context, run *v1alpha
 	if err != nil {
 		return nil, fmt.Errorf("snapshot assigned run usage: %w", err)
 	}
-	usageByPod := r.effectiveUsage(actualUsageByPod, runs)
+	usageByPod, affinityTargets := r.assumptions.snapshot(actualUsageByPod, runs)
 
 	return &schedulingSnapshot{
 		run:              run,
@@ -68,23 +69,31 @@ func (r *RunReconciler) loadSchedulingSnapshot(ctx context.Context, run *v1alpha
 		actualUsageByPod: actualUsageByPod,
 		usageByPod:       usageByPod,
 		runs:             runs,
+		affinityTargets:  affinityTargets,
 		now:              time.Now(),
 	}, nil
 }
 
 // planSchedulingCycle applies the Filter and Score phases to one snapshot.
 func (r *RunReconciler) planSchedulingCycle(snapshot *schedulingSnapshot) (schedulingPlan, error) {
+	affinity, err := newRunAffinity(snapshot.run, snapshot.affinityTargets)
+	if err != nil {
+		return schedulingPlan{}, fmt.Errorf("pre-filter run affinity: %w", err)
+	}
 	candidates := make([]corev1.Pod, 0, len(snapshot.pods))
 	for i := range snapshot.pods {
 		pod := &snapshot.pods[i]
 		if r.isRuntimePodAvailable(pod, snapshot.now, snapshot.usageByPod[pod.Name], snapshot.request) {
-			candidates = append(candidates, *pod)
+			if affinity.matchesRequired(pod.Name) {
+				candidates = append(candidates, *pod)
+			}
 		}
 	}
 	if len(candidates) == 0 {
 		return schedulingPlan{action: schedulingPlanWait}, nil
 	}
 
+	candidates = affinity.preferredCandidates(candidates)
 	selected, err := r.Strategy.Select(candidates, snapshot.usageByPod, snapshot.run)
 	if err != nil {
 		return schedulingPlan{}, fmt.Errorf("score runtime pods: %w", err)

--- a/internal/scheduler/framework.go
+++ b/internal/scheduler/framework.go
@@ -28,9 +28,9 @@ type schedulingSnapshot struct {
 }
 
 type schedulingPlan struct {
-	action         schedulingPlanAction
-	selected       *corev1.Pod
-	pendingMessage string
+	action   schedulingPlanAction
+	selected *corev1.Pod
+	message  string
 }
 
 type schedulingPlanAction string
@@ -154,8 +154,8 @@ func (r *RunReconciler) planSchedulingCycle(snapshot *schedulingSnapshot) (sched
 	}
 	if len(candidates) == 0 {
 		return schedulingPlan{
-			action:         schedulingPlanWait,
-			pendingMessage: waitingMessageForFilterRejections(snapshot.run.Spec.Runtime, rejections),
+			action:  schedulingPlanWait,
+			message: waitingMessageForFilterRejections(snapshot.run.Spec.Runtime, rejections),
 		}, nil
 	}
 

--- a/internal/scheduler/framework_test.go
+++ b/internal/scheduler/framework_test.go
@@ -124,8 +124,8 @@ func TestPlanSchedulingCycleReportsAffinityRejection(t *testing.T) {
 	if plan.action != schedulingPlanWait {
 		t.Fatalf("plan action = %q, want Wait", plan.action)
 	}
-	if got := plan.pendingMessage; got != `waiting for available runtime pods satisfying required Run affinity for runtime "bash"` {
-		t.Fatalf("pending message = %q", got)
+	if got := plan.message; got != `waiting for available runtime pods satisfying required Run affinity for runtime "bash"` {
+		t.Fatalf("message = %q", got)
 	}
 }
 

--- a/internal/scheduler/framework_test.go
+++ b/internal/scheduler/framework_test.go
@@ -72,6 +72,7 @@ func TestPlanSchedulingCycleHonorsRunAffinity(t *testing.T) {
 			PreferredDuringSchedulingIgnoredDuringExecution: []v1alpha1.WeightedRunAffinityTerm{{Weight: 1, RunAffinityTerm: affinityTestTerm("zone", "blue")}},
 		},
 	})
+	run.Spec.Runtime = "bash"
 	request, err := run.Spec.ResourceRequests()
 	if err != nil {
 		t.Fatal(err)
@@ -94,6 +95,56 @@ func TestPlanSchedulingCycleHonorsRunAffinity(t *testing.T) {
 	}
 	if plan.action != schedulingPlanBind || plan.selected == nil || plan.selected.Name != "runtime-a" {
 		t.Fatalf("plan = %#v, want Bind on preferred affinity pod runtime-a", plan)
+	}
+}
+
+func TestPlanSchedulingCycleReportsAffinityRejection(t *testing.T) {
+	now := time.Now()
+	run := affinityTestRun("next", map[string]string{"stage": "test"}, &v1alpha1.RunAffinity{
+		RunAffinity: &v1alpha1.RunAffinityRules{
+			RequiredDuringSchedulingIgnoredDuringExecution: []v1alpha1.RunAffinityTerm{affinityTestTerm("stage", "build")},
+		},
+	})
+	run.Spec.Runtime = "bash"
+	request, err := run.Spec.ResourceRequests()
+	if err != nil {
+		t.Fatal(err)
+	}
+	reconciler := &RunReconciler{Strategy: &LeastLoaded{}, RuntimedHeartbeatStaleAfter: time.Minute}
+	plan, err := reconciler.planSchedulingCycle(&schedulingSnapshot{
+		run:             run,
+		request:         request,
+		pods:            []corev1.Pod{readyAffinityPod("runtime-a", now)},
+		now:             now,
+		affinityTargets: []affinityTarget{{podName: "runtime-a", labels: map[string]string{"stage": "test"}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.action != schedulingPlanWait || plan.rejections[filterReasonRunAffinity] != 1 {
+		t.Fatalf("plan = %#v, want one RunAffinity rejection", plan)
+	}
+	if got := plan.waitingMessage(run.Spec.Runtime); got != `waiting for available runtime pods satisfying required Run affinity for runtime "bash"` {
+		t.Fatalf("waiting message = %q", got)
+	}
+}
+
+func TestRegisteredFilterPlugins(t *testing.T) {
+	reconciler := &RunReconciler{}
+	snapshot := &schedulingSnapshot{run: &v1alpha1.Run{}}
+	preFilter, err := reconciler.preFilter(snapshot)
+	if err != nil {
+		t.Fatalf("preFilter: %v", err)
+	}
+	plugins, err := reconciler.registeredFilterPlugins(snapshot, preFilter)
+	if err != nil {
+		t.Fatalf("registeredFilterPlugins: %v", err)
+	}
+	if len(plugins) != 2 {
+		t.Fatalf("registered plugins = %d, want 2", len(plugins))
+	}
+	if plugins[0].Name() != "RuntimePodAvailability" || plugins[1].Name() != "RunAffinity" {
+		t.Fatalf("registered plugin order = %q, %q", plugins[0].Name(), plugins[1].Name())
 	}
 }
 

--- a/internal/scheduler/framework_test.go
+++ b/internal/scheduler/framework_test.go
@@ -121,11 +121,11 @@ func TestPlanSchedulingCycleReportsAffinityRejection(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.action != schedulingPlanWait || plan.rejections[filterReasonRunAffinity] != 1 {
-		t.Fatalf("plan = %#v, want one RunAffinity rejection", plan)
+	if plan.action != schedulingPlanWait {
+		t.Fatalf("plan action = %q, want Wait", plan.action)
 	}
-	if got := plan.waitingMessage(run.Spec.Runtime); got != `waiting for available runtime pods satisfying required Run affinity for runtime "bash"` {
-		t.Fatalf("waiting message = %q", got)
+	if got := plan.pendingMessage; got != `waiting for available runtime pods satisfying required Run affinity for runtime "bash"` {
+		t.Fatalf("pending message = %q", got)
 	}
 }
 

--- a/internal/scheduler/framework_test.go
+++ b/internal/scheduler/framework_test.go
@@ -63,3 +63,46 @@ func TestPlanSchedulingCycle(t *testing.T) {
 		t.Fatalf("schedulable plan = %#v, want Bind for %q", plan, pod.Name)
 	}
 }
+
+func TestPlanSchedulingCycleHonorsRunAffinity(t *testing.T) {
+	now := time.Now()
+	run := affinityTestRun("next", map[string]string{"stage": "test"}, &v1alpha1.RunAffinity{
+		RunAffinity: &v1alpha1.RunAffinityRules{
+			RequiredDuringSchedulingIgnoredDuringExecution:  []v1alpha1.RunAffinityTerm{affinityTestTerm("stage", "build")},
+			PreferredDuringSchedulingIgnoredDuringExecution: []v1alpha1.WeightedRunAffinityTerm{{Weight: 1, RunAffinityTerm: affinityTestTerm("zone", "blue")}},
+		},
+	})
+	request, err := run.Spec.ResourceRequests()
+	if err != nil {
+		t.Fatal(err)
+	}
+	reconciler := &RunReconciler{Strategy: &LeastLoaded{}, RuntimedHeartbeatStaleAfter: time.Minute}
+	pods := []corev1.Pod{readyAffinityPod("runtime-a", now), readyAffinityPod("runtime-b", now)}
+
+	plan, err := reconciler.planSchedulingCycle(&schedulingSnapshot{
+		run:     run,
+		request: request,
+		pods:    pods,
+		now:     now,
+		affinityTargets: []affinityTarget{
+			{podName: "runtime-a", labels: map[string]string{"stage": "build", "zone": "blue"}},
+			{podName: "runtime-b", labels: map[string]string{"stage": "build"}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.action != schedulingPlanBind || plan.selected == nil || plan.selected.Name != "runtime-a" {
+		t.Fatalf("plan = %#v, want Bind on preferred affinity pod runtime-a", plan)
+	}
+}
+
+func readyAffinityPod(name string, now time.Time) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Annotations: map[string]string{runtimepod.CapacityAnnotation(v1alpha1.RuntimeResourceRuns): "2"}},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{
+			{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+			{Type: v1alpha1.RuntimePodRuntimedReadyCondition, Status: corev1.ConditionTrue, LastProbeTime: metav1.NewTime(now)},
+		}},
+	}
+}

--- a/internal/scheduler/reconciler.go
+++ b/internal/scheduler/reconciler.go
@@ -140,7 +140,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		noPodsTotal.WithLabelValues(run.Spec.Runtime).Inc()
 		log.Info("No available runtime pods", "runtime", run.Spec.Runtime)
 
-		message := plan.pendingMessage
+		message := plan.message
 		if run.Status.Phase != v1alpha1.RunPending || run.Status.Message != message {
 			run.Status.Phase = v1alpha1.RunPending
 			run.Status.Message = message

--- a/internal/scheduler/reconciler.go
+++ b/internal/scheduler/reconciler.go
@@ -140,7 +140,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		noPodsTotal.WithLabelValues(run.Spec.Runtime).Inc()
 		log.Info("No available runtime pods", "runtime", run.Spec.Runtime)
 
-		message := plan.waitingMessage(run.Spec.Runtime)
+		message := plan.pendingMessage
 		if run.Status.Phase != v1alpha1.RunPending || run.Status.Message != message {
 			run.Status.Phase = v1alpha1.RunPending
 			run.Status.Message = message

--- a/internal/scheduler/reconciler.go
+++ b/internal/scheduler/reconciler.go
@@ -140,7 +140,7 @@ func (r *RunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		noPodsTotal.WithLabelValues(run.Spec.Runtime).Inc()
 		log.Info("No available runtime pods", "runtime", run.Spec.Runtime)
 
-		message := fmt.Sprintf("waiting for available runtime pods for runtime %q", run.Spec.Runtime)
+		message := plan.waitingMessage(run.Spec.Runtime)
 		if run.Status.Phase != v1alpha1.RunPending || run.Status.Message != message {
 			run.Status.Phase = v1alpha1.RunPending
 			run.Status.Message = message

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1637,6 +1637,40 @@ capacityObserved:
 	waitForRun(t, second, 30*time.Second)
 }
 
+func TestSchedulerInterRunAffinityBootstrap(t *testing.T) {
+	runtimeName := "bash-affinity"
+	ensureRuntimeWithRunsCapacity(t, runtimeName, bashRuntimeImage(), 9091, 2)
+	affinity := &v1alpha1.RunAffinity{RunAffinity: &v1alpha1.RunAffinityRules{
+		RequiredDuringSchedulingIgnoredDuringExecution: []v1alpha1.RunAffinityTerm{{
+			TopologyKey:   v1alpha1.RunAffinityTopologyRuntimePod,
+			LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"cohort": "build"}},
+		}},
+	}}
+	first := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "e2e-affinity-first-", Namespace: testNamespace, Labels: map[string]string{"cohort": "build"}},
+		Spec:       v1alpha1.RunSpec{Runtime: runtimeName, Affinity: affinity, Mode: taskMode("sleep 5; echo first")},
+	}
+	if err := k8sClient.Create(context.Background(), first); err != nil {
+		t.Fatalf("create first affinity run: %v", err)
+	}
+	defer func() { _ = k8sClient.Delete(context.Background(), first) }()
+	waitForRunPhase(t, first, 20*time.Second, v1alpha1.RunRunning)
+
+	second := &v1alpha1.Run{
+		ObjectMeta: metav1.ObjectMeta{GenerateName: "e2e-affinity-second-", Namespace: testNamespace, Labels: map[string]string{"cohort": "build"}},
+		Spec:       v1alpha1.RunSpec{Runtime: runtimeName, Affinity: affinity, Mode: taskMode("sleep 1; echo second")},
+	}
+	if err := k8sClient.Create(context.Background(), second); err != nil {
+		t.Fatalf("create second affinity run: %v", err)
+	}
+	defer func() { _ = k8sClient.Delete(context.Background(), second) }()
+	waitForRun(t, second, 20*time.Second)
+	if second.Status.AssignedPod != first.Status.AssignedPod {
+		t.Fatalf("second Run assigned to %q, want affinity target %q", second.Status.AssignedPod, first.Status.AssignedPod)
+	}
+	waitForRun(t, first, 20*time.Second)
+}
+
 func killRuntimed(t *testing.T, podName string) {
 	t.Helper()
 	if _, stderr, err := execInPod(context.Background(), podName, "runtimed", []string{"/bin/sh", "-c", "kill 1"}); err != nil {


### PR DESCRIPTION
## Summary
- build atomic scheduler snapshots of actual and assumed Run affinity targets
- register independent RuntimePodAvailability and RunAffinity filters with a shared PreFilter state
- filter required Run affinity and anti-affinity before placement, with bounded Pending reasons
- score preferred affinity before deterministic capacity placement
- apply the reviewed Inter-Run Affinity bootstrap rule

Tests: `make test`, `make test-integration`, and `make e2e` pass locally.