### PR TITLE
docs(scheduler): propose filter plugin framework

### DIFF
--- a/docs/design/scheduler-framework.md
+++ b/docs/design/scheduler-framework.md
@@ -2,6 +2,8 @@
 
 Status: **Accepted; Reserve/Assume/Bind implementation complete**
 
+Filter-plugin amendment: **Proposed for review**
+
 This document defines the target scheduling architecture for kruntimes. It
 replaces the current model of independently reconciling each Pending Run with
 a scheduler queue and a single-Run scheduling cycle. Each cycle evaluates one
@@ -83,7 +85,34 @@ For one dequeued Run, the scheduler performs:
    assignment.
 6. **Bind**: patch the Run to `Scheduled` with its Pod name and UID. A
    resource-version conflict or stale Pod observation discards that Run's
-   reservation and requeues the key; it is not a terminal failure.
+reservation and requeues the key; it is not a terminal failure.
+
+### Filter Plugins (Proposed)
+
+The scheduler applies registered Filter plugins to every Runtime Pod in the
+snapshot. A plugin receives the immutable scheduling snapshot, the Run's
+precomputed state, and one Pod; it returns either feasible or a bounded
+rejection reason. Plugins must not patch Kubernetes objects, mutate the
+assumed-reservation cache, or make placement decisions.
+
+The initial registry has two independent filters, evaluated in deterministic
+registration order:
+
+- **RuntimePodAvailability** verifies Runtime Pod readiness, runtimed
+  heartbeat freshness, and the complete logical resource request against
+  effective capacity.
+- **RunAffinity** evaluates required Run affinity and anti-affinity against
+  actual and assumed targets, including the Inter-Run Affinity bootstrap rule.
+
+The planner prepares each plugin's Run-specific state once during PreFilter,
+then runs the filters for every Pod and stops evaluating that Pod at its first
+rejection. It passes only Pods accepted by every filter to Score. Rejection
+reasons are aggregated only into bounded Pending status messages and metrics;
+they never expose Pod names, selectors, or Run names.
+
+Preferred affinity remains a scoring concern, not a Filter plugin. Reserve,
+Assume, and Bind remain the only operations allowed to mutate scheduler-local
+placement state.
 
 Each reservation belongs to one Run. As in Kubernetes, the assumed placement
 lets later scheduling cycles observe capacity consumption and an affinity target
@@ -195,9 +224,9 @@ The framework has explicit internal extension points:
 
 - **Queue ordering**: currently deterministic FIFO-like ordering; a future
   priority design can define priority classes, aging, quotas, and fairness.
-- **PreFilter/Filter**: Runtime readiness, capacity, workspace placement, and
-  required affinity are separate predicates rather than branches in one
-  reconciler.
+- **PreFilter/Filter**: Runtime readiness/capacity and required affinity are
+  independently registered Filter plugins rather than branches in one
+  reconciler. Future hard predicates follow the same contract.
 - **Score**: preferred affinity and least-loaded scoring are independent
   weighted inputs with stable tie breaking.
 - **Reserve/Assume/Bind**: an assumed assignment makes a selected Runtime Pod
@@ -222,7 +251,9 @@ names, selectors, and Pod names must not be metric labels.
    selection, assumed capacity accounting, handoff to actual assignments, and
    bind conflicts. This step is complete.
 4. Implement assumed-target matching and Inter-Run Affinity bootstrap with
-   integration and E2E coverage.
+   integration and E2E coverage. First implement the reviewed Filter-plugin
+   amendment so RuntimePodAvailability and RunAffinity do not accumulate in
+   the planner's candidate loop.
 5. Add priority only after a separate API and fairness design review.
 
 The affinity implementation PR must not merge until steps 1 and the intended

--- a/docs/design/scheduler-framework.zh.md
+++ b/docs/design/scheduler-framework.zh.md
@@ -6,6 +6,8 @@ title: "Scheduler Framework"
 
 状态：**Accepted；Reserve/Assume/Bind 实现完成**
 
+Filter-plugin 修订：**Proposed，等待 review**
+
 本文定义 kruntimes 的目标调度架构。它将当前“每个 Pending Run 独立 reconcile”的模型替换为 scheduler
 queue 与单 Run scheduling cycle。每个 cycle 针对一个 Run，读取 Runtime Pods、active assignments 和
 scheduler-local assumed assignments 的一致快照。
@@ -72,6 +74,26 @@ Run keys 加入 queue。event handler 不会选择 Runtime Pod 或 patch Run；�
    cycles 可以看到这个 tentative assignment。
 6. **Bind**：将该 Run patch 为带 Pod name 和 UID 的 `Scheduled`。resource-version conflict 或 stale Pod
    observation 会释放该 Run 的 reservation 并重新 enqueue 它；这不是 terminal failure。
