### PR TITLE
feat(runtimed): materialize inline function source

### DIFF
--- a/docs/design/function-inline-source.md
+++ b/docs/design/function-inline-source.md
@@ -1,6 +1,6 @@
 # Function Inline Source Materialization
 
-Status: **Proposed for review**
+Status: **Accepted; API and generic source preparation complete**
 
 Function-mode Runs can use either repository source or inline source. Repository
 source already preserves its file layout. Inline source currently does not: runtimed
@@ -8,19 +8,20 @@ writes it to a fixed file named `script`. That is insufficient for function hand
 whose runtime-defined handler notation identifies a file or module, such as Python
 `app.invoke` or Bash `handler.handle`.
 
-This document proposes the minimal API needed to materialize a single inline
+This document defines the minimal API needed to materialize a single inline
 function source file predictably, without making runtimed understand any specific
 runtime language.
 
-## Proposed API
+## API
 
 Add `inlinePath` to `Run.spec.source`:
 
 ```go
 type CodeSource struct {
-    Inline     string `json:"inline,omitempty"`
+    Inline     *string `json:"inline,omitempty"`
     InlinePath string `json:"inlinePath,omitempty"`
-    Git        *GitSource `json:"git,omitempty"`
+    RepoURL    string `json:"repoURL,omitempty"`
+    CommitSHA  string `json:"commitSHA,omitempty"`
 }
 ```
 
@@ -96,10 +97,9 @@ they receive their own API review.
 
 ## Implementation Follow-Up
 
-After this API is approved:
+The API field, CEL validation, generated deepcopy code, CRD manifests, and
+generic source preparation are complete. The remaining implementation is:
 
-1. add the API field, CEL validation, generated deepcopy code, and CRD manifests;
-2. update generic source preparation to materialize the validated path;
-3. update function examples and validation tests for Python, Bash, repository, and
+1. update function examples and validation tests for Python, Bash, repository, and
    invalid-path cases;
-4. implement the function registration lifecycle from `Scheduled` through `Ready`.
+2. implement the function registration lifecycle from `Scheduled` through `Ready`.

--- a/docs/design/function-inline-source.zh.md
+++ b/docs/design/function-inline-source.zh.md
@@ -1,24 +1,25 @@
 # Function Inline Source 物化
 
-状态：**提案，等待 review**
+状态：**已接受；API 与通用 source preparation 已完成**
 
 function-mode Run 可以使用 repository source 或 inline source。repository source 会保留原有
 文件布局；当前 inline source 不会：runtimed 会将其写到固定的 `script` 文件。对于由 runtime
 定义、并通过文件或 module 标识的 handler，这并不足够，例如 Python `app.invoke` 或 Bash
 `handler.handle`。
 
-本文提出一个最小 API，使单个 inline function source 能以可预测的文件路径物化，同时不让
+本文定义一个最小 API，使单个 inline function source 能以可预测的文件路径物化，同时不让
 runtimed 理解具体 runtime 的语言。
 
-## 提议的 API
+## API
 
 在 `Run.spec.source` 增加 `inlinePath`：
 
 ```go
 type CodeSource struct {
-    Inline     string `json:"inline,omitempty"`
+    Inline     *string `json:"inline,omitempty"`
     InlinePath string `json:"inlinePath,omitempty"`
-    Git        *GitSource `json:"git,omitempty"`
+    RepoURL    string `json:"repoURL,omitempty"`
+    CommitSHA  string `json:"commitSHA,omitempty"`
 }
 ```
 
@@ -87,9 +88,7 @@ process-start 语义经过单独 API review 前，它不会改变 task 的行为
 
 ## 后续实现
 
-该 API 获得批准后：
+API field、CEL validation、generated deepcopy code、CRD manifests 和通用 source preparation 已完成。剩余实现为：
 
-1. 增加 API field、CEL validation、generated deepcopy code 和 CRD manifests；
-2. 更新通用 source preparation，使其物化已验证的路径；
-3. 更新 function 示例和 Python、Bash、repository、invalid-path 的 validation tests；
-4. 实现从 `Scheduled` 到 `Ready` 的 function registration lifecycle。
+1. 更新 function 示例和 Python、Bash、repository、invalid-path 的 validation tests；
+2. 实现从 `Scheduled` 到 `Ready` 的 function registration lifecycle。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -126,13 +126,15 @@ wiring from accumulating avoidable conflicts.
     and active/non-terminal phase-classification tests;
   - [x] add immutable execution-input transitions and the function cleanup
     finalizer constant;
-  - [ ] review and approve the
+  - [x] review and approve the
     [Function Inline Source Materialization](design/function-inline-source.md)
     API before registering inline function Runs;
   - [ ] implement the function control-plane lifecycle in independently
     reviewable slices:
     - [x] add a deterministic FunctionRuntime registration request builder,
       including immutable-input digest coverage;
+    - [x] materialize inline function source at the validated
+      `source.inlinePath` below the Run working directory;
     - [ ] transition assigned function Runs through source preparation,
       cleanup-finalizer installation, local registration through a runtimed
       FunctionRuntime client, and `Running -> Ready`;

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -112,11 +112,12 @@ controller wiring 累积不必要的冲突。
     active/non-terminal phase-classification tests；
   - [x] 增加 immutable execution-input transitions 和 function cleanup finalizer
     constant；
-  - [ ] 在注册 inline function Run 前 review 并批准
+  - [x] 在注册 inline function Run 前 review 并批准
     [Function Inline Source 物化](design/function-inline-source.md) API；
   - [ ] 以可独立 review 的分片实现 function control-plane lifecycle：
     - [x] 增加 deterministic FunctionRuntime registration request builder，
       包含 immutable-input digest coverage；
+    - [x] 在 Run working directory 下经过验证的 `source.inlinePath` 物化 inline function source；
     - [ ] 让已 assigned 的 function Run 完成 source preparation、安装 cleanup finalizer，
       通过 runtimed FunctionRuntime client 进行 local registration，并完成
       `Running -> Ready` transition；

--- a/internal/runtimed/controller.go
+++ b/internal/runtimed/controller.go
@@ -994,7 +994,18 @@ func prepareSource(run *v1alpha1.Run) (string, error) {
 		return runDir, nil
 	}
 	if run.Spec.Source.Inline != nil {
-		scriptPath := filepath.Join(runDir, "script")
+		scriptPath := "script"
+		if run.Spec.Mode.Function != nil {
+			var err error
+			scriptPath, err = execpath.ResolveEntrypoint(run.Spec.Source.InlinePath, "")
+			if err != nil {
+				return "", fmt.Errorf("resolve inline function source path: %w", err)
+			}
+		}
+		scriptPath = filepath.Join(runDir, scriptPath)
+		if err := os.MkdirAll(filepath.Dir(scriptPath), 0o755); err != nil {
+			return "", fmt.Errorf("mkdir inline source parent: %w", err)
+		}
 		if err := os.WriteFile(scriptPath, []byte(*run.Spec.Source.Inline), 0o644); err != nil {
 			return "", fmt.Errorf("write inline: %w", err)
 		}

--- a/internal/runtimed/controller_test.go
+++ b/internal/runtimed/controller_test.go
@@ -137,6 +137,62 @@ func TestPrepareSource_InlineDefaultEntrypoint(t *testing.T) {
 	}
 }
 
+func TestPrepareSource_FunctionInlineMaterializesInlinePath(t *testing.T) {
+	dir := t.TempDir()
+	workspacePath = dir
+
+	inline := "def invoke(request):\n    return request\n"
+	run := &v1alpha1.Run{
+		Spec: v1alpha1.RunSpec{
+			Source: &v1alpha1.CodeSource{
+				Inline:     &inline,
+				InlinePath: "app/handler.py",
+			},
+			Mode: v1alpha1.RunMode{
+				Function: &v1alpha1.RunFunctionMode{Handler: "app.handler.invoke"},
+			},
+		},
+	}
+	run.UID = "test-function-uid"
+
+	workDir, err := prepareSource(run)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(workDir, "app", "handler.py"))
+	if err != nil {
+		t.Fatalf("read inline function source: %v", err)
+	}
+	if string(data) != inline {
+		t.Errorf("inline function source = %q, want %q", data, inline)
+	}
+	if _, err := os.Stat(filepath.Join(workDir, "script")); !os.IsNotExist(err) {
+		t.Fatalf("function inline source should not create default script, stat err = %v", err)
+	}
+}
+
+func TestPrepareSource_FunctionInlineRejectsEscapingInlinePath(t *testing.T) {
+	dir := t.TempDir()
+	workspacePath = dir
+
+	inline := "def invoke(request):\n    return request\n"
+	run := &v1alpha1.Run{
+		Spec: v1alpha1.RunSpec{
+			Source: &v1alpha1.CodeSource{Inline: &inline, InlinePath: "../handler.py"},
+			Mode:   v1alpha1.RunMode{Function: &v1alpha1.RunFunctionMode{Handler: "handler.invoke"}},
+		},
+	}
+	run.UID = "test-function-uid"
+
+	if _, err := prepareSource(run); err == nil {
+		t.Fatal("prepareSource succeeded for escaping inlinePath")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "handler.py")); !os.IsNotExist(err) {
+		t.Fatalf("escaping inlinePath created a file outside the Run directory: %v", err)
+	}
+}
+
 func TestPrepareSource_InlineIgnoresEscapingEntrypoint(t *testing.T) {
 	dir := t.TempDir()
 	workspacePath = dir


### PR DESCRIPTION
## Summary
- materialize function-mode inline source at `spec.source.inlinePath` below the Run working directory
- reject invalid local paths defensively in runtimed before writing source files
- retain task-mode inline materialization at `script`
- align the accepted design and v0.x roadmap with the implemented API and source-preparation slice

Tests: focused `internal/runtimed`, `make test`, `make test-integration`, and `make site-build` pass locally.