### PR TITLE
docs(workspace): fence RuntimePodLocal bindings by Pod UID

### DIFF
--- a/docs/design/workflow-data-sharing.md
+++ b/docs/design/workflow-data-sharing.md
@@ -2,6 +2,8 @@
 
 This document describes a target v0.x design. It is not implemented yet.
 
+RuntimePodLocal binding fencing amendment: **Proposed for review**
+
 The goal is to define how Workflow jobs and Runs share data without making
 scheduler or runtimed understand Workflow-specific semantics. The design is
 driven by the v0.x workflow demo target: job-to-job data should move through
@@ -91,6 +93,7 @@ status:
   phase: Bound
   runtime: bash
   boundPod: runtime-bash-7f587b4668-njcks
+  boundPodUID: 2c24c1f0-9f8f-4f80-82d5-3dd16a12d1e6
   path: /workspace/persistent/ci-build-workspace
   lastUsedTime: "2026-07-06T12:00:00Z"
 ```
@@ -146,20 +149,22 @@ The binding controller should use the following v0.x rules:
 2. When candidates exist, the controller sorts ready Runtime Pods by
    `metadata.name` and selects the lexicographically first Pod. The choice is
    deterministic for a stable Pod set; later scheduling work uses
-   `status.boundPod` rather than trying to repeat this selection.
+   `status.boundPod` and `status.boundPodUID` rather than trying to repeat this
+   selection.
 3. The controller records `status.phase: Bound`, `status.runtime`,
-   `status.boundPod`, and `status.path: /workspace/persistent/<workspace-name>`.
-   It does not create the directory itself: runtimed creates it when a
-   referenced Run starts.
+   `status.boundPod`, immutable `status.boundPodUID`, and
+   `status.path: /workspace/persistent/<workspace-name>`. It does not create
+   the directory itself: runtimed creates it when a referenced Run starts.
 4. A Bound workspace remains bound while its Pod exists, even if that Pod is
    temporarily not ready. The status conditions make the availability problem
    visible, and Runs referring to it stay Pending until later scheduler and
    runtimed work can use that binding safely.
-5. If the bound Pod is deleted or no longer exists, the workspace becomes
-   `Lost`. The controller must not silently bind it to another Pod: for
-   `RuntimePodLocal`, that would make a caller observe a new empty directory as
-   though it contained the original data. Recovery requires an explicit new
-   workspace or a future reviewed recovery API.
+5. If the bound Pod is deleted, no longer exists, or a same-name Pod has a
+   different UID, the workspace becomes `Lost`. The controller must not
+   silently bind it to another Pod: for `RuntimePodLocal`, that would make a
+   caller observe a new empty directory as though it contained the original
+   data. Recovery requires an explicit new workspace or a future reviewed
+   recovery API.
 
 Binding is metadata-only in this slice. TTL cleanup, filesystem deletion,
 `lastUsedTime`, and Run admission/preparation remain separate follow-up work.
@@ -356,8 +361,10 @@ Required safeguards:
 5. Add Kubernetes-style Run affinity/anti-affinity fields.
 6. Update scheduler placement to respect required/preferred Run affinity while
    keeping no-capacity Runs Pending.
-7. Bind `RuntimePodLocal` PersistentWorkspaces to ready Runtime Pods and record
-   their lifecycle status without touching runtime filesystems.
+7. After reviewing the bound-Pod UID fencing amendment, add
+   `status.boundPodUID`, then bind `RuntimePodLocal` PersistentWorkspaces to
+   ready Runtime Pods and record their lifecycle status without touching runtime
+   filesystems.
 8. Update runtimed workspace preparation and cleanup for referenced
    workspaces.
 9. Add Workflow step artifact input fields and job-scoped artifact status.

--- a/docs/design/workflow-data-sharing.md
+++ b/docs/design/workflow-data-sharing.md
@@ -19,12 +19,19 @@ The current experimental Workflow API supports:
 - child Runs per step;
 - bounded step outputs from `KRUNTIME_OUTPUTS`;
 - cross-step and cross-job expression references for small string outputs.
+- `Runtime.spec.workspace` with an inline Kubernetes `VolumeSource` and an
+  `emptyDir` default;
+- `PersistentWorkspace` API types, CRD validation, status, and controller
+  skeleton;
+- generic Run workspace references and Kubernetes-style Run affinity fields.
 
 It does not yet provide:
 
 - first-class artifact inputs between jobs;
-- a workspace object or lifecycle;
-- Run affinity/anti-affinity for co-locating child Runs;
+- `RuntimePodLocal` workspace binding, UID fencing, or workspace lifecycle
+  operations;
+- scheduler enforcement of Run affinity/anti-affinity;
+- runtimed preparation and cleanup of referenced workspaces;
 - explicit promotion of child Run artifact references into Workflow status;
 - cleanup and permission boundaries for shared job-local workspaces.
 

--- a/docs/design/workflow-data-sharing.zh.md
+++ b/docs/design/workflow-data-sharing.zh.md
@@ -2,6 +2,8 @@
 
 本文描述 v0.x 的目标设计，当前尚未实现。
 
+RuntimePodLocal binding fencing 修订：**Proposed，等待 review**
+
 目标是定义 Workflow jobs 和 Runs 如何共享数据，同时不让 scheduler 或 runtimed 理解
 Workflow-specific 语义。这个设计由 v0.x workflow demo 目标驱动：job-to-job 数据应通过
 artifacts 传递，而同一个 job 内的 Runs 应在 Workflow controller 请求 co-location 时可以
@@ -86,6 +88,7 @@ status:
   phase: Bound
   runtime: bash
   boundPod: runtime-bash-7f587b4668-njcks
+  boundPodUID: 2c24c1f0-9f8f-4f80-82d5-3dd16a12d1e6
   path: /workspace/persistent/ci-build-workspace
   lastUsedTime: "2026-07-06T12:00:00Z"
 ```