+
+### Filter 插件（Proposed）
+
+scheduler 会对 snapshot 中的每个 Runtime Pod 执行已注册的 Filter 插件。一个插件接收不可变的 scheduling
+snapshot、该 Run 预计算后的 state 和一个 Pod，并返回 feasible 或一个有界的 rejection reason。插件不能 patch
+Kubernetes object、修改 assumed-reservation cache，或自行作出 placement decision。
+
+初始 registry 包含两个独立 filter，并按照确定性的注册顺序执行：
+
+- **RuntimePodAvailability**：校验 Runtime Pod readiness、runtimed heartbeat freshness，以及完整 logical
+  resource request 是否能被 effective capacity 满足。
+- **RunAffinity**：针对 actual 和 assumed targets 计算 required Run affinity 与 anti-affinity，其中包括
+  Run 间亲和性 bootstrap rule。
+
+planner 在 PreFilter 阶段对每个插件的 Run-specific state 只准备一次；随后对每个 Pod 运行 filters，在第一个
+rejection 后停止处理该 Pod。只有被所有 filter 接受的 Pods 才会进入 Score。rejection reasons 只能聚合成有界的
+Pending status message 和 metrics，不能暴露 Pod names、selectors 或 Run names。
+
+preferred affinity 仍是 scoring concern，而不是 Filter plugin。Reserve、Assume 和 Bind 仍是唯一允许修改
+scheduler-local placement state 的操作。
 
 每个 reservation 属于一条 Run。与 Kubernetes 一样，assumed placement 让后续 scheduling cycles 在 status
 patch 完成前看到 capacity consumption 和 affinity target。bind 失败会释放 reservation 并移除 assumed
@@ -159,8 +181,8 @@ framework 有显式的 internal extension points：
 
 - **Queue ordering**：当前是确定性的 FIFO-like ordering；未来 priority design 可以定义 priority classes、
   aging、quotas 和 fairness。
-- **PreFilter/Filter**：Runtime readiness、capacity、workspace placement 和 required affinity 是独立
-  predicates，而不是一个 reconciler 中的 branches。
+- **PreFilter/Filter**：Runtime readiness/capacity 和 required affinity 是独立注册的 Filter plugins，
+  而不是一个 reconciler 中的 branches。未来 hard predicates 也遵循该 contract。
 - **Score**：preferred affinity 和 least-loaded scoring 是独立 weighted inputs，并具有 stable tie breaking。
 - **Reserve/Assume/Bind**：assumed assignment 会让选中的 Runtime Pod 和已消耗的 capacity 在 Run bind 前
   对后续 Run cycles 可见。
@@ -179,7 +201,9 @@ selectors 和 Pod names 不能作为 metric labels。
    或 affinity semantics。
 3. 实现 Reserve/Assume 和 Bind，并增加 deterministic selection、assumed capacity accounting、handoff 到 actual
    assignments 以及 bind conflicts 的 unit tests。此步骤已完成。
-4. 实现 assumed-target matching 和 Run 间亲和性 bootstrap，并增加 integration 与 E2E coverage。
+4. 实现 assumed-target matching 和 Run 间亲和性 bootstrap，并增加 integration 与 E2E coverage。先实现经过
+   review 的 Filter-plugin 修订，避免 RuntimePodAvailability 和 RunAffinity 继续堆积在 planner 的
+   candidate loop 中。
 5. 只有经过独立 API 与 fairness design review 后，才加入 priority。
 
 在第 1 步以及预期 bootstrap/status semantics 被 review 前，affinity implementation PR 不能 merge。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -94,6 +94,8 @@ wiring from accumulating avoidable conflicts.
   - [x] add deterministic selection, assumed-capacity, bind-conflict,
     and restart-recovery coverage;
   - [ ] implement assumed affinity targets and Inter-Run Affinity bootstrap:
+    - [ ] review the Filter-plugin amendment, then implement independent
+      RuntimePodAvailability and RunAffinity filters in the scheduler planner;
     - [ ] project namespace-local actual assignments and unconfirmed assumed
       assignments into an immutable affinity-target snapshot;
     - [ ] add required Run affinity and anti-affinity filtering with bounded

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -84,6 +84,8 @@ controller wiring 累积不必要的冲突。
     metrics；
   - [x] 增加 deterministic selection、assumed-capacity、bind-conflict 和 restart-recovery coverage；
   - [ ] 实现 assumed affinity targets 和 Run 间亲和性 bootstrap：
+    - [ ] review Filter-plugin 修订，然后在 scheduler planner 中实现独立的
+      RuntimePodAvailability 和 RunAffinity filters；
     - [ ] 将 namespace-local actual assignment 和尚未确认的 assumed assignment 投影为不可变的
       affinity-target snapshot；
     - [ ] 增加 required Run affinity 和 anti-affinity filter，以及有界的 Pending waiting reason；


### PR DESCRIPTION
## Summary
- define an internal Filter plugin contract for candidate Pod evaluation
- separate RuntimePodAvailability from RunAffinity, with deterministic execution and bounded rejection reasons
- add the review gate before the affinity implementation proceeds

## Validation
- `GOBIN=/tmp/kruntimes-bin make site-build`