@@ -132,17 +135,18 @@ binding controller 在 v0.x 中应遵循以下规则：
 1. 未绑定 workspace 在其引用的 Runtime 没有 ready Runtime Pods 时保持等待。无论等待或已经绑定，
    它都不会消耗或预留 Run capacity。
 2. 有候选 Pod 时，controller 先按 `metadata.name` 对 ready Runtime Pod 排序，再选择名称字典序最小的
-   Pod。在稳定 Pod 集合下该选择是 deterministic 的；后续调度工作使用 `status.boundPod`，而不是试图
-   重复这个选择。
+   Pod。在稳定 Pod 集合下该选择是 deterministic 的；后续调度工作使用 `status.boundPod` 和
+   `status.boundPodUID`，而不是试图重复这个选择。
 3. controller 记录 `status.phase: Bound`、`status.runtime`、`status.boundPod`，以及计划使用的本地
+   immutable 的 `status.boundPodUID`，以及计划使用的本地
    `status.path: /workspace/persistent/<workspace-name>`。controller 不会自行创建目录；runtimed 在引用
    它的 Run 启动时创建。
 4. Bound workspace 在 Pod 仍存在时保持绑定，即使该 Pod 暂时不 ready。status conditions 会让
    availability 问题可见；引用它的 Runs 将保持 Pending，直到后续 scheduler 和 runtimed 工作能够
    安全地使用这个 binding。
-5. bound Pod 被删除或不再存在时，workspace 变为 `Lost`。controller 不得静默地把它绑定到另一个
-   Pod：对于 `RuntimePodLocal`，那会让调用者把新的空目录误认为原有数据。恢复需要显式创建新的
-   workspace，或等待未来经过 review 的 recovery API。
+5. bound Pod 被删除、不再存在，或同名 Pod 的 UID 不同时，workspace 变为 `Lost`。controller 不得静默地
+   把它绑定到另一个 Pod：对于 `RuntimePodLocal`，那会让调用者把新的空目录误认为原有数据。恢复需要显式
+   创建新的 workspace，或等待未来经过 review 的 recovery API。
 
 这个 binding slice 仅写入 metadata。TTL cleanup、filesystem deletion、`lastUsedTime` 和 Run
 admission/preparation 都是独立的后续工作。
@@ -329,8 +333,8 @@ job 正在等待本地 workspace capacity，或者因为 controller-owned worksp
 5. 增加 Kubernetes-style Run affinity/anti-affinity fields。
 6. 更新 scheduler placement，使其支持 required/preferred Run affinity，同时保持无 capacity
    Runs Pending。
-7. 将 `RuntimePodLocal` PersistentWorkspaces 绑定到 ready Runtime Pods，并记录 lifecycle
-   status，不修改 runtime filesystems。
+7. review bound-Pod UID fencing 修订后，增加 `status.boundPodUID`，再将 `RuntimePodLocal`
+   PersistentWorkspaces 绑定到 ready Runtime Pods，并记录 lifecycle status，不修改 runtime filesystems。
 8. 更新 runtimed workspace preparation 和 cleanup，使其支持 referenced workspaces。
 9. 增加 Workflow step artifact input fields 和 job-scoped artifact status。
 10. 将 child Run artifact refs 提升到 Workflow status。

--- a/docs/design/workflow-data-sharing.zh.md
+++ b/docs/design/workflow-data-sharing.zh.md
@@ -18,12 +18,16 @@ artifacts 传递，而同一个 job 内的 Runs 应在 Workflow controller 请�
 - 每个 step 创建 child Run；
 - 来自 `KRUNTIME_OUTPUTS` 的有界 step outputs；
 - 用于小字符串 outputs 的 cross-step 和 cross-job expression references。
+- 使用 inline Kubernetes `VolumeSource` 和 `emptyDir` 默认值的 `Runtime.spec.workspace`；
+- `PersistentWorkspace` API types、CRD validation、status 和 controller skeleton；
+- 通用 Run workspace references 和 Kubernetes-style Run affinity fields。
 
 当前尚不支持：
 
 - job 之间的 first-class artifact inputs；
-- workspace object 或 lifecycle；
-- 用于 co-locate child Runs 的 Run affinity/anti-affinity；
+- `RuntimePodLocal` workspace binding、UID fencing 或 workspace lifecycle operations；
+- scheduler 对 Run affinity/anti-affinity 的 enforcement；
+- runtimed 对 referenced workspaces 的 preparation 和 cleanup；
 - 将 child Run artifact references 显式提升到 Workflow status；
 - shared job-local workspace 的 cleanup 和权限边界。
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -243,7 +243,11 @@ wiring from accumulating avoidable conflicts.
     no-capacity Runs Pending;
   - [ ] review and define `RuntimePodLocal` binding semantics: deterministic
     ready-Pod selection without capacity reservation, planned path ownership,
-    and sticky `Lost` status after bound-Pod deletion;
+    and sticky `Lost` status after bound-Pod deletion:
+    - [ ] review the `status.boundPodUID` fencing amendment so same-name Pod
+      recreation cannot silently replace a RuntimePodLocal workspace;
+    - [ ] add the status field, regenerate CRDs, then implement metadata-only
+      binding and Lost-state handling;
   - update runtimed workspace preparation and cleanup to support referenced
     persistent workspaces without knowing Workflow semantics;
   - promote child Run artifact refs into Workflow status and add explicit step

--- a/docs/roadmap.zh.md
+++ b/docs/roadmap.zh.md
@@ -211,7 +211,10 @@ controller wiring 累积不必要的冲突。
   - [ ] 通过经过 review 的 [scheduler framework](design/scheduler-framework.md) 实现
     required/preferred Run affinity，同时在无 capacity 时继续保持 Run Pending；
   - [ ] review 并定义 `RuntimePodLocal` binding semantics：不预留 capacity 的 deterministic
-    ready-Pod selection、planned path ownership，以及 bound-Pod deletion 后 sticky `Lost` status；
+    ready-Pod selection、planned path ownership，以及 bound-Pod deletion 后 sticky `Lost` status：
+    - [ ] review `status.boundPodUID` fencing 修订，避免同名 Pod 重建时静默替换
+      RuntimePodLocal workspace；
+    - [ ] 增加该 status field、重新生成 CRD，然后实现 metadata-only binding 与 Lost-state handling；
   - 更新 runtimed workspace preparation 和 cleanup，使其支持被引用的 persistent workspace，
     但不感知 Workflow 语义；
   - 将 child Run artifact refs 提升到 Workflow status，并增加显式 step artifact inputs；


### PR DESCRIPTION
## Summary
- require `PersistentWorkspace.status.boundPodUID` alongside `boundPod`
- define same-name Pod recreation as a sticky `Lost` transition
- split the API/CRD fencing work from the metadata-only binding controller implementation
- add the review gate to the bilingual v0.x roadmap

Tests: `make site-build` passes locally